### PR TITLE
Implement Connection.recv_into.

### DIFF
--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1027,6 +1027,45 @@ class Connection(object):
     read = recv
 
 
+    def recv_into(self, buffer, nbytes=None, flags=None):
+        """
+        Receive data on the connection and store the data into a buffer rather
+        than creating a new string.
+
+        :param buffer: The buffer to copy into.
+        :param nbytes: (optional) The maximum number of bytes to read into the
+            buffer. If not present, defaults to the size of the buffer. If
+            larger than the size of the buffer, is reduced to the size of the
+            buffer.
+        :param flags: (optional) Included for compatibility with the socket
+            API, the value is ignored.
+        :return: The number of bytes read into the buffer.
+        """
+        if nbytes is None:
+            nbytes = len(buffer)
+        else:
+            nbytes = min(nbytes, len(buffer))
+
+        # We need to create a temporary buffer. This is annoying, it would be
+        # better if we could pass memoryviews straight into the SSL_read call,
+        # but right now we can't. Revisit this if CFFI gets that ability.
+        buf = _ffi.new("char[]", nbytes)
+        result = _lib.SSL_read(self._ssl, buf, nbytes)
+        self._raise_ssl_error(self._ssl, result)
+
+        # This strange line is all to avoid a memory copy. The buffer protocol
+        # should allow us to assign a CFFI buffer to the LHS of this line, but
+        # on CPython 3.3+ that segfaults. As a workaround, we can temporarily
+        # wrap it in a memoryview, except on Python 2.6 which doesn't have a
+        # memoryview type.
+        try:
+            buffer[:result] = memoryview(_ffi.buffer(buf, result))
+        except NameError:
+            buffer[:result] = _ffi.buffer(buf, result)
+
+        return result
+
+
     def _handle_bio_errors(self, bio, result):
         if _lib.BIO_should_retry(bio):
             if _lib.BIO_should_read(bio):

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -614,6 +614,13 @@ Connection objects have the following methods:
     by *bufsize*.
 
 
+.. py:method:: Connection.recv_into(buffer[, nbytes])
+
+    Receive data from the Connection and copy it directly into the provided
+    buffer. The return value is the number of bytes read from the connection.
+    The maximum amount of data to be received at once is specified by *nbytes*.
+
+
 .. py:method:: Connection.bio_write(bytes)
 
     If the Connection was created with a memory BIO, this method can be used to add


### PR DESCRIPTION
This brings PyOpenSSL slightly closer to the standard `socket` module by providing `recv_into`.

This isn't an ideal implementation. In an ideal world the buffer object could be passed directly into the call to `SSL_read`, which would reduce this method to a single memory copy (by OpenSSL into the buffer). Instead, this method takes us to two copies (one by OpenSSL into the temp buffer, one from the temp buffer into the main buffer) and one allocation. This is better than implementing it on top of recv, which would lead to three copies and an allocation (one copy by OpenSSL into the temp buffer, one from the temp buffer into the return value, and one from the return value into the main buffer).

We can get that better performance if we can get CFFI support for [issue 65](https://bitbucket.org/cffi/cffi/issue/65/support-memoryview-to-char-conversion), but @arigo has suggested that there might be PyPy problems with that. For the moment I'd rather go ahead with this, which is imperfect but better, than wait behind CFFI-65.