### PR TITLE
Add some missing test coverage for handling values of type `long` and fi...

### DIFF
--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -252,7 +252,7 @@ class Context(object):
         :param method: One of SSLv2_METHOD, SSLv3_METHOD, SSLv23_METHOD, or
             TLSv1_METHOD.
         """
-        if not isinstance(method, int):
+        if not isinstance(method, integer_types):
             raise TypeError("method must be an integer")
 
         try:
@@ -383,7 +383,7 @@ class Context(object):
             certfile = certfile.encode("utf-8")
         if not isinstance(certfile, bytes):
             raise TypeError("certfile must be bytes or unicode")
-        if not isinstance(filetype, int):
+        if not isinstance(filetype, integer_types):
             raise TypeError("filetype must be an integer")
 
         use_result = _lib.SSL_CTX_use_certificate_file(self._context, certfile, filetype)
@@ -449,7 +449,7 @@ class Context(object):
 
         if filetype is _unspecified:
             filetype = FILETYPE_PEM
-        elif not isinstance(filetype, int):
+        elif not isinstance(filetype, integer_types):
             raise TypeError("filetype must be an integer")
 
         use_result = _lib.SSL_CTX_use_PrivateKey_file(
@@ -1250,7 +1250,7 @@ class Connection(object):
         :param state - bitvector of SENT_SHUTDOWN, RECEIVED_SHUTDOWN.
         :return: None
         """
-        if not isinstance(state, int):
+        if not isinstance(state, integer_types):
             raise TypeError("state must be an integer")
 
         _lib.SSL_set_shutdown(self._ssl, state)

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -337,6 +337,16 @@ class ContextTests(TestCase, _LoopbackMixin):
         self.assertRaises(ValueError, Context, 10)
 
 
+    if not PY3:
+        def test_method_long(self):
+            """
+            On Python 2 :py:class:`Context` accepts values of type
+            :py:obj:`long` as well as :py:obj:`int`.
+            """
+            Context(long(TLSv1_METHOD))
+
+
+
     def test_type(self):
         """
         :py:obj:`Context` and :py:obj:`ContextType` refer to the same type object and can be
@@ -364,6 +374,25 @@ class ContextTests(TestCase, _LoopbackMixin):
         """
         ctx = Context(TLSv1_METHOD)
         self.assertRaises(Error, ctx.use_privatekey_file, self.mktemp())
+
+
+    if not PY3:
+        def test_use_privatekey_file_long(self):
+            """
+            On Python 2 :py:obj:`Context.use_privatekey_file` accepts a
+            filetype of type :py:obj:`long` as well as :py:obj:`int`.
+            """
+            pemfile = self.mktemp()
+
+            key = PKey()
+            key.generate_key(TYPE_RSA, 128)
+
+            with open(pemfile, "wt") as pem:
+                pem.write(
+                    dump_privatekey(FILETYPE_PEM, key).decode("ascii"))
+
+            ctx = Context(TLSv1_METHOD)
+            ctx.use_privatekey_file(pemfile, long(FILETYPE_PEM))
 
 
     def test_use_certificate_wrong_args(self):
@@ -443,6 +472,20 @@ class ContextTests(TestCase, _LoopbackMixin):
 
         ctx = Context(TLSv1_METHOD)
         ctx.use_certificate_file(pem_filename)
+
+
+    if not PY3:
+        def test_use_certificate_file_long(self):
+            """
+            On Python 2 :py:obj:`Context.use_certificate_file` accepts a
+            filetype of type :py:obj:`long` as well as :py:obj:`int`.
+            """
+            pem_filename = self.mktemp()
+            with open(pem_filename, "wb") as pem_file:
+                pem_file.write(cleartextCertificatePEM)
+
+            ctx = Context(TLSv1_METHOD)
+            ctx.use_certificate_file(pem_filename, long(FILETYPE_PEM))
 
 
     def test_set_app_data_wrong_args(self):
@@ -1615,6 +1658,17 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         connection = Connection(Context(TLSv1_METHOD), socket())
         connection.set_shutdown(RECEIVED_SHUTDOWN)
         self.assertEquals(connection.get_shutdown(), RECEIVED_SHUTDOWN)
+
+
+    if not PY3:
+        def test_set_shutdown_long(self):
+            """
+            On Python 2 :py:obj:`Connection.set_shutdown` accepts an argument
+            of type :py:obj:`long` as well as :py:obj:`int`.
+            """
+            connection = Connection(Context(TLSv1_METHOD), socket())
+            connection.set_shutdown(long(RECEIVED_SHUTDOWN))
+            self.assertEquals(connection.get_shutdown(), RECEIVED_SHUTDOWN)
 
 
     def test_app_data_wrong_args(self):


### PR DESCRIPTION
...x the implementation to accept either `int` or `long` on Python 2 (more closely matching the API implemented by the old C code).
