### PR TITLE
up certificate sizes to 2432 bit

### DIFF
--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -153,7 +153,7 @@ def _create_certificate_chain():
 
     # Step 1
     cakey = PKey()
-    cakey.generate_key(TYPE_RSA, 512)
+    cakey.generate_key(TYPE_RSA, 2432)
     cacert = X509()
     cacert.get_subject().commonName = "Authority Certificate"
     cacert.set_issuer(cacert.get_subject())
@@ -166,7 +166,7 @@ def _create_certificate_chain():
 
     # Step 2
     ikey = PKey()
-    ikey.generate_key(TYPE_RSA, 512)
+    ikey.generate_key(TYPE_RSA, 2432)
     icert = X509()
     icert.get_subject().commonName = "Intermediate Certificate"
     icert.set_issuer(cacert.get_subject())
@@ -179,7 +179,7 @@ def _create_certificate_chain():
 
     # Step 3
     skey = PKey()
-    skey.generate_key(TYPE_RSA, 512)
+    skey.generate_key(TYPE_RSA, 2432)
     scert = X509()
     scert.get_subject().commonName = "Server Certificate"
     scert.set_issuer(icert.get_subject())


### PR DESCRIPTION
512 bits in a test case seems a little outdated.

2432 is from the default in gnutls certtool
