### PR TITLE
Add OpenSSL.crypto.verify_cert method.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,12 +1,17 @@
-2014-12-11  Jean-Paul Calderone  <exarkun@twistedmatrix.com>
+2015-01-30  Stephen Holsapple <sholsapp@gmail.com>
 
-	* OpenSSL/SSL.py: Fixed a regression ``Context.check_privatekey``
-	  causing it to always succeed - even if it should fail.
+	* OpenSSL/crypto.py: Expose ``X509StoreContext`` for verifying certificates.
+	* OpenSSL/test/test_crypto.py: Add intermediate certificates for
 
 2015-01-08  Paul Aurich <paul@darkrain42.org>
 
 	* OpenSSL/SSL.py: ``Connection.shutdown`` now propagates errors from the
 	  underlying socket.
+
+2014-12-11  Jean-Paul Calderone  <exarkun@twistedmatrix.com>
+
+	* OpenSSL/SSL.py: Fixed a regression ``Context.check_privatekey``
+	  causing it to always succeed - even if it should fail.
 
 2014-08-21  Alex Gaynor  <alex.gaynor@gmail.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,7 +11,7 @@
 2014-08-21  Alex Gaynor  <alex.gaynor@gmail.com>
 
 	* OpenSSL/crypto.py: Fixed a regression where calling ``load_pkcs7_data``
-	  with ``FILETYPE_ASN1`` would fail with a ``NameError.
+	  with ``FILETYPE_ASN1`` would fail with a ``NameError``.
 
 2014-05-05  Jean-Paul Calderone  <exarkun@twistedmatrix.com>
 

--- a/OpenSSL/_util.py
+++ b/OpenSSL/_util.py
@@ -5,11 +5,25 @@ binding = Binding()
 ffi = binding.ffi
 lib = binding.lib
 
-def exception_from_error_queue(exceptionType):
-    def text(charp):
-        return native(ffi.string(charp))
+
+
+def text(charp):
+    return native(ffi.string(charp))
+
+
+
+def exception_from_error_queue(exception_type):
+    """
+    Convert an OpenSSL library failure into a Python exception.
+
+    When a call to the native OpenSSL library fails, this is usually signalled
+    by the return value, and an error code is stored in an error queue
+    associated with the current thread. The err library provides functions to
+    obtain these error codes and textual error messages.
+    """
 
     errors = []
+
     while True:
         error = lib.ERR_get_error()
         if error == 0:
@@ -19,7 +33,7 @@ def exception_from_error_queue(exceptionType):
                 text(lib.ERR_func_error_string(error)),
                 text(lib.ERR_reason_error_string(error))))
 
-    raise exceptionType(errors)
+    raise exception_type(errors)
 
 
 

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -1439,11 +1439,12 @@ class X509StoreContext(object):
             _native(_ffi.string(_lib.X509_verify_cert_error_string(
                         _lib.X509_STORE_CTX_get_error(self._store_ctx)))),
         ]
+        # A context error should always be associated with a certificate, so we
+        # expect this call to never return :class:`None`.
         _x509 = _lib.X509_STORE_CTX_get_current_cert(self._store_ctx)
-        if _x509 != _ffi.NULL:
-          _cert = _lib.X509_dup(_x509)
-          pycert = X509.__new__(X509)
-          pycert._x509 = _ffi.gc(_cert, _lib.X509_free)
+        _cert = _lib.X509_dup(_x509)
+        pycert = X509.__new__(X509)
+        pycert._x509 = _ffi.gc(_cert, _lib.X509_free)
         return X509StoreContextError(errors, pycert)
 
 

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -1397,16 +1397,27 @@ class X509StoreContext(object):
     encapsulated in this object includes, but is not limited to, a set of
     trusted certificates, verification parameters and revoked certificates.
 
-    :param store: An :py:class:`X509Store` of trusted certificates.
-    :param cert: An :py:class:`X509` certificate to be validated during a
-        subsequent call to :py:func:`verify_cert`.
+    :ivar _store_ctx: The underlying X509_STORE_CTX structure used by this
+        instance.  It is dynamically allocated and automatically garbage
+        collected.
+
+    :ivar _store: See the ``store`` `__init__`` parameter.
+
+    :ivar _cert: See the ``certificate`` `__init__`` parameter.
     """
 
-    def __init__(self, store, cert):
+    def __init__(self, store, certificate):
+        """
+        :param X509Store store: The certificates which will be trusted for the
+            purposes of any verifications.
+
+        :param X509 certificate: The certificate to be verified.
+        """
         store_ctx = _lib.X509_STORE_CTX_new()
         self._store_ctx = _ffi.gc(store_ctx, _lib.X509_STORE_CTX_free)
         self._store = store
-        self._cert = cert
+        self._cert = certificate
+
 
     def _init(self):
         """
@@ -1416,6 +1427,7 @@ class X509StoreContext(object):
         if ret <= 0:
             _raise_current_error()
 
+
     def _cleanup(self):
         """
         Internally cleans up the store context.
@@ -1424,6 +1436,7 @@ class X509StoreContext(object):
         :py:meth:`init`.
         """
         _lib.X509_STORE_CTX_cleanup(self._store_ctx)
+
 
 
 def load_certificate(type, buffer):

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -1392,10 +1392,12 @@ class X509StoreContext(object):
     """
     An X.509 store context.
 
-    An :py:class:`X509StoreContext` is used to verify a certificate in some
-    context in conjunction with :py:func:`verify_cert`. The information
-    encapsulated in this object includes, but is not limited to, a set of
-    trusted certificates, verification parameters and revoked certificates.
+    An :py:class:`X509StoreContext` is used to define some of the criteria for
+    certificate verification.  The information encapsulated in this object
+    includes, but is not limited to, a set of trusted certificates,
+    verification parameters, and revoked certificates.
+
+    Of these, only the set of trusted certificates is currently exposed.
 
     :ivar _store_ctx: The underlying X509_STORE_CTX structure used by this
         instance.  It is dynamically allocated and automatically garbage

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -1399,7 +1399,7 @@ class X509StoreContext(object):
 
     :param store: An :py:class:`X509Store` of trusted certificates.
     :param cert: An :py:class:`X509` certificate to be validated during a
-      subsequent call to :py:func:`verify_cert`.
+        subsequent call to :py:func:`verify_cert`.
     """
 
     def __init__(self, store, cert):

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -1392,12 +1392,12 @@ class X509StoreContext(object):
     """
     An X.509 store context.
 
-    A :py:class:`X509StoreContext` is used to verify a certificate in some
+    An :py:class:`X509StoreContext` is used to verify a certificate in some
     context in conjunction with :py:func:`verify_cert`. The information
     encapsulated in this object includes, but is not limited to, a set of
     trusted certificates, verification parameters and revoked certificates.
 
-    :param store: A :py:class:`X509Store` of trusted certificates.
+    :param store: An :py:class:`X509Store` of trusted certificates.
     :param cert: An :py:class:`X509` certificate to be validated during a
       subsequent call to :py:func:`verify_cert`.
     """

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -45,7 +45,8 @@ def _exception_from_context_error(exception_type, store_ctx):
     errors = [
         _lib.X509_STORE_CTX_get_error(store_ctx._store_ctx),
         _lib.X509_STORE_CTX_get_error_depth(store_ctx._store_ctx),
-        _native(_ffi.string(_lib.X509_verify_cert_error_string(_lib.X509_STORE_CTX_get_error(store_ctx._store_ctx)))),
+        _native(_ffi.string(_lib.X509_verify_cert_error_string(
+                    _lib.X509_STORE_CTX_get_error(store_ctx._store_ctx)))),
     ]
     _x509 = _lib.X509_STORE_CTX_get_current_cert(store_ctx._store_ctx)
     if _x509 != _ffi.NULL:

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -39,7 +39,7 @@ def _exception_from_context_error(exception_type, store_ctx):
     exception.
 
     When a call to native OpenSSL X509_verify_cert fails, additonal information
-    about the failure can be contained from the store context.
+    about the failure can be obtained from the store context.
     """
 
     errors = [

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -10,6 +10,7 @@ from unittest import main
 import base64
 import os
 import re
+import sys
 from subprocess import PIPE, Popen
 from datetime import datetime, timedelta
 
@@ -17,7 +18,8 @@ from six import u, b, binary_type
 
 from OpenSSL.crypto import TYPE_RSA, TYPE_DSA, Error, PKey, PKeyType
 from OpenSSL.crypto import X509, X509Type, X509Name, X509NameType
-from OpenSSL.crypto import X509Store, X509StoreType, X509Req, X509ReqType
+from OpenSSL.crypto import X509Store, X509StoreType, X509StoreContext
+from OpenSSL.crypto import X509Req, X509ReqType
 from OpenSSL.crypto import X509Extension, X509ExtensionType
 from OpenSSL.crypto import load_certificate, load_privatekey
 from OpenSSL.crypto import FILETYPE_PEM, FILETYPE_ASN1, FILETYPE_TEXT
@@ -28,7 +30,7 @@ from OpenSSL.crypto import PKCS12, PKCS12Type, load_pkcs12
 from OpenSSL.crypto import CRL, Revoked, load_crl
 from OpenSSL.crypto import NetscapeSPKI, NetscapeSPKIType
 from OpenSSL.crypto import (
-    sign, verify, get_elliptic_curve, get_elliptic_curves)
+    sign, verify, verify_cert, get_elliptic_curve, get_elliptic_curves)
 from OpenSSL.test.util import EqualityTestsMixin, TestCase
 from OpenSSL._util import native, lib
 
@@ -83,6 +85,40 @@ cbvAhow217X9V0dVerEOKxnNYspXRrh36h7k4mQA+sDq
 -----END RSA PRIVATE KEY-----
 """)
 
+intermediate_cert_pem = b("""-----BEGIN CERTIFICATE-----
+MIICVzCCAcCgAwIBAgIRAMPzhm6//0Y/g2pmnHR2C4cwDQYJKoZIhvcNAQENBQAw
+WDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAklMMRAwDgYDVQQHEwdDaGljYWdvMRAw
+DgYDVQQKEwdUZXN0aW5nMRgwFgYDVQQDEw9UZXN0aW5nIFJvb3QgQ0EwHhcNMTQw
+ODI4MDIwNDA4WhcNMjQwODI1MDIwNDA4WjBmMRUwEwYDVQQDEwxpbnRlcm1lZGlh
+dGUxDDAKBgNVBAoTA29yZzERMA8GA1UECxMIb3JnLXVuaXQxCzAJBgNVBAYTAlVT
+MQswCQYDVQQIEwJDQTESMBAGA1UEBxMJU2FuIERpZWdvMIGfMA0GCSqGSIb3DQEB
+AQUAA4GNADCBiQKBgQDYcEQw5lfbEQRjr5Yy4yxAHGV0b9Al+Lmu7wLHMkZ/ZMmK
+FGIbljbviiD1Nz97Oh2cpB91YwOXOTN2vXHq26S+A5xe8z/QJbBsyghMur88CjdT
+21H2qwMa+r5dCQwEhuGIiZ3KbzB/n4DTMYI5zy4IYPv0pjxShZn4aZTCCK2IUwID
+AQABoxMwETAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBDQUAA4GBAPIWSkLX
+QRMApOjjyC+tMxumT5e2pMqChHmxobQK4NMdrf2VCx+cRT6EmY8sK3/Xl/X8UBQ+
+9n5zXb1ZwhW/sTWgUvmOceJ4/XVs9FkdWOOn1J0XBch9ZIiFe/s5ASIgG7fUdcUF
+9mAWS6FK2ca3xIh5kIupCXOFa0dPvlw/YUFT
+-----END CERTIFICATE-----
+""")
+
+intermediate_key_pem = b("""-----BEGIN RSA PRIVATE KEY-----
+MIICWwIBAAKBgQDYcEQw5lfbEQRjr5Yy4yxAHGV0b9Al+Lmu7wLHMkZ/ZMmKFGIb
+ljbviiD1Nz97Oh2cpB91YwOXOTN2vXHq26S+A5xe8z/QJbBsyghMur88CjdT21H2
+qwMa+r5dCQwEhuGIiZ3KbzB/n4DTMYI5zy4IYPv0pjxShZn4aZTCCK2IUwIDAQAB
+AoGAfSZVV80pSeOKHTYfbGdNY/jHdU9eFUa/33YWriXU+77EhpIItJjkRRgivIfo
+rhFJpBSGmDLblaqepm8emsXMeH4+2QzOYIf0QGGP6E6scjTt1PLqdqKfVJ1a2REN
+147cujNcmFJb/5VQHHMpaPTgttEjlzuww4+BCDPsVRABWrkCQQD3loH36nLoQTtf
++kQq0T6Bs9/UWkTAGo0ND81ALj0F8Ie1oeZg6RNT96RxZ3aVuFTESTv6/TbjWywO
+wdzlmV1vAkEA38rTJ6PTwaJlw5OttdDzAXGPB9tDmzh9oSi7cHwQQXizYd8MBYx4
+sjHUKD3dCQnb1dxJFhd3BT5HsnkRMbVZXQJAbXduH17ZTzcIOXc9jHDXYiFVZV5D
+52vV0WCbLzVCZc3jMrtSUKa8lPN5EWrdU3UchWybyG0MR5mX8S5lrF4SoQJAIyUD
+DBKaSqpqONCUUx1BTFS9FYrFjzbL4+c1qHCTTPTblt8kUCrDOZjBrKAqeiTmNSum
+/qUot9YUBF8m6BuGsQJATHHmdFy/fG1VLkyBp49CAa8tN3Z5r/CgTznI4DfMTf4C
+NbRHn2UmYlwQBa+L5lg9phewNe8aEwpPyPLoV85U8Q==
+-----END RSA PRIVATE KEY-----
+""")
+
 server_cert_pem = b("""-----BEGIN CERTIFICATE-----
 MIICKDCCAZGgAwIBAgIJAJn/HpR21r/8MA0GCSqGSIb3DQEBBQUAMFgxCzAJBgNV
 BAYTAlVTMQswCQYDVQQIEwJJTDEQMA4GA1UEBxMHQ2hpY2FnbzEQMA4GA1UEChMH
@@ -115,6 +151,40 @@ NaeNCFfH3aeTrX0LyQJAMBWjWmeKM2G2sCExheeQK0ROnaBC8itCECD4Jsve4nqf
 r50+LF74iLXFwqysVCebPKMOpDWp/qQ1BbJQIPs7/A==
 -----END RSA PRIVATE KEY-----
 """))
+
+intermediate_server_cert_pem = b("""-----BEGIN CERTIFICATE-----
+MIICWDCCAcGgAwIBAgIRAPQFY9jfskSihdiNSNdt6GswDQYJKoZIhvcNAQENBQAw
+ZjEVMBMGA1UEAxMMaW50ZXJtZWRpYXRlMQwwCgYDVQQKEwNvcmcxETAPBgNVBAsT
+CG9yZy11bml0MQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExEjAQBgNVBAcTCVNh
+biBEaWVnbzAeFw0xNDA4MjgwMjEwNDhaFw0yNDA4MjUwMjEwNDhaMG4xHTAbBgNV
+BAMTFGludGVybWVkaWF0ZS1zZXJ2aWNlMQwwCgYDVQQKEwNvcmcxETAPBgNVBAsT
+CG9yZy11bml0MQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExEjAQBgNVBAcTCVNh
+biBEaWVnbzCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAqpJZygd+w1faLOr1
+iOAmbBhx5SZWcTCZ/ZjHQTJM7GuPT624QkqsixFghRKdDROwpwnAP7gMRukLqiy4
++kRuGT5OfyGggL95i2xqA+zehjj08lSTlvGHpePJgCyTavIy5+Ljsj4DKnKyuhxm
+biXTRrH83NDgixVkObTEmh/OVK0CAwEAATANBgkqhkiG9w0BAQ0FAAOBgQBa0Npw
+UkzjaYEo1OUE1sTI6Mm4riTIHMak4/nswKh9hYup//WVOlr/RBSBtZ7Q/BwbjobN
+3bfAtV7eSAqBsfxYXyof7G1ALANQERkq3+oyLP1iVt08W1WOUlIMPhdCF/QuCwy6
+x9MJLhUCGLJPM+O2rAPWVD9wCmvq10ALsiH3yA==
+-----END CERTIFICATE-----
+""")
+
+intermediate_server_key_pem = b("""-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQCqklnKB37DV9os6vWI4CZsGHHlJlZxMJn9mMdBMkzsa49PrbhC
+SqyLEWCFEp0NE7CnCcA/uAxG6QuqLLj6RG4ZPk5/IaCAv3mLbGoD7N6GOPTyVJOW
+8Yel48mALJNq8jLn4uOyPgMqcrK6HGZuJdNGsfzc0OCLFWQ5tMSaH85UrQIDAQAB
+AoGAIQ594j5zna3/9WaPsTgnmhlesVctt4AAx/n827DA4ayyuHFlXUuVhtoWR5Pk
+5ezj9mtYW8DyeCegABnsu2vZni/CdvU6uiS1Hv6qM1GyYDm9KWgovIP9rQCDSGaz
+d57IWVGxx7ODFkm3gN5nxnSBOFVHytuW1J7FBRnEsehRroECQQDXHFOv82JuXDcz
+z3+4c74IEURdOHcbycxlppmK9kFqm5lsUdydnnGW+mvwDk0APOB7Wg7vyFyr393e
+dpmBDCzNAkEAyv6tVbTKUYhSjW+QhabJo896/EqQEYUmtMXxk4cQnKeR/Ao84Rkf
+EqD5IykMUfUI0jJU4DGX+gWZ10a7kNbHYQJAVFCuHNFxS4Cpwo0aqtnzKoZaHY/8
+X9ABZfafSHCtw3Op92M+7ikkrOELXdS9KdKyyqbKJAKNEHF3LbOfB44WIQJAA2N4
+9UNNVUsXRbElEnYUS529CdUczo4QdVgQjkvk5RiPAUwSdBd9Q0xYnFOlFwEmIowg
+ipWJWe0aAlP18ZcEQQJBAL+5lekZ/GUdQoZ4HAsN5a9syrzavJ9VvU1KOOPorPZK
+nMRZbbQgP+aSB7yl6K0gaLaZ8XaK0pjxNBh6ASqg9f4=
+-----END RSA PRIVATE KEY-----
+""")
 
 client_cert_pem = b("""-----BEGIN CERTIFICATE-----
 MIICJjCCAY+gAwIBAgIJAKxpFI5lODkjMA0GCSqGSIb3DQEBBQUAMFgxCzAJBgNV
@@ -3104,6 +3174,88 @@ class CRLTests(TestCase):
         """
         self.assertRaises(Error, load_crl, FILETYPE_PEM, b"hello, world")
 
+
+class VerifyCertTests(TestCase):
+    """
+    Tests for :py:obj:`OpenSSL.crypto.verify_cert`.
+    """
+    root_cert = load_certificate(FILETYPE_PEM, root_cert_pem)
+    intermediate_cert = load_certificate(FILETYPE_PEM, intermediate_cert_pem)
+    intermediate_server_cert = load_certificate(FILETYPE_PEM, intermediate_server_cert_pem)
+
+    def test_valid(self):
+        """
+        :py:obj:`verify_cert` does nothing when called with a certificate and
+        valid chain.
+        """
+        store = X509Store()
+        store.add_cert(self.root_cert)
+        store.add_cert(self.intermediate_cert)
+        store_ctx = X509StoreContext(store, self.intermediate_server_cert)
+        self.assertEqual(verify_cert(store_ctx), None)
+
+    def test_reuse(self):
+        """
+        :py:obj:`verify_cert` can be called multiple times.
+        """
+        store = X509Store()
+        store.add_cert(self.root_cert)
+        store.add_cert(self.intermediate_cert)
+        store_ctx = X509StoreContext(store, self.intermediate_server_cert)
+        self.assertEqual(verify_cert(store_ctx), None)
+        self.assertEqual(verify_cert(store_ctx), None)
+
+    def test_trusted_self_signed(self):
+        """
+        :py:obj:`verify_cert` does nothign when called with a self-signed
+        certificate and itself in the chain.
+        """
+        store = X509Store()
+        store.add_cert(self.root_cert)
+        store_ctx = X509StoreContext(store, self.root_cert)
+        self.assertEqual(verify_cert(store_ctx), None)
+
+    def test_untrusted_self_signed(self):
+        """
+        :py:obj:`verify_cert` raises error when a self-signed certificate is
+        verified without itself in the chain.
+        """
+        store = X509Store()
+        store_ctx = X509StoreContext(store, self.root_cert)
+        try:
+          verify_cert(store_ctx)
+          self.assertTrue(False)
+        except Error as e:
+          self.assertTrue('self signed certificate' in str(e))
+          self.assertEqual(e.certificate.get_subject().CN, 'Testing Root CA')
+
+    def test_invalid_chain_no_root(self):
+        """
+        :py:obj:`verify_cert` raises error when a root certificate is missing
+        from the chain.
+        """
+        store = X509Store()
+        store.add_cert(self.intermediate_cert)
+        store_ctx = X509StoreContext(store, self.intermediate_server_cert)
+        try:
+          verify_cert(store_ctx)
+        except Error as e:
+          self.assertTrue('unable to get issuer certificate' in str(e))
+          self.assertEqual(e.certificate.get_subject().CN, 'intermediate')
+
+    def test_invalid_chain_no_intermediate(self):
+        """
+        :py:obj:`verify_cert` raises error when an intermediate certificate is
+        missing from the chain.
+        """
+        store = X509Store()
+        store.add_cert(self.root_cert)
+        store_ctx = X509StoreContext(store, self.intermediate_server_cert)
+        try:
+          verify_cert(store_ctx)
+        except Error as e:
+          self.assertTrue('unable to get local issuer certificate' in str(e))
+          self.assertEqual(e.certificate.get_subject().CN, 'intermediate-service')
 
 
 class SignVerifyTests(TestCase):

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -3186,8 +3186,8 @@ class VerifyCertTests(TestCase):
 
     def test_valid(self):
         """
-        :py:obj:`verify_cert` does nothing when called with a certificate and
-        valid chain.
+        :py:obj:`verify_cert` returns ``None`` when called with a certificate
+        and valid chain.
         """
         store = X509Store()
         store.add_cert(self.root_cert)
@@ -3198,7 +3198,8 @@ class VerifyCertTests(TestCase):
 
     def test_reuse(self):
         """
-        :py:obj:`verify_cert` can be called multiple times.
+        :py:obj:`verify_cert` can be called multiple times with the same
+        ``X509StoreContext`` instance to produce the same result.
         """
         store = X509Store()
         store.add_cert(self.root_cert)
@@ -3210,7 +3211,7 @@ class VerifyCertTests(TestCase):
 
     def test_trusted_self_signed(self):
         """
-        :py:obj:`verify_cert` does nothign when called with a self-signed
+        :py:obj:`verify_cert` returns ``None`` when called with a self-signed
         certificate and itself in the chain.
         """
         store = X509Store()
@@ -3226,12 +3227,9 @@ class VerifyCertTests(TestCase):
         """
         store = X509Store()
         store_ctx = X509StoreContext(store, self.root_cert)
-        try:
-            verify_cert(store_ctx)
-            self.assertTrue(False)
-        except Error as e:
-            self.assertTrue('self signed certificate' in str(e))
-            self.assertEqual(e.certificate.get_subject().CN, 'Testing Root CA')
+        e = self.assertRaises(Error, verify_cert, store_ctx)
+        self.assertIn('self signed certificate', str(e))
+        self.assertEqual(e.certificate.get_subject().CN, 'Testing Root CA')
 
 
     def test_invalid_chain_no_root(self):
@@ -3242,11 +3240,9 @@ class VerifyCertTests(TestCase):
         store = X509Store()
         store.add_cert(self.intermediate_cert)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
-        try:
-            verify_cert(store_ctx)
-        except Error as e:
-            self.assertTrue('unable to get issuer certificate' in str(e))
-            self.assertEqual(e.certificate.get_subject().CN, 'intermediate')
+        e = self.assertRaises(Error, verify_cert, store_ctx)
+        self.assertIn('unable to get issuer certificate', str(e))
+        self.assertEqual(e.certificate.get_subject().CN, 'intermediate')
 
 
     def test_invalid_chain_no_intermediate(self):
@@ -3257,11 +3253,9 @@ class VerifyCertTests(TestCase):
         store = X509Store()
         store.add_cert(self.root_cert)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
-        try:
-            verify_cert(store_ctx)
-        except Error as e:
-            self.assertTrue('unable to get local issuer certificate' in str(e))
-            self.assertEqual(e.certificate.get_subject().CN, 'intermediate-service')
+        e = self.assertRaises(Error, verify_cert, store_ctx)
+        self.assertIn('unable to get local issuer certificate', str(e))
+        self.assertEqual(e.certificate.get_subject().CN, 'intermediate-service')
 
 
 

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -3227,7 +3227,7 @@ class VerifyCertTests(TestCase):
         store = X509Store()
         store_ctx = X509StoreContext(store, self.root_cert)
         e = self.assertRaises(Error, verify_cert, store_ctx)
-        self.assertIn('self signed certificate', str(e))
+        self.assertEqual(e.args[0][2], 'self signed certificate')
         self.assertEqual(e.certificate.get_subject().CN, 'Testing Root CA')
 
 
@@ -3240,7 +3240,7 @@ class VerifyCertTests(TestCase):
         store.add_cert(self.intermediate_cert)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         e = self.assertRaises(Error, verify_cert, store_ctx)
-        self.assertIn('unable to get issuer certificate', str(e))
+        self.assertEqual(e.args[0][2], 'unable to get issuer certificate')
         self.assertEqual(e.certificate.get_subject().CN, 'intermediate')
 
 
@@ -3253,7 +3253,7 @@ class VerifyCertTests(TestCase):
         store.add_cert(self.root_cert)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         e = self.assertRaises(Error, verify_cert, store_ctx)
-        self.assertIn('unable to get local issuer certificate', str(e))
+        self.assertEqual(e.args[0][2], 'unable to get local issuer certificate')
         self.assertEqual(e.certificate.get_subject().CN, 'intermediate-service')
 
 

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -3175,6 +3175,7 @@ class CRLTests(TestCase):
         self.assertRaises(Error, load_crl, FILETYPE_PEM, b"hello, world")
 
 
+
 class VerifyCertTests(TestCase):
     """
     Tests for :py:obj:`OpenSSL.crypto.verify_cert`.
@@ -3194,6 +3195,7 @@ class VerifyCertTests(TestCase):
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         self.assertEqual(verify_cert(store_ctx), None)
 
+
     def test_reuse(self):
         """
         :py:obj:`verify_cert` can be called multiple times.
@@ -3205,6 +3207,7 @@ class VerifyCertTests(TestCase):
         self.assertEqual(verify_cert(store_ctx), None)
         self.assertEqual(verify_cert(store_ctx), None)
 
+
     def test_trusted_self_signed(self):
         """
         :py:obj:`verify_cert` does nothign when called with a self-signed
@@ -3215,6 +3218,7 @@ class VerifyCertTests(TestCase):
         store_ctx = X509StoreContext(store, self.root_cert)
         self.assertEqual(verify_cert(store_ctx), None)
 
+
     def test_untrusted_self_signed(self):
         """
         :py:obj:`verify_cert` raises error when a self-signed certificate is
@@ -3223,11 +3227,12 @@ class VerifyCertTests(TestCase):
         store = X509Store()
         store_ctx = X509StoreContext(store, self.root_cert)
         try:
-          verify_cert(store_ctx)
-          self.assertTrue(False)
+            verify_cert(store_ctx)
+            self.assertTrue(False)
         except Error as e:
-          self.assertTrue('self signed certificate' in str(e))
-          self.assertEqual(e.certificate.get_subject().CN, 'Testing Root CA')
+            self.assertTrue('self signed certificate' in str(e))
+            self.assertEqual(e.certificate.get_subject().CN, 'Testing Root CA')
+
 
     def test_invalid_chain_no_root(self):
         """
@@ -3238,10 +3243,11 @@ class VerifyCertTests(TestCase):
         store.add_cert(self.intermediate_cert)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         try:
-          verify_cert(store_ctx)
+            verify_cert(store_ctx)
         except Error as e:
-          self.assertTrue('unable to get issuer certificate' in str(e))
-          self.assertEqual(e.certificate.get_subject().CN, 'intermediate')
+            self.assertTrue('unable to get issuer certificate' in str(e))
+            self.assertEqual(e.certificate.get_subject().CN, 'intermediate')
+
 
     def test_invalid_chain_no_intermediate(self):
         """
@@ -3252,10 +3258,11 @@ class VerifyCertTests(TestCase):
         store.add_cert(self.root_cert)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         try:
-          verify_cert(store_ctx)
+            verify_cert(store_ctx)
         except Error as e:
-          self.assertTrue('unable to get local issuer certificate' in str(e))
-          self.assertEqual(e.certificate.get_subject().CN, 'intermediate-service')
+            self.assertTrue('unable to get local issuer certificate' in str(e))
+            self.assertEqual(e.certificate.get_subject().CN, 'intermediate-service')
+
 
 
 class SignVerifyTests(TestCase):

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -10,7 +10,6 @@ from unittest import main
 import base64
 import os
 import re
-import sys
 from subprocess import PIPE, Popen
 from datetime import datetime, timedelta
 

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -3257,6 +3257,24 @@ class X509StoreContextTests(TestCase):
         self.assertEqual(e.certificate.get_subject().CN, 'intermediate-service')
 
 
+    def test_modification_pre_verify(self):
+        """
+        :py:obj:`verify_certificate` can use a store context modified after
+        instantiation.
+        """
+        store_bad = X509Store()
+        store_bad.add_cert(self.intermediate_cert)
+        store_good = X509Store()
+        store_good.add_cert(self.root_cert)
+        store_good.add_cert(self.intermediate_cert)
+        store_ctx = X509StoreContext(store_bad, self.intermediate_server_cert)
+        e = self.assertRaises(X509StoreContextError, store_ctx.verify_certificate)
+        self.assertEqual(e.args[0][2], 'unable to get issuer certificate')
+        self.assertEqual(e.certificate.get_subject().CN, 'intermediate')
+        store_ctx.set_store(store_good)
+        self.assertEqual(store_ctx.verify_certificate(), None)
+
+
 
 class SignVerifyTests(TestCase):
     """

--- a/doc/api/crypto.rst
+++ b/doc/api/crypto.rst
@@ -240,18 +240,6 @@
     .. versionadded:: 0.11
 
 
-.. py:function:: verify_cert(store_ctx)
-
-    Verify a certificate in a context.
-
-    A :py:class:`X509StoreContext` is used to verify a certificate in some
-    context in conjunction with :py:func:`verify_cert`. The information
-    encapsulated in this object includes, but is not limited to, a set of
-    trusted certificates, verification parameters and revoked certificates.
-
-    .. versionadded:: 0.15
-
-
 .. _openssl-x509:
 
 X509 objects
@@ -546,6 +534,22 @@ The X509Store object has currently just one method:
 .. py:method:: X509Store.add_cert(cert)
 
     Add the certificate *cert* to the certificate store.
+
+
+X509StoreContext objects
+------------------------
+
+The X509StoreContext object is used for verifying a certificate against a set
+of trusted certificates.
+
+
+.. py:method:: X509StoreContext.verify_certificate()
+
+    Verify a certificate in the context of this initialized `X509StoreContext`.
+    On error, raises `X509StoreContextError`, otherwise does nothing.
+
+    .. versionadded:: 0.15
+
 
 
 .. _openssl-pkey:

--- a/doc/api/crypto.rst
+++ b/doc/api/crypto.rst
@@ -42,7 +42,17 @@
 
 .. py:data:: X509StoreType
 
-    A Python type object representing the X509Store object type.
+    See :py:class:`X509Store`
+
+
+.. py:data X509Store
+
+    A class representing the X.509 store.
+
+
+.. py:data:: X509StoreContext
+
+    A class representing the X.509 store context.
 
 
 .. py:data:: PKeyType
@@ -228,6 +238,18 @@
     digest type of the signature, for example :py:const:`sha1`.
 
     .. versionadded:: 0.11
+
+
+.. py:function:: verify_cert(store_ctx)
+
+    Verify a certificate in a context.
+
+    A :py:class:`X509StoreContext` is used to verify a certificate in some
+    context in conjunction with :py:func:`verify_cert`. The information
+    encapsulated in this object includes, but is not limited to, a set of
+    trusted certificates, verification parameters and revoked certificates.
+
+    .. versionadded:: 0.15
 
 
 .. _openssl-x509:

--- a/doc/api/crypto.rst
+++ b/doc/api/crypto.rst
@@ -536,6 +536,18 @@ The X509Store object has currently just one method:
     Add the certificate *cert* to the certificate store.
 
 
+X509StoreContextError objects
+-----------------------------
+
+The X509StoreContextError is an exception raised from
+`X509StoreContext.verify_certificate` in circumstances where a certificate
+cannot be verified in a provided context.
+
+The exception objects have a :py:class:`basestring` ``message`` attribute which
+contains error messages and :py:class:`X509` ``certificate`` attribute by which
+they indicate where the verification error was detected.
+
+
 X509StoreContext objects
 ------------------------
 


### PR DESCRIPTION
This change adds support for verifying a certificate or a certificate
chain. This implementation uses OpenSSL's underlying X509_STORE_CTX_*
class of functions to accomplish this.

This change also adds an intermediate signing certificate/key and a
service certificate/key signed with the intermediate signing
certificate, to make testing the OpenSSL.crypto.verify_chain method
easier to test. I figured I would add it to the top level module so
other people can use an intermediate signing certificate in their own
tests.

Issue: https://github.com/pyca/pyopenssl/issues/154