### PR TITLE
Fix memory leak in _X509_REVOKED_dup

### DIFF
--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -1323,9 +1323,11 @@ def _X509_REVOKED_dup(original):
         _raise_current_error()
 
     if original.serialNumber != _ffi.NULL:
+        _lib.ASN1_INTEGER_free(copy.serialNumber)
         copy.serialNumber = _lib.ASN1_INTEGER_dup(original.serialNumber)
 
     if original.revocationDate != _ffi.NULL:
+        _lib.ASN1_TIME_free(copy.revocationDate)
         copy.revocationDate = _lib.M_ASN1_TIME_dup(original.revocationDate)
 
     if original.extensions != _ffi.NULL:


### PR DESCRIPTION
The call to X509_REVOKED_new() will create two empty ASN1 structures
that were never freed, but simply replaced by a copy.
When doing multiple calls to CRL.get_revoked() on a big CRL, this
results in a huge memory leak.
This change adds two calls to free those empty ASN1 structures before
replacing them with the copy.

It requires https://github.com/pyca/cryptography/pull/830 to work.
