### PR TITLE
Add the generic Python 3 trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ High-level wrapper around a subset of the OpenSSL library, includes
         'Operating System :: POSIX',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: Implementation :: CPython',


### PR DESCRIPTION
That way PyOpenSSL gets listed under the "Python 3 packages" link on PyPI
