### PR TITLE
Add support for querying the negotiated TLS version.

### DIFF
--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1551,6 +1551,16 @@ class Connection(object):
             return version.decode("utf-8")
 
 
+    def get_protocol_version(self):
+        """
+        Obtain the protocol version of the current connection.
+
+        :returns: The TLS version of the current connection, for example
+            the value for TLS 1.2 would be 0x303.
+        :rtype: :py:class:`int`
+        """
+        version = _lib.SSL_version(self._ssl)
+        return version
 
 ConnectionType = Connection
 

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -2129,6 +2129,20 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         self.assertEqual(server_cipher_bits, client_cipher_bits)
 
 
+    def test_get_protocol_version(self):
+        """
+        :py:obj:`Connection.get_protocol_version` returns a :py:class:`int`
+        giving the protocol version of the current connection.
+        """
+        server, client = self._loopback()
+        server_protocol_version, client_protocol_version = \
+            server.get_protocol_version(), client.get_protocol_version()
+
+        self.assertIsInstance(server_protocol_version, int)
+        self.assertIsInstance(client_protocol_version, int)
+
+        self.assertEqual(server_protocol_version, client_protocol_version)
+
 
 class ConnectionGetCipherListTests(TestCase):
     """

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='pyOpenSSL', version=__version__,
       maintainer_email = 'exarkun@twistedmatrix.com',
       url = 'https://github.com/pyca/pyopenssl',
       license = 'APL2',
-      install_requires=["cryptography>=0.5.4", "six>=1.5.2"],
+      install_requires=["cryptography>=0.7.2", "six>=1.5.2"],
       long_description = """\
 High-level wrapper around a subset of the OpenSSL library, includes
  * SSL.Connection objects, wrapping the methods of Python's portable


### PR DESCRIPTION
Note this requires https://github.com/pyca/cryptography/pull/1619 to be merged first.
