### PR TITLE
Add ALPN support.

### DIFF
--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -319,7 +319,7 @@ class _NpnSelectHelper(_CallbackExceptionHelper):
         )
 
 
-class _AlpnSelectHelper(_CallbackExceptionHelper):
+class _ALPNSelectHelper(_CallbackExceptionHelper):
     """
     Wrap a callback such that it can be used as an ALPN selection callback.
     """
@@ -1053,7 +1053,7 @@ class Context(object):
             bytestrings, e.g ``[b'http/1.1', b'spdy/2']``.  It should return
             one of those bytestrings, the chosen protocol.
         """
-        self._alpn_select_helper = _AlpnSelectHelper(callback)
+        self._alpn_select_helper = _ALPNSelectHelper(callback)
         self._alpn_select_callback = self._alpn_select_helper.callback
         _lib.SSL_CTX_set_alpn_select_cb(
             self._context, self._alpn_select_callback, _ffi.NULL)

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -958,8 +958,9 @@ class Context(object):
 
     def set_alpn_protos(self, protos):
         """
-        Specify the list of protocols that will get offered to the server for
-        ALPN negotiation.
+        Specify the clients ALPN protocol list.
+
+        These protocols are offered to the server during protocol negotiation.
 
         :param protos: A list of the protocols to be offered to the server.
             This list should be a Python list of bytestrings representing the
@@ -976,17 +977,15 @@ class Context(object):
         input_str = _ffi.new("unsigned char[]", protostr)
         input_str_len = _ffi.new("unsigned", len(protostr))
         _lib.SSL_CTX_set_alpn_protos(self._context, input_str)
-        return
 
     def set_alpn_select_callback(self, callback):
         """
-        Specify a callback that will be called when the client offers ALPN
-        protocols.
+        Set the callback to handle ALPN protocol choice.
 
         :param callback: The callback function.  It will be invoked with two
             arguments: the Connection, and a list of offered protocols as
             bytestrings, e.g ``[b'http/1.1', b'spdy/2']``.  It should return
-            one of those bytestrings, then chosen protocol.
+            one of those bytestrings, the chosen protocol.
         """
         @wraps(callback)
         def wrapper(ssl, out, outlen, in_, inlen, arg):
@@ -1832,8 +1831,9 @@ class Connection(object):
 
     def set_alpn_protos(self, protos):
         """
-        Specify the list of protocols that will get offered to the server for
-        ALPN negotiation.
+        Specify the client's ALPN protocol list.
+
+        These protocols are offered to the server during protocol negotiation.
 
         :param protos: A list of the protocols to be offered to the server.
             This list should be a Python list of bytestrings representing the
@@ -1850,17 +1850,17 @@ class Connection(object):
         input_str = _ffi.new("unsigned char[]", protostr)
         input_str_len = _ffi.new("unsigned", len(protostr))
         _lib.SSL_set_alpn_protos(self._ssl, input_str)
-        return
 
 
     def get_alpn_proto_negotiated(self):
-        """
-        Get the protocol that was negotiated by ALPN.
-        """
+        """Get the protocol that was negotiated by ALPN."""
         data = _ffi.new("unsigned char **")
         data_len = _ffi.new("unsigned int *")
 
         _lib.SSL_get0_alpn_selected(self._ssl, data, data_len)
+
+        if not data_len:
+            return b''
 
         return _ffi.buffer(data[0], data_len[0])[:]
 

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1017,7 +1017,7 @@ class Context(object):
 
         self._alpn_select_callback = _ffi.callback(
             "int (*)(SSL *, unsigned char **, unsigned char *, "
-                    "const unsigned char *, unsigned int, void *",
+                    "const unsigned char *, unsigned int, void *)",
             wrapper)
         _lib.SSL_CTX_set_alpn_select_cb(
             self._context, self._alpn_select_callback, _ffi.NULL)
@@ -1848,8 +1848,8 @@ class Connection(object):
         # Build a C string from the list. We don't need to save this off
         # because OpenSSL immediately copies the data out.
         input_str = _ffi.new("unsigned char[]", protostr)
-        input_str_len = _ffi.new("unsigned", len(protostr))
-        _lib.SSL_set_alpn_protos(self._ssl, input_str)
+        input_str_len = _ffi.cast("unsigned", len(protostr))
+        _lib.SSL_set_alpn_protos(self._ssl, input_str, input_str_len)
 
 
     def get_alpn_proto_negotiated(self):

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -975,8 +975,8 @@ class Context(object):
         # Build a C string from the list. We don't need to save this off
         # because OpenSSL immediately copies the data out.
         input_str = _ffi.new("unsigned char[]", protostr)
-        input_str_len = _ffi.new("unsigned", len(protostr))
-        _lib.SSL_CTX_set_alpn_protos(self._context, input_str)
+        input_str_len = _ffi.cast("unsigned", len(protostr))
+        _lib.SSL_CTX_set_alpn_protos(self._context, input_str, input_str_len)
 
     def set_alpn_select_callback(self, callback):
         """

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1018,6 +1018,9 @@ class Context(object):
             This list should be a Python list of bytestrings representing the
             protocols to offer, e.g. ``[b'http/1.1', b'spdy/2']``.
         """
+        if not _lib.Cryptography_HAS_ALPN:
+            raise NotImplementedError("ALPN not available")
+
         # Take the list of protocols and join them together, prefixing them
         # with their lengths.
         protostr = b''.join(
@@ -1039,6 +1042,9 @@ class Context(object):
             bytestrings, e.g ``[b'http/1.1', b'spdy/2']``.  It should return
             one of those bytestrings, the chosen protocol.
         """
+        if not _lib.Cryptography_HAS_ALPN:
+            raise NotImplementedError("ALPN not available")
+
         self._alpn_select_helper = _AlpnSelectHelper(callback)
         self._alpn_select_callback = self._alpn_select_helper.callback
         _lib.SSL_CTX_set_alpn_select_cb(
@@ -1863,6 +1869,9 @@ class Connection(object):
             This list should be a Python list of bytestrings representing the
             protocols to offer, e.g. ``[b'http/1.1', b'spdy/2']``.
         """
+        if not _lib.Cryptography_HAS_ALPN:
+            raise NotImplementedError("ALPN not available")
+
         # Take the list of protocols and join them together, prefixing them
         # with their lengths.
         protostr = b''.join(
@@ -1878,6 +1887,9 @@ class Connection(object):
 
     def get_alpn_proto_negotiated(self):
         """Get the protocol that was negotiated by ALPN."""
+        if not _lib.Cryptography_HAS_ALPN:
+            raise NotImplementedError("ALPN not available")
+
         data = _ffi.new("unsigned char **")
         data_len = _ffi.new("unsigned int *")
 

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -5,6 +5,7 @@ from weakref import WeakValueDictionary
 from errno import errorcode
 
 from six import text_type as _text_type
+from six import binary_type as _binary_type
 from six import integer_types as integer_types
 from six import int2byte, indexbytes
 
@@ -1003,6 +1004,9 @@ class Context(object):
 
             # Call the callback
             outstr = callback(conn, protolist)
+
+            if not isinstance(outstr, _binary_type):
+                raise TypeError("ALPN callback must return a bytestring.")
 
             # Save our callback arguments on the connection object to make sure
             # that they don't get freed before OpenSSL can use them. Then,

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -400,6 +400,10 @@ def SSLeay_version(type):
 
 
 def _requires_alpn(func):
+    """
+    Wraps any function that requires ALPN support in OpenSSL, ensuring that
+    NotImplementedError is raised if ALPN support is not present.
+    """
     @wraps(func)
     def wrapper(*args, **kwargs):
         if not _lib.Cryptography_HAS_ALPN:

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1896,7 +1896,9 @@ class Connection(object):
 
 
     def get_alpn_proto_negotiated(self):
-        """Get the protocol that was negotiated by ALPN."""
+        """
+        Get the protocol that was negotiated by ALPN.
+        """
         if not _lib.Cryptography_HAS_ALPN:
             raise NotImplementedError("ALPN not available")
 

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -337,10 +337,10 @@ class _ALPNSelectHelper(_CallbackExceptionHelper):
                 instr = _ffi.buffer(in_, inlen)[:]
                 protolist = []
                 while instr:
-                    l = indexbytes(instr, 0)
-                    proto = instr[1:l+1]
+                    encoded_len = indexbytes(instr, 0)
+                    proto = instr[1:encoded_len + 1]
                     protolist.append(proto)
-                    instr = instr[l+1:]
+                    instr = instr[encoded_len + 1:]
 
                 # Call the callback
                 outstr = callback(conn, protolist)

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -1973,22 +1973,18 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             """
             # Test the context methods first.
             context = Context(TLSv1_METHOD)
-            fail_methods = [
-                context.set_alpn_protos,
-                context.set_alpn_select_callback,
-            ]
-            for method in fail_methods:
-                self.assertRaises(
-                    NotImplementedError, method, None
-                )
+            self.assertRaises(
+                NotImplementedError, context.set_alpn_protos, None
+            )
+            self.assertRaises(
+                NotImplementedError, context.set_alpn_select_callback, None
+            )
 
             # Now test a connection.
             conn = Connection(context)
-            fail_methods = [
-                conn.set_alpn_protos,
-            ]
-            for method in fail_methods:
-                self.assertRaises(NotImplementedError, method)
+            self.assertRaises(
+                NotImplementedError, context.set_alpn_protos, None
+            )
 
 
 

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -1966,6 +1966,28 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             )
             self.assertEqual([(server, [b'http/1.1', b'spdy/2'])], select_args)
 
+    else:
+        # No ALPN.
+        def test_alpn_not_implemented(self):
+            # Test the context methods first.
+            context = Context(TLSv1_METHOD)
+            fail_methods = [
+                context.set_alpn_protos,
+                context.set_alpn_select_callback,
+            ]
+            for method in fail_methods:
+                self.assertRaises(
+                    NotImplementedError, method, None
+                )
+
+            # Now test a connection.
+            conn = Connection(context)
+            fail_methods = [
+                conn.set_alpn_protos,
+            ]
+            for method in fail_methods:
+                self.assertRaises(NotImplementedError, method)
+
 
 
 class SessionTests(TestCase):

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -1793,9 +1793,9 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
 
         def test_alpn_success(self):
             """
-            Tests that clients and servers that agree on the negotiated ALPN
-            protocol can correct establish a connection, and that the agreed
-            protocol is reported by the connections.
+            Clients and servers that agree on the negotiated ALPN protocol can
+            correct establish a connection, and the agreed protocol is reported
+            by the connections.
             """
             select_args = []
             def select(conn, options):
@@ -1870,8 +1870,8 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
 
         def test_alpn_server_fail(self):
             """
-            Tests that when clients and servers cannot agree on what protocol
-            to use next that the TLS connection does not get established.
+            When clients and servers cannot agree on what protocol to use next
+            the TLS connection does not get established.
             """
             select_args = []
             def select(conn, options):
@@ -1905,8 +1905,8 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
 
         def test_alpn_no_server(self):
             """
-            Tests that when clients and servers cannot agree on what protocol
-            to use next because the server doesn't offer ALPN.
+            When clients and servers cannot agree on what protocol to use next
+            because the server doesn't offer ALPN, no protocol is negotiated.
             """
             client_context = Context(TLSv1_METHOD)
             client_context.set_alpn_protos([b'http/1.1', b'spdy/2'])
@@ -1934,7 +1934,7 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
 
         def test_alpn_callback_exception(self):
             """
-            Test that we can handle exceptions in the ALPN select callback.
+            We can handle exceptions in the ALPN select callback.
             """
             select_args = []
             def select(conn, options):

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -1939,7 +1939,7 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             select_args = []
             def select(conn, options):
                 select_args.append((conn, options))
-                raise TypeError
+                raise TypeError()
 
             client_context = Context(TLSv1_METHOD)
             client_context.set_alpn_protos([b'http/1.1', b'spdy/2'])
@@ -1960,7 +1960,6 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             client = Connection(client_context, None)
             client.set_connect_state()
 
-            # If the client doesn't return anything, the connection will fail.
             self.assertRaises(
                 TypeError, self._interactInMemory, server, client
             )
@@ -1969,6 +1968,9 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
     else:
         # No ALPN.
         def test_alpn_not_implemented(self):
+            """
+            If ALPN is not in OpenSSL, we should raise NotImplementedError.
+            """
             # Test the context methods first.
             context = Context(TLSv1_METHOD)
             fail_methods = [

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -1818,7 +1818,7 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
 
         self._interactInMemory(server, client)
 
-        self.assertEqual([(client, [b'http/1.1', b'spdy/2'])], select_args)
+        self.assertEqual([(server, [b'http/1.1', b'spdy/2'])], select_args)
 
         self.assertEqual(server.get_alpn_proto_negotiated(), b'spdy/2')
         self.assertEqual(client.get_alpn_proto_negotiated(), b'spdy/2')
@@ -1857,7 +1857,7 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
 
         self._interactInMemory(server, client)
 
-        self.assertEqual([(client, [b'http/1.1', b'spdy/2'])], select_args)
+        self.assertEqual([(server, [b'http/1.1', b'spdy/2'])], select_args)
 
         self.assertEqual(server.get_alpn_proto_negotiated(), b'spdy/2')
         self.assertEqual(client.get_alpn_proto_negotiated(), b'spdy/2')
@@ -1895,7 +1895,7 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
         # If the client doesn't return anything, the connection will fail.
         self.assertRaises(Error, self._interactInMemory, server, client)
 
-        self.assertEqual([(client, [b'http/1.1', b'spdy/2'])], select_args)
+        self.assertEqual([(server, [b'http/1.1', b'spdy/2'])], select_args)
 
 
     def test_alpn_no_server(self):
@@ -1903,11 +1903,6 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
         Tests that when clients and servers cannot agree on what protocol to
         use next because the server doesn't offer ALPN.
         """
-        select_args = []
-        def select(conn, options):
-            select_args.append((conn, options))
-            return b''
-
         client_context = Context(TLSv1_METHOD)
         client_context.set_alpn_protos([b'http/1.1', b'spdy/2'])
 
@@ -1929,7 +1924,6 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
         # Do the dance.
         self._interactInMemory(server, client)
 
-        self.assertEqual([(client, [b'http/1.1', b'spdy/2'])], select_args)
         self.assertEqual(client.get_alpn_proto_negotiated(), b'')
 
 

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -501,7 +501,7 @@ Context objects have the following methods:
 .. py:method:: Context.set_alpn_protos(protos)
 
     Specify the protocols that the client is prepared to speak after the TLS
-    connection has been negotiated, using Application Layer Protocol
+    connection has been negotiated using Application Layer Protocol
     Negotiation.
 
     *protos* should be a list of protocols that the client is offering, each
@@ -514,7 +514,7 @@ Context objects have the following methods:
     offers protocols using Application Layer Protocol Negotiation.
 
     *callback* should be the callback function. It will be invoked with two
-    arguments: the :py:class:`Connection`, and a list of offered protocols as
+    arguments: the :py:class:`Connection` and a list of offered protocols as
     bytestrings, e.g. ``[b'http/1.1', b'spdy/2']``. It should return one of
     these bytestrings, the chosen protocol.
 
@@ -872,7 +872,7 @@ Connection objects have the following methods:
 .. py:method:: Connection.set_alpn_protos(protos)
 
     Specify the protocols that the client is prepared to speak after the TLS
-    connection has been negotiated, using Application Layer Protocol
+    connection has been negotiated using Application Layer Protocol
     Negotiation.
 
     *protos* should be a list of protocols that the client is offering, each

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -498,6 +498,26 @@ Context objects have the following methods:
 
     .. versionadded:: 0.15
 
+.. py:method:: Context.set_alpn_protos(protos)
+
+    Specify the protocols that the client is prepared to speak after the TLS
+    connection has been negotiated, using Application Layer Protocol
+    Negotiation.
+
+    *protos* should be a list of protocols that the client is offering, each
+    as a bytestring. For example, ``[b'http/1.1', b'spdy/2']``.
+
+
+.. py:method:: Context.set_alpn_select_callback(callback)
+
+    Specify a callback function that will be called on the server when a client
+    offers protocols using Application Layer Protocol Negotiation.
+
+    *callback* should be the callback function. It will be invoked with two
+    arguments: the :py:class:`Connection`, and a list of offered protocols as
+    bytestrings, e.g. ``[b'http/1.1', b'spdy/2']``. It should return one of
+    these bytestrings, the chosen protocol.
+
 
 .. _openssl-session:
 
@@ -848,6 +868,22 @@ Connection objects have the following methods:
     returns an empty string.
 
     .. versionadded:: 0.15
+
+.. py:method:: Connection.set_alpn_protos(protos)
+
+    Specify the protocols that the client is prepared to speak after the TLS
+    connection has been negotiated, using Application Layer Protocol
+    Negotiation.
+
+    *protos* should be a list of protocols that the client is offering, each
+    as a bytestring. For example, ``[b'http/1.1', b'spdy/2']``.
+
+
+.. py:method:: Connection.get_alpn_proto_negotiated()
+
+    Get the protocol that was negotiated by Application Layer Protocol
+    Negotiation. Returns a bytestring of the protocol name. If no protocol has
+    been negotiated yet, returns an empty string.
 
 
 .. Rubric:: Footnotes


### PR DESCRIPTION
This pull request adds support for Application Layer Protocol Negotiation, the spec-standardised version of NPN.

This was added to OpenSSL in v1.0.2. The keen eye might detect that OpenSSL v1.0.2 is only in beta at the moment, which means that unsurprisingly this doesn't work right now. I'm opening this Pull Request to track the work: I don't expect it to be merged any time soon.

The relevant `cryptography` support was merged in pyca/cryptography#1105.

This is the second half of #79.