### PR TITLE
Handle when an OpenSSL error doesn't contain a reason

### DIFF
--- a/OpenSSL/_util.py
+++ b/OpenSSL/_util.py
@@ -7,6 +7,8 @@ lib = binding.lib
 
 def exception_from_error_queue(exceptionType):
     def text(charp):
+        if not charp:
+            return ""
         return native(ffi.string(charp))
 
     errors = []

--- a/OpenSSL/test/test_util.py
+++ b/OpenSSL/test/test_util.py
@@ -5,6 +5,6 @@ from OpenSSL.test.util import TestCase
 
 class TestErrors(TestCase):
     def test_exception_from_error_queue_nonexistant_reason(self):
-        lib.ERR_put_error(lib.ERR_LIB_EVP, 0, 1112, "", 10)
+        lib.ERR_put_error(lib.ERR_LIB_EVP, 0, 1112, b"", 10)
         exc = self.assertRaises(ValueError, exception_from_error_queue, ValueError)
         self.assertEqual(exc.args[0][0][2], "")

--- a/OpenSSL/test/test_util.py
+++ b/OpenSSL/test/test_util.py
@@ -5,6 +5,11 @@ from OpenSSL.test.util import TestCase
 
 class TestErrors(TestCase):
     def test_exception_from_error_queue_nonexistant_reason(self):
+        """
+        :py:func:`exception_from_error_queue` does not raise a ``TypeError``
+        when it encounters an OpenSSL error code which does not have a reason
+        string.
+        """
         lib.ERR_put_error(lib.ERR_LIB_EVP, 0, 1112, b"", 10)
         exc = self.assertRaises(ValueError, exception_from_error_queue, ValueError)
         self.assertEqual(exc.args[0][0][2], "")

--- a/OpenSSL/test/test_util.py
+++ b/OpenSSL/test/test_util.py
@@ -4,7 +4,7 @@ from OpenSSL.test.util import TestCase
 
 
 class TestErrors(TestCase):
-    def test_exception_from_error_queue_nonexistant_reason(self):
+    def test_exception_from_error_queue_nonexistent_reason(self):
         """
         :py:func:`exception_from_error_queue` does not raise a ``TypeError``
         when it encounters an OpenSSL error code which does not have a reason

--- a/OpenSSL/test/test_util.py
+++ b/OpenSSL/test/test_util.py
@@ -1,0 +1,10 @@
+from OpenSSL._util import exception_from_error_queue, lib
+from OpenSSL.test.util import TestCase
+
+
+
+class TestErrors(TestCase):
+    def test_exception_from_error_queue_nonexistant_reason(self):
+        lib.ERR_put_error(lib.ERR_LIB_EVP, 0, 1112, "", 10)
+        exc = self.assertRaises(ValueError, exception_from_error_queue, ValueError)
+        self.assertEqual(exc.args[0][0][2], "")


### PR DESCRIPTION
(Or any other field)

You can reproduce the error by running:

```
treq.get('https://nile.ghdonline.org')
```

from within a twisted program (and doing the approrpiate deferred stuff).

I'm unsure how to craft a unit test for this