### PR TITLE
Cleaner support PKCS#12 without passphrase.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,11 @@
 	* OpenSSL/SSL.py: ``Connection.send`` and ``Connection.sendall``
 	  now also accept the ``buffer`` type as data.
 
+2014-04-05  Stephen Holsapple <sholsapp@gmail.com>
+
+	* OpenSSL/crypto.py: Make ``load_pkcs12`` backwards compatible with
+	  pyOpenSSL 0.13 by making passphrase optional.
+
 2014-03-30  Fedor Brunner  <fedor.brunner@azet.sk>
 
 	* OpenSSL/SSL.py: Add ``get_finished``, ``get_peer_finished``

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -2215,7 +2215,7 @@ def load_pkcs7_data(type, buffer):
 
 
 
-def load_pkcs12(buffer, passphrase):
+def load_pkcs12(buffer, passphrase=None):
     """
     Load a PKCS12 object from a buffer
 
@@ -2227,6 +2227,13 @@ def load_pkcs12(buffer, passphrase):
         buffer = buffer.encode("ascii")
 
     bio = _new_mem_buf(buffer)
+
+    # Use null passphrase if passphrase is None or empty string. With PKCS#12
+    # password based encryption no password and a zero length password are two
+    # different things, but OpenSSL implementation will try both to figure out
+    # which one works.
+    if not passphrase:
+        passphrase = _ffi.NULL
 
     p12 = _lib.d2i_PKCS12_bio(bio, _ffi.NULL)
     if p12 == _ffi.NULL:

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -1940,6 +1940,17 @@ class PKCS12Tests(TestCase):
             self.assertEqual(recovered_cert[-len(ca):], ca)
 
 
+    def verify_pkcs12_container(self, p12):
+        """
+        Verify that the PKCS#12 container contains the correct client
+        certificate and private key.
+        """
+        cert_pem = dump_certificate(FILETYPE_PEM, p12.get_certificate())
+        key_pem = dump_privatekey(FILETYPE_PEM, p12.get_privatekey())
+        self.assertEqual((client_cert_pem, client_key_pem, None),
+          (cert_pem, key_pem, p12.get_ca_certificates()))
+
+
     def test_load_pkcs12(self):
         """
         A PKCS12 string generated using the openssl command line can be loaded
@@ -1949,14 +1960,66 @@ class PKCS12Tests(TestCase):
         pem = client_key_pem + client_cert_pem
         p12_str = _runopenssl(
             pem, b"pkcs12", b"-export", b"-clcerts", b"-passout", b"pass:" + passwd)
-        p12 = load_pkcs12(p12_str, passwd)
-        # verify
-        self.assertTrue(isinstance(p12, PKCS12))
-        cert_pem = dump_certificate(FILETYPE_PEM, p12.get_certificate())
-        self.assertEqual(cert_pem, client_cert_pem)
-        key_pem = dump_privatekey(FILETYPE_PEM, p12.get_privatekey())
-        self.assertEqual(key_pem, client_key_pem)
-        self.assertEqual(None, p12.get_ca_certificates())
+        p12 = load_pkcs12(p12_str, passphrase=passwd)
+        self.verify_pkcs12_container(p12)
+
+
+    def test_load_pkcs12_no_passphrase(self):
+        """
+        A PKCS12 string generated using openssl command line can be loaded
+        with :py:obj:`load_pkcs12` without a passphrase and its components
+        extracted and examined.
+        """
+        pem = client_key_pem + client_cert_pem
+        p12_str = _runopenssl(
+            pem, b"pkcs12", b"-export", b"-clcerts", b"-passout", b"pass:")
+        p12 = load_pkcs12(p12_str)
+        self.verify_pkcs12_container(p12)
+
+
+    def _dump_and_load(self, dump_passphrase, load_passphrase):
+        """
+        A helper method to dump and load a PKCS12 object.
+        """
+        p12 = self.gen_pkcs12(client_cert_pem, client_key_pem)
+        dumped_p12 = p12.export(passphrase=dump_passphrase, iter=2, maciter=3)
+        return load_pkcs12(dumped_p12, passphrase=load_passphrase)
+
+
+    def test_load_pkcs12_null_passphrase_load_empty(self):
+        """
+        A PKCS12 string can be dumped with a null passphrase, loaded with an
+        empty passphrase with :py:obj:`load_pkcs12`, and it's components
+        extracted and examined.
+        """
+        self.verify_pkcs12_container(self._dump_and_load(dump_passphrase=None, load_passphrase=b''))
+
+
+    def test_load_pkcs12_null_passphrase_load_null(self):
+        """
+        A PKCS12 string can be dumped with a null passphrase, loaded with a
+        null passphrase with :py:obj:`load_pkcs12`, and it's components
+        extracted and examined.
+        """
+        self.verify_pkcs12_container(self._dump_and_load(dump_passphrase=None, load_passphrase=None))
+
+
+    def test_load_pkcs12_empty_passphrase_load_empty(self):
+        """
+        A PKCS12 string can be dumped with an empty passphrase, loaded with an
+        empty passphrase with :py:obj:`load_pkcs12`, and it's components
+        extracted and examined.
+        """
+        self.verify_pkcs12_container(self._dump_and_load(dump_passphrase=b'', load_passphrase=b''))
+
+
+    def test_load_pkcs12_empty_passphrase_load_null(self):
+        """
+        A PKCS12 string can be dumped with an empty passphrase, loaded with a
+        null passphrase with :py:obj:`load_pkcs12`, and it's components
+        extracted and examined.
+        """
+        self.verify_pkcs12_container(self._dump_and_load(dump_passphrase=b'', load_passphrase=None))
 
 
     def test_load_pkcs12_garbage(self):


### PR DESCRIPTION
The upgrade from 0.13 -> 0.14 had a small backwards incompatible API change
that, in 0.14, requires `load_pkcs12` to pass in a passphrase. This change
makes the API backwards compatible by setting a default value for the
passphrase argument.
