### PR TITLE
sendall buf convertion atempt from unicode to str

### DIFF
--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -997,7 +997,7 @@ class Connection(object):
 	    try:
 	        buf = str(buf)
 	    except:
-                raise TypeError("couldn't convert unicode to byte string")
+                raise TypeError("couldn't convert unicode buf to byte string")
         if isinstance(buf, _buffer):
             buf = str(buf)
         if not isinstance(buf, bytes):


### PR DESCRIPTION
Sendall method raises **Typerror** without considering a unicode **buf** parameter. Here i try to convert from unicode to str before testing isinstance(buf, bytes).
