### PR TITLE
Fix issue with string type check in python3

### DIFF
--- a/OpenSSL/rand.py
+++ b/OpenSSL/rand.py
@@ -136,7 +136,7 @@ def load_file(filename, maxbytes=_unspecified):
                      to read the entire file
     :return: The number of bytes read
     """
-    if not isinstance(filename, str) and not isinstance(filename, _builtin_bytes):
+    if not isinstance(filename, (str, _builtin_bytes)):
         raise TypeError("filename must be a string")
 
     if maxbytes is _unspecified:
@@ -155,7 +155,7 @@ def write_file(filename):
     :param filename: The file to write data to
     :return: The number of bytes written
     """
-    if not isinstance(filename, str) and not isinstance(filename, _builtin_bytes):
+    if not isinstance(filename, (str, _builtin_bytes)):
         raise TypeError("filename must be a string")
 
     return _lib.RAND_write_file(filename)

--- a/OpenSSL/rand.py
+++ b/OpenSSL/rand.py
@@ -136,7 +136,7 @@ def load_file(filename, maxbytes=_unspecified):
                      to read the entire file
     :return: The number of bytes read
     """
-    if not isinstance(filename, _builtin_bytes):
+    if not isinstance(filename, str) and not isinstance(filename, _builtin_bytes):
         raise TypeError("filename must be a string")
 
     if maxbytes is _unspecified:
@@ -155,7 +155,7 @@ def write_file(filename):
     :param filename: The file to write data to
     :return: The number of bytes written
     """
-    if not isinstance(filename, _builtin_bytes):
+    if not isinstance(filename, str) and not isinstance(filename, _builtin_bytes):
         raise TypeError("filename must be a string")
 
     return _lib.RAND_write_file(filename)

--- a/OpenSSL/test/test_rand.py
+++ b/OpenSSL/test/test_rand.py
@@ -176,7 +176,6 @@ class RandTests(TestCase):
         self.assertRaises(TypeError, rand.write_file, None)
         self.assertRaises(TypeError, rand.write_file, "foo", None)
 
-
     def test_files(self):
         """
         Test reading and writing of files via rand functions.


### PR DESCRIPTION
The `rand.write_file` and `rand.read_file` methods take a string, however, they excplicitly check for type `bytes`. In Python 3, this check will fail when given a normal UTF-8 string (`isinstance("", bytes)` is false).

One would expect to be able to `rand.write_file("somefilename")`, this fixes that and works in both python 2 and 3.

I didn't see anywhere else this was happening, but it's quite possible that this should be fixed elsewhere as well (in which case using `6` or having a generalized `is_string` utility method or something would probably be a better solution). As it was only two places, I just fixed it in both (this simpler fix reads nicely anyways).