### PR TITLE
Fix error handling in Connection.shutdown

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-01-08  Paul Aurich <paul@darkrain42.org>
+
+	* OpenSSL/SSL.py: ``Connection.shutdown`` now propagates errors from the
+	  underlying socket.
+
 2014-08-21  Alex Gaynor  <alex.gaynor@gmail.com>
 
 	* OpenSSL/crypto.py: Fixed a regression where calling ``load_pkcs7_data``

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1183,8 +1183,7 @@ class Connection(object):
         """
         result = _lib.SSL_shutdown(self._ssl)
         if result < 0:
-            # TODO: This is untested.
-            _raise_current_error()
+            self._raise_ssl_error(self._ssl, result)
         elif result > 0:
             return True
         else:

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -1709,6 +1709,20 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         self.assertEquals(server.get_shutdown(), SENT_SHUTDOWN|RECEIVED_SHUTDOWN)
 
 
+    def test_shutdown_closed(self):
+        """
+        If the underlying socket is closed, :py:obj:`Connection.shutdown` propagates the
+        write error from the low level write call.
+        """
+        server, client = self._loopback()
+        server.sock_shutdown(2)
+        exc = self.assertRaises(SysCallError, server.shutdown)
+        if platform == "win32":
+            self.assertEqual(exc.args[0], ESHUTDOWN)
+        else:
+            self.assertEqual(exc.args[0], EPIPE)
+
+
     def test_set_shutdown(self):
         """
         :py:obj:`Connection.set_shutdown` sets the state of the SSL connection shutdown


### PR DESCRIPTION
Fix the error handling in ``Connection.shutdown`` so that underlying socket conditions (``SSL_ERR_WANT_WRITE``, ``SSL_ERR_WANT_WRITE``, or other system-level errors such as ``ECONNRESET``) are propagated properly.

This fixes #91.