### PR TITLE
Make setting of OP_NO_TICKET conditional (for <= 0.9.8f compatibility)

### DIFF
--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -81,7 +81,10 @@ except AttributeError:
 
 OP_NO_QUERY_MTU = _lib.SSL_OP_NO_QUERY_MTU
 OP_COOKIE_EXCHANGE = _lib.SSL_OP_COOKIE_EXCHANGE
-OP_NO_TICKET = _lib.SSL_OP_NO_TICKET
+try:
+    OP_NO_TICKET = _lib.SSL_OP_NO_TICKET
+except AttributeError:
+    pass
 
 OP_ALL   = _lib.SSL_OP_ALL
 


### PR DESCRIPTION
This is required to make OpenSSL compatible with version of openssl <= 0.9.8f.

Compatibilities for such version of openssl are already present inside of cryptography.

Tested on Fedora 8.
