### PR TITLE
First attempt at creating a more GeneralNames based  X509SubjectAltnativeName class

### DIFF
--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -18,11 +18,18 @@ from OpenSSL._util import (
 FILETYPE_PEM = _lib.SSL_FILETYPE_PEM
 FILETYPE_ASN1 = _lib.SSL_FILETYPE_ASN1
 
+NID_subject_alt_name = _lib.NID_subject_alt_name
+
 # TODO This was an API mistake.  OpenSSL has no such constant.
 FILETYPE_TEXT = 2 ** 16 - 1
 
 TYPE_RSA = _lib.EVP_PKEY_RSA
 TYPE_DSA = _lib.EVP_PKEY_DSA
+
+
+def _ia5_to_pystring(ia5):
+    return _ffi.string(_lib.ASN1_STRING_data(
+        _ffi.cast("ASN1_STRING *", ia5)))
 
 
 class Error(Exception):
@@ -740,8 +747,142 @@ class X509Extension(object):
         char_result = _lib.ASN1_STRING_data(string_result)
         result_length = _lib.ASN1_STRING_length(string_result)
         return _ffi.buffer(char_result, result_length)[:]
-
 X509ExtensionType = X509Extension
+
+
+class X509GeneralName(object):
+    def __init__(self, gn_type, gn_value):
+        self.type = gn_type
+        self.value = gn_value
+
+    def get_type(self):
+        return self.type
+
+    def get_value(self):
+        return self.value
+
+    def __str__(self):
+        return "(%s, %s)" % (self.type.__str__(), self.value.__str__())
+
+    def __repr__(self):
+        return "<GeneralName (%s,%s)>" % (
+            self.type.__repr__(), self.value.__repr__())
+
+
+class X509AltName(object):
+    def __init__(self, x509, nid):
+        """
+        Retrieve the AltName extension if it exists.
+
+        :param x509:X509 instance to fetch the AltName extension from
+        :param nid: May be either NID_subject_alt_nam for getting the
+        subject alt name extension. In the future we can use
+        NID_issuer_alt_name when the hazmat project exposes it.
+        """
+        self._x509 = x509
+        self._ext = None
+        n_exts = x509.get_extension_count()
+        for i in range(0, n_exts):
+            ext = x509.get_extension(i)
+            if ext._nid == nid:
+                self._ext = ext
+                break
+
+    def get_general_names(self):
+        """
+        Returns a list of the general names contained in this extenion
+        """
+        if self._ext:
+            #Ancher the _names_ptr to the destructor GENERAL_NAMES_free
+            names_ptr = _ffi.gc(
+                _lib.X509V3_EXT_d2i(self._ext._extension),
+                _lib.GENERAL_NAMES_free)
+
+            general_names = _ffi.cast("GENERAL_NAMES *",
+                                      names_ptr)
+            n_names = _lib.sk_GENERAL_NAME_num(general_names)
+            names = []
+            for i in range(0, n_names):
+                general_name = _lib.sk_GENERAL_NAME_value(general_names, i)
+
+                if general_name.type == _lib.GEN_OTHERNAME:
+                    gn_type = 'otherName'
+                    gn_value = 'UNSUPPORTED_VALUE'
+                    names.append(X509GeneralName(gn_type, gn_value))
+
+                elif general_name.type == _lib.GEN_EMAIL:
+                    gn_type = 'rfc822Name'
+                    gn_value = _ia5_to_pystring(general_name.d.ia5)
+                    names.append(X509GeneralName(gn_type, gn_value))
+
+                elif general_name.type == _lib.GEN_X400:
+                    gn_type = 'x400Address'
+                    gn_value = 'UNSUPPORTED_VALUE'
+                    names.append(X509GeneralName(gn_type, gn_value))
+
+                elif general_name.type ==_lib.GEN_DNS:
+                    gn_type = 'dNSName'
+                    gn_value = _ia5_to_pystring(general_name.d.ia5)
+                    names.append(X509GeneralName(gn_type, gn_value))
+
+                elif general_name.type == _lib.GEN_URI:
+                    gn_type = 'uniformResourceIdentifier'
+                    gn_value = _ia5_to_pystring(general_name.d.ia5)
+                    names.append(X509GeneralName(gn_type, gn_value))
+
+                elif general_name.type == _lib.GEN_DIRNAME:
+                    name = X509Name.__new__(X509Name)
+                    name._name = _ffi.gc(_lib.X509_NAME_dup(
+                        general_name.d.directoryName), _lib.X509_NAME_free)
+                    gn_type = 'directoryName'
+                    gn_value = name
+                    names.append(X509GeneralName(gn_type, gn_value))
+
+                elif general_name.type == _lib.GEN_EDIPARTY:
+                    gn_type = 'ediPartyName'
+                    gn_value = 'UNSUPPORTED_TYPE'
+                    names.append(X509GeneralName(gn_type, gn_value))
+
+                elif general_name.type == _lib.GEN_IPADD:
+                    gn_type = None
+                    gn_value = None
+                    if general_name.d.ip.length == 4:
+                        gn_type = "iPAddress_IPv4"
+                        d = general_name.d.iPAddress.data
+                        gn_value = "%s.%s.%s.%s" % (d[0], d[1], d[2], d[3])
+                    elif general_name.d.ip.length == 16:
+                        gn_type = "iPAddress_IPv6"
+                        d = general_name.d.iPAddress.data
+                        ipv6 = []
+                        for j in range(0, 16, 2):
+                            ipv6.append("%x" % ((d[j] << 8) | d[j+1]))
+                        gn_value = ":".join(ipv6).upper()
+
+                    if gn_type is not None and gn_value is not None:
+                        names.append(X509GeneralName(gn_type, gn_value))
+                    else:
+                        names.append(X509GeneralName("iPAddress_?", "UNKNOWN"))
+
+                elif general_name.type == _lib.GEN_RID:
+                    gn_type = 'registeredID'
+                    gn_value = 'UNSUPPORTED_VALUE'
+                    names.append(X509GeneralName(gn_type, gn_value))
+
+                else:
+                    gn_type = "UNSUPPORTED_TYPE"
+                    gn_value = "UNSUPPORTED_VALUE"
+                    names.append(X509GeneralName(gn_type,gn_value))
+            return names
+
+
+class X509SubjectAltName(X509AltName):
+    def __init__(self, x509):
+        """
+        :param x509: The X509 instance that will be searched for the
+        subject alt name extension
+        """
+        super(X509SubjectAltName, self).__init__(
+            x509, NID_subject_alt_name)
 
 
 class X509Req(object):
@@ -1333,6 +1474,9 @@ class X509(object):
         extension = _lib.X509_EXTENSION_dup(ext._extension)
         ext._extension = _ffi.gc(extension, _lib.X509_EXTENSION_free)
         return ext
+
+    def get_subject_alt_name(self):
+        return X509SubjectAltName(self)
 
 X509Type = X509
 

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -29,7 +29,7 @@ TYPE_DSA = _lib.EVP_PKEY_DSA
 
 def _ia5_to_pystring(ia5):
     return _ffi.string(_lib.ASN1_STRING_data(
-        _ffi.cast("ASN1_STRING *", ia5)))
+        _ffi.cast("ASN1_STRING *", ia5))).decode("utf-8")
 
 
 class Error(Exception):

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -1613,6 +1613,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         test that the get_subject_alt_name() method can split up the
         list of general names
         """
+
         cert = load_certificate(FILETYPE_PEM, BIG_ALT_CERT_PEM)
         san = cert.get_subject_alt_name()
         general_names = san.get_general_names()
@@ -1629,7 +1630,7 @@ WpOdIpB8KksUTCzV591Nr1wd
                              'www.hostFrom_dNSName2.com',
                              'www.hostFrom_dNSName3.com']
 
-        for i in range(0,3):
+        for i in range(0, 3):
             self.assertEquals(general_names[i].value,
                               expected_dNSNames.pop(0))
 
@@ -1637,10 +1638,10 @@ WpOdIpB8KksUTCzV591Nr1wd
         self.assertEquals(
             general_names[3].value, 'carlos.garza@rackspace.com')
 
-        expected_cns = [u'www.cnFromAltName1.org', u'www.cnFromAltName2.org',
-                        u'www.cnFromAltName3.org', u'www.cnFromAltName4.org']
+        expected_cns = ['www.cnFromAltName1.org', 'www.cnFromAltName2.org',
+                        'www.cnFromAltName3.org', 'www.cnFromAltName4.org']
 
-        for i in xrange(4,8):
+        for i in range(4, 8):
             self.assertEquals(general_names[i].value.CN, expected_cns.pop(0))
 
         self.assertEquals(general_names[8].value, "10.1.2.3")

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -44,6 +44,46 @@ BAD_CIPHER = "zippers"
 GOOD_DIGEST = "MD5"
 BAD_DIGEST = "monkeys"
 
+BIG_ALT_CERT_PEM = b("""-----BEGIN CERTIFICATE-----
+MIIGuDCCBaCgAwIBAgIGAUdHb05VMA0GCSqGSIb3DQEBDQUAMIGMMQswCQYDVQQG
+EwJVUzEOMAwGA1UECAwFVGV4YXMxEzARBgNVBAcMClNhbkFudG9uaW8xGjAYBgNV
+BAoMEVJhY2tzcGFjZSBIb3N0aW5nMRwwGgYDVQQLDBNDbG91ZCBMb2FkQmFsYW5j
+aW5nMR4wHAYDVQQDDBV3d3cuQ05Gcm9tU3ViamVjdC5vcmcwHhcNMTQwNzE3MDMw
+NjIxWhcNMTQwNzE5MDMwNjIxWjCBjDELMAkGA1UEBhMCVVMxDjAMBgNVBAgMBVRl
+eGFzMRMwEQYDVQQHDApTYW5BbnRvbmlvMRowGAYDVQQKDBFSYWNrc3BhY2UgSG9z
+dGluZzEcMBoGA1UECwwTQ2xvdWQgTG9hZEJhbGFuY2luZzEeMBwGA1UEAwwVd3d3
+LkNORnJvbVN1YmplY3Qub3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEAz5KXcYzaF1uNIpLM/I3MiBGV4ncF0wGZfShl5FU6V4DGWUomIzg47DUksxF/
+i0nMMoY1oK5zM2CwnowyNeCMTTYFjtiKUTHdOq5Xb0iV5I4gCqRJddjrq5ndRjUv
+OyPZDmnmnFJXbiwdOi1PX/SOh+w3bxNqJW0qJabT/cqW1KwvzyJFlUoNsGAsokk3
+JShl5sHjERAPhCpuEh5KZA/6Ef8+wyeBz33eXYzHdbo9O1zMoB3kGiRmooOE8P4J
+IUCpFqAhIIyUeC9h9scOJLHF9WVHgA1i5xk0da7ReLdb0Il5bSXMbaxsarbRRk4s
+Jvx22lqW+fcIpyfww0RM/N7mEQIDAQABo4IDHDCCAxgwDAYDVR0TAQH/BAIwADAO
+BgNVHQ8BAf8EBAMCA7gwggL2BgNVHREEggLtMIIC6YIZd3d3Lmhvc3RGcm9tX2RO
+U05hbWUxLmNvbYIZd3d3Lmhvc3RGcm9tX2ROU05hbWUyLmNvbYIZd3d3Lmhvc3RG
+cm9tX2ROU05hbWUzLmNvbYEaY2FybG9zLmdhcnphQHJhY2tzcGFjZS5jb22kgZAw
+gY0xCzAJBgNVBAYTAlVTMQ4wDAYDVQQIDAVUZXhhczETMBEGA1UEBwwKU2FuQW50
+b25pbzEaMBgGA1UECgwRUmFja3NwYWNlIEhvc3RpbmcxHDAaBgNVBAsME0Nsb3Vk
+IExvYWRCYWxhbmNpbmcxHzAdBgNVBAMMFnd3dy5jbkZyb21BbHROYW1lMS5vcmek
+gZAwgY0xCzAJBgNVBAYTAlVTMQ4wDAYDVQQIDAVUZXhhczETMBEGA1UEBwwKU2Fu
+QW50b25pbzEaMBgGA1UECgwRUmFja3NwYWNlIEhvc3RpbmcxHDAaBgNVBAsME0Ns
+b3VkIExvYWRCYWxhbmNpbmcxHzAdBgNVBAMMFnd3dy5jbkZyb21BbHROYW1lMi5v
+cmekgZAwgY0xCzAJBgNVBAYTAlVTMQ4wDAYDVQQIDAVUZXhhczETMBEGA1UEBwwK
+U2FuQW50b25pbzEaMBgGA1UECgwRUmFja3NwYWNlIEhvc3RpbmcxHDAaBgNVBAsM
+E0Nsb3VkIExvYWRCYWxhbmNpbmcxHzAdBgNVBAMMFnd3dy5jbkZyb21BbHROYW1l
+My5vcmekgZAwgY0xCzAJBgNVBAYTAlVTMQ4wDAYDVQQIDAVUZXhhczETMBEGA1UE
+BwwKU2FuQW50b25pbzEaMBgGA1UECgwRUmFja3NwYWNlIEhvc3RpbmcxHDAaBgNV
+BAsME0Nsb3VkIExvYWRCYWxhbmNpbmcxHzAdBgNVBAMMFnd3dy5jbkZyb21BbHRO
+YW1lNC5vcmeHBAoBAgOHEAEjRWeJq83v97PVkeaixICGFmh0dHA6Ly93d3cucmFj
+a2V4cC5vcmcwDQYJKoZIhvcNAQENBQADggEBAJ1G0A2ukY9o8nJspZ9goCSSSn30
+RL1Pe1R8IlyNYVvxhlmHcm+FoanmrdpABf7mr9P55dyaQdHOoBLYxU8NtCQ8wld4
+8O1MzwjOGX8c7BXuNy5HMi4ofjlKJN+4+2iQNY+WNxBIBEYWcU/+52ztkE5mIgdR
+JA36JQAO+7VTthKBuIhBarIMJQhtagYlukyHJ0/7EytjPMe2hKEAYTttJdfuX1qg
+nlPA7ojSCCVjOC7X2gBMU4meaJlzic++XDyIoNTW340SWN/yMGEwKUiVQPBslSc/
+glSQGSkOofA+DJaniRg4FVDUNC55dtZFjDZPgLVHgoDBJXYuLJqYWZtkgDM=
+-----END CERTIFICATE-----
+""")
+
 root_cert_pem = b("""-----BEGIN CERTIFICATE-----
 MIIC7TCCAlagAwIBAgIIPQzE4MbeufQwDQYJKoZIhvcNAQEFBQAwWDELMAkGA1UE
 BhMCVVMxCzAJBgNVBAgTAklMMRAwDgYDVQQHEwdDaGljYWdvMRAwDgYDVQQKEwdU
@@ -1567,6 +1607,46 @@ WpOdIpB8KksUTCzV591Nr1wd
               "URI:http://null.python.org\x00http://example.org, "
               "IP Address:192.0.2.1, IP Address:2001:DB8:0:0:0:0:0:1\n"),
             b(str(ext)))
+
+    def test_X509SubjectAltName(self):
+        """
+        test that the get_subject_alt_name() method can split up the
+        list of general names
+        """
+        cert = load_certificate(FILETYPE_PEM, BIG_ALT_CERT_PEM)
+        san = cert.get_subject_alt_name()
+        general_names = san.get_general_names()
+        self.assertEquals(len(general_names), 11)
+        expected_types = ['dNSName', 'dNSName', 'dNSName', 'rfc822Name',
+                          'directoryName', 'directoryName', 'directoryName',
+                          'directoryName', 'iPAddress_IPv4', 'iPAddress_IPv6',
+                          'uniformResourceIdentifier']
+
+        for i in range(0,len(expected_types)):
+            self.assertEquals(general_names[i].type, expected_types[i])
+
+        expected_dNSNames = ['www.hostFrom_dNSName1.com',
+                             'www.hostFrom_dNSName2.com',
+                             'www.hostFrom_dNSName3.com']
+
+        for i in range(0,3):
+            self.assertEquals(general_names[i].value,
+                              expected_dNSNames.pop(0))
+
+        self.assertEquals(general_names[3].type, 'rfc822Name')
+        self.assertEquals(
+            general_names[3].value, 'carlos.garza@rackspace.com')
+
+        expected_cns = [u'www.cnFromAltName1.org', u'www.cnFromAltName2.org',
+                        u'www.cnFromAltName3.org', u'www.cnFromAltName4.org']
+
+        for i in xrange(4,8):
+            self.assertEquals(general_names[i].value.CN, expected_cns.pop(0))
+
+        self.assertEquals(general_names[8].value, "10.1.2.3")
+        self.assertEquals(
+            general_names[9].value, "123:4567:89AB:CDEF:F7B3:D591:E6A2:C480")
+        self.assertEquals(general_names[10].value, "http://www.rackexp.org")
 
 
     def test_invalid_digest_algorithm(self):


### PR DESCRIPTION
The tests will fail untill the X509_NAME_free and X509V3_EXT_d2i are exposed from the cryptography project.  This new get_subject_alt_name method will split up the alt Names into seperate components.
