### PR TITLE
write even smaller strings just like for #31 but fixes #37

### DIFF
--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -1912,8 +1912,8 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         client_socket, server_socket = socket_pair()
         # Fill up the client's send buffer so Connection won't be able to write
         # anything.
-        msg = b"x" * 512
-        for i in range(2048):
+        msg = b"x" * 256
+        for i in range(4096):
             try:
                 client_socket.send(msg)
             except error as e:


### PR DESCRIPTION
This fixed #37 for me on FreeBSD 9.2-RELEASE #0 r255898. Possibly this has something to do with `sysctl` values. Possibly relevant values on my system:

```
$ sysctl net.inet.tcp.sendspace net.inet.tcp.recvspace
net.inet.tcp.sendspace: 32768
net.inet.tcp.recvspace: 65536
```
