### PR TITLE
Interface for the SSL_get_peer_finished, SSL_get_finished.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2014-03-28  Fedor Brunner  <fedor.brunner@azet.sk>
+
+	* OpenSSL/ssl.py: Add ``get_finished``, ``get_peer_finished``
+	  methods to ``Connection``. If you use these methods to
+	  implement TLS channel binding (RFC 5929) disable session
+	  resumption because triple handshake attacks against TLS.
+	  <https://www.ietf.org/mail-archive/web/tls/current/msg11337.html>
+	  <https://secure-resumption.com/tlsauth.pdf>
+
 2014-03-02  Stephen Holsapple  <sholsapp@gmail.com>
 
 	* OpenSSL/crypto.py: Add ``get_extensions`` method to ``X509Req``.

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1421,7 +1421,10 @@ class Connection(object):
         """
         Obtain latest Finished message that we sent.
 
-        :return: A string representing the Finished message
+        :return: The Finished message or :py:obj:`None` if the TLS handshake
+            is not completed.
+        :rtype: :py:data:`bytes`
+
         """
         # The size of Finished message is 12 bytes in TLS,
         # 36 bytes in SSL protocol, but let's be safe with
@@ -1438,7 +1441,10 @@ class Connection(object):
         """
         Obtain latest Finished message that we expected from peer.
 
-        :return: A string representing the Finished message
+        :return: The Finished message or :py:obj:`None` if the TLS handshake
+            is not completed.
+        :rtype: :py:data:`bytes`
+
         """
         # Same buffer size as in get_finished
         bufsiz = 128

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -1932,24 +1932,60 @@ class ConnectionTests(TestCase, _LoopbackMixin):
 
     # XXX want_read
 
-    def test_finished(self):
+    def test_get_finished_before_connect(self):
         """
-        :py:obj:`Connection.get_finished` and :py:obj:`Connection.get_peer_finished`
-        methods return the TLS Finished messages. Finished messages are send
-        during TLS handshake. Before handshake :py:obj:`Connection.get_finished` and
-        :py:obj:`Connection.get_peer_finished` return None.
+        :py:obj:`Connection.get_finished` returns  :py:obj:`None`
+            before TLS handshake is completed.
         """
 
         ctx = Context(TLSv1_METHOD)
         connection = Connection(ctx, None)
         self.assertEqual(connection.get_finished(), None)
+
+    def test_get_peer_finished_before_connect(self):
+        """
+        :py:obj:`Connection.get_peer_finished` returns  :py:obj:`None`
+            before TLS handshake is completed.
+        """
+
+        ctx = Context(TLSv1_METHOD)
+        connection = Connection(ctx, None)
         self.assertEqual(connection.get_peer_finished(), None)
+
+    def test_get_finished(self):
+        """
+        :py:obj:`Connection.get_finished` method returns the TLS Finished
+            message send from client, or server. Finished messages are send
+            during TLS handshake.
+        """
 
         server, client = self._loopback()
 
         self.assertNotEqual(server.get_finished(), None)
         self.assertTrue(len(server.get_finished()) > 0)
+
+    def test_get_peer_finished(self):
+        """
+        :py:obj:`Connection.get_peer_finished` method returns the TLS Finished
+            message received from client, or server. Finished messages are send
+            during TLS handshake.
+        """
+
+        server, client = self._loopback()
+
+        self.assertNotEqual(server.get_peer_finished(), None)
         self.assertTrue(len(server.get_peer_finished()) > 0)
+
+    def test_tls_finished_message_symmetry(self):
+        """
+        The TLS Finished message send by server muss be the TLS Finished message
+        received by client.
+
+        The TLS Finished message send by client muss be the TLS Finished message
+        received by server.
+        """
+
+        server, client = self._loopback()
 
         self.assertEqual(server.get_finished(), client.get_peer_finished())
         self.assertEqual(client.get_finished(), server.get_peer_finished())

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -765,6 +765,19 @@ Connection objects have the following methods:
 
     .. versionadded:: 0.14
 
+.. py:method:: Connection.get_finished()
+
+    Obtain latest TLS Finished message that we sent, or :py:obj:`None` if
+    handshake is not completed.
+
+    .. versionadded:: 0.15
+
+.. py:method:: Connection.get_peer_finished()
+
+    Obtain latest TLS Finished message that we expected from peer, or
+    :py:obj:`None` if handshake is not completed.
+
+    .. versionadded:: 0.15
 
 .. Rubric:: Footnotes
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='pyOpenSSL', version=__version__,
       maintainer_email = 'exarkun@twistedmatrix.com',
       url = 'https://github.com/pyca/pyopenssl',
       license = 'APL2',
-      install_requires=["cryptography>=0.2.1", "six>=1.5.2"],
+      install_requires=["cryptography>=0.3", "six>=1.5.2"],
       long_description = """\
 High-level wrapper around a subset of the OpenSSL library, includes
  * SSL.Connection objects, wrapping the methods of Python's portable


### PR DESCRIPTION
These methods allow to retrieve the TLS Finished messages. This information can used to calculate channel bindings for TLS (RFC 5929)
