### PR TITLE
Added support for getting extensions from a X509Req object.

### DIFF
--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -698,18 +698,18 @@ class X509Req(object):
 
 
     def get_extensions(self):
-      """
-      Get extensions to the request.
+        """
+        Get extensions to the request.
 
-      :return: A list of X509Extension objects.
-      """
-      exts = []
-      _exts = _lib.X509_REQ_get_extensions(self._req)
-      for i in range(0, _lib.sk_X509_EXTENSION_num(_exts)):
-          ext = X509Extension.__new__(X509Extension)
-          ext._extension = _lib.sk_X509_EXTENSION_value(_exts, i)
-          exts.append(ext)
-      return exts
+        :return: A list of X509Extension objects.
+        """
+        exts = []
+        _native_exts_obj = _lib.X509_REQ_get_extensions(self._req)
+        for i in range(0, _lib.sk_X509_EXTENSION_num(_native_exts_obj)):
+            ext = X509Extension.__new__(X509Extension)
+            ext._extension = _lib.sk_X509_EXTENSION_value(_native_exts_obj, i)
+            exts.append(ext)
+        return exts
 
 
     def sign(self, pkey, digest):

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -1109,10 +1109,31 @@ class X509ReqTests(TestCase, _PKeyInteractionTestsMixin):
         request.add_extensions([
                 X509Extension(b('basicConstraints'), True, b('CA:false'))])
         exts = request.get_extensions()
-        self.assertEquals(len(exts), 1)
-        self.assertEquals(exts[0].get_short_name(), b('basicConstraints'))
-        self.assertEquals(exts[0].get_critical(), 1)
-        self.assertEquals(exts[0].get_data(), b('0\x00'))
+        self.assertEqual(len(exts), 1)
+        self.assertEqual(exts[0].get_short_name(), b('basicConstraints'))
+        self.assertEqual(exts[0].get_critical(), 1)
+        self.assertEqual(exts[0].get_data(), b('0\x00'))
+
+
+    def test_get_extensions(self):
+        """
+        :py:obj:`X509Req.get_extensions` returns a :py:obj:`list` of
+        extensions added to this X509 request.
+        """
+        request = X509Req()
+        exts = request.get_extensions()
+        self.assertEqual(exts, [])
+        request.add_extensions([
+                X509Extension(b('basicConstraints'), True, b('CA:true')),
+                X509Extension(b('keyUsage'), False, b('digitalSignature'))])
+        exts = request.get_extensions()
+        self.assertEqual(len(exts), 2)
+        self.assertEqual(exts[0].get_short_name(), b('basicConstraints'))
+        self.assertEqual(exts[0].get_critical(), 1)
+        self.assertEqual(exts[0].get_data(), b('0\x03\x01\x01\xff'))
+        self.assertEqual(exts[1].get_short_name(), b('keyUsage'))
+        self.assertEqual(exts[1].get_critical(), 0)
+        self.assertEqual(exts[1].get_data(), b('\x03\x02\x07\x80'))
 
 
     def test_add_extensions_wrong_args(self):


### PR DESCRIPTION
These two commits add support for getting extensions from X509Req objects and adjust the appropriate unit tests (although, I still can't seem to run them because of https://github.com/pyca/pyopenssl/issues/18).
