### PR TITLE
Set the string-mask to utf8only

### DIFF
--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -456,9 +456,6 @@ class X509Name(object):
         if isinstance(value, _text_type):
             value = value.encode('utf-8')
 
-        # Make it so OpenSSL generates utf-8 strings.
-        _lib.ASN1_STRING_set_default_mask_asc(b'utf8only')
-
         add_result = _lib.X509_NAME_add_entry_by_NID(
             self._name, nid, _lib.MBSTRING_UTF8, value, -1, -1, 0)
         if not add_result:
@@ -2490,3 +2487,9 @@ _lib.OpenSSL_add_all_algorithms()
 # This is similar but exercised mainly by exception_from_error_queue.  It calls
 # both ERR_load_crypto_strings() and ERR_load_SSL_strings().
 _lib.SSL_load_error_strings()
+
+
+
+# Set the default string mask to match OpenSSL upstream (since 2005) and
+# RFC5280 recommendations.
+_lib.ASN1_STRING_set_default_mask_asc(b'utf8only')

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -456,6 +456,9 @@ class X509Name(object):
         if isinstance(value, _text_type):
             value = value.encode('utf-8')
 
+        # Make it so OpenSSL generates utf-8 strings.
+        _lib.ASN1_STRING_set_default_mask_asc(b'utf8only')
+
         add_result = _lib.X509_NAME_add_entry_by_NID(
             self._name, nid, _lib.MBSTRING_UTF8, value, -1, -1, 0)
         if not add_result:

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -906,7 +906,7 @@ class X509NameTests(TestCase):
         self.assertEqual(
             a.der(),
             b('0\x1b1\x0b0\t\x06\x03U\x04\x06\x13\x02US'
-              '1\x0c0\n\x06\x03U\x04\x03\x13\x03foo'))
+              '1\x0c0\n\x06\x03U\x04\x03\x0c\x03foo'))
 
 
     def test_get_components(self):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='pyOpenSSL', version=__version__,
       maintainer_email = 'exarkun@twistedmatrix.com',
       url = 'https://github.com/pyca/pyopenssl',
       license = 'APL2',
-      install_requires=["cryptography>=0.4", "six>=1.5.2"],
+      install_requires=["cryptography>=0.5", "six>=1.5.2"],
       long_description = """\
 High-level wrapper around a subset of the OpenSSL library, includes
  * SSL.Connection objects, wrapping the methods of Python's portable

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Jean-Paul Calderone 2008-2014, All rights reserved

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ Installation script for the OpenSSL module
 from setuptools import setup
 
 # XXX Deduplicate this
-__version__ = '0.14'
+__version__ = '0.15dev'
 
 setup(name='pyOpenSSL', version=__version__,
       packages = ['OpenSSL'],

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Jean-Paul Calderone 2008-2014, All rights reserved
@@ -34,7 +34,7 @@ setup(name='pyOpenSSL', version=__version__,
       maintainer_email = 'exarkun@twistedmatrix.com',
       url = 'https://github.com/pyca/pyopenssl',
       license = 'APL2',
-      install_requires=["cryptography>=0.5", "six>=1.5.2"],
+      install_requires=["cryptography>=0.5.dev1", "six>=1.5.2"],
       long_description = """\
 High-level wrapper around a subset of the OpenSSL library, includes
  * SSL.Connection objects, wrapping the methods of Python's portable


### PR DESCRIPTION
If subject had utf-8 characters in them, the encoding chosen by OpenSSL for
defaults T61.

Requires changes in cryptography, commit id f8561cdf06f163806a57b0dd36290192414e3496

From the OpenSSL source code:
	 * utf8only : only use UTF8Strings (RFC2459 recommendation for 2004).

That was 10 years ago, and the last remnant that had problems with it
was Netscape, which is no longer a problem.

A request changes from:
   13:d=5  hl=2 l=   3 prim: OBJECT            :commonName
   18:d=5  hl=2 l=   9 prim: T61STRING         :Gurka ���

To:
   13:d=5  hl=2 l=   3 prim: OBJECT            :commonName
   18:d=5  hl=2 l=  12 prim: UTF8STRING        :Gurka åäö

OpenSSL/test/test_crypto.py
	Update test DER data to have utf8string.
	( \x0c instead of \0x13, PrintableString )