### PR TITLE
Allow creating a Context with SSLv2_METHOD

### DIFF
--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -235,6 +235,7 @@ class Context(object):
     new SSL connections.
     """
     _methods = {
+        SSLv2_METHOD: "SSLv2_method",
         SSLv3_METHOD: "SSLv3_method",
         SSLv23_METHOD: "SSLv23_method",
         TLSv1_METHOD: "TLSv1_method",


### PR DESCRIPTION
Hi there,

It appears that it's not possible to create a new Context with SSLv2_METHOD.  I realize this is horribly insecure, but I'm attempting to use pyOpenSSL to scan for insecure HTTPS settings, and this error occurs.  Here's the message:

```
$ python
Python 2.7.6 (default, Feb 19 2014, 19:58:32)
[GCC 4.2.1 Compatible Apple LLVM 5.0 (clang-500.2.79)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from OpenSSL import SSL
>>> ctx = SSL.Context(SSL.SSLv2_METHOD)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/andrew/.virtualenvs/ssl/lib/python2.7/site-packages/OpenSSL/SSL.py",
 line 261, in __init__
    raise ValueError("No such protocol")
ValueError: No such protocol
>>>
```

I've attached a patch that fixes this.

Thanks! :smile:
