### PR TITLE
Make X509Name instances usable as dictionary keys.

### DIFF
--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -394,6 +394,10 @@ class X509Name(object):
         return _lib.X509_NAME_hash(self._name)
 
 
+    def __hash__(self):
+        return _lib.X509_NAME_hash(self._name)
+
+
     def der(self):
         """
         Return the DER encoding of this name

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -810,6 +810,15 @@ class X509NameTests(TestCase):
             "<X509Name object '/emailAddress=bar/CN=foo'>")
 
 
+    def test_dict_key(self):
+        """
+        :py:class:`X509NameType` instances are usable as dictionary keys.
+        """
+        name = self._x509name(commonName="foo", emailAddress="bar")
+        mapping = {name: 42}
+        self.assertEqual(mapping[self._x509name(commonName="foo", emailAddress="bar")], 42)
+
+
     def test_comparison(self):
         """
         :py:class:`X509NameType` instances should compare based on their NIDs.


### PR DESCRIPTION
I tried to use X509Name instances as dictionary keys and was surprised that looking up the certificates by subject failed. Checking the X509_NAME_hash function I was wondering why this can go wrong only to notice on the third read that X509Name implements a method hash but not the special method **hash**.

I think that it is much more intuitive to have X509Name work like special strings. Also, if a == b and a.hash() == b.hash() I would also expect hash(a) == hash(b) to hold.

I hope you agree :-)
