### PR TITLE
Dedup version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ Installation script for the OpenSSL module
 
 from setuptools import setup
 
-# XXX Deduplicate this
-__version__ = '0.14'
+from OpenSSL.version import __version__
+
 
 setup(name='pyOpenSSL', version=__version__,
       packages = ['OpenSSL'],


### PR DESCRIPTION
There was a XXX to dedup the version between OpenSSL.version and
setup.py, so I did this using what I think is the best approach.
