### PR TITLE
Test against cryptography's master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,15 @@ python:
 
 matrix:
   include:
+  - python: "2.6"
+    env: CRYPTOGRAPHY_GIT_MASTER=true
   - python: "2.7"
+    env: CRYPTOGRAPHY_GIT_MASTER=true
+  - python: "3.2"
+    env: CRYPTOGRAPHY_GIT_MASTER=true
+  - python: "3.3"
+    env: CRYPTOGRAPHY_GIT_MASTER=true
+  - python: "pypy"
     env: CRYPTOGRAPHY_GIT_MASTER=true
   allow_failures:
   - env: CRYPTOGRAPHY_GIT_MASTER=true


### PR DESCRIPTION
Adds tests for all pythons against the cryptography master branch. The tests are allowed to fail without failing the build for now.
