### PR TITLE
Remove EGD

### DIFF
--- a/OpenSSL/rand.py
+++ b/OpenSSL/rand.py
@@ -93,29 +93,6 @@ def status():
 
 
 
-def egd(path, bytes=_unspecified):
-    """
-    Query an entropy gathering daemon (EGD) for random data and add it to the
-    PRNG. I haven't found any problems when the socket is missing, the function
-    just returns 0.
-
-    :param path: The path to the EGD socket
-    :param bytes: (optional) The number of bytes to read, default is 255
-    :returns: The number of bytes read (NB: a value of 0 isn't necessarily an
-              error, check rand.status())
-    """
-    if not isinstance(path, _builtin_bytes):
-        raise TypeError("path must be a byte string")
-
-    if bytes is _unspecified:
-        bytes = 255
-    elif not isinstance(bytes, int):
-        raise TypeError("bytes must be an integer")
-
-    return _lib.RAND_egd_bytes(path, bytes)
-
-
-
 def cleanup():
     """
     Erase the memory used by the PRNG.

--- a/OpenSSL/test/test_rand.py
+++ b/OpenSSL/test/test_rand.py
@@ -103,43 +103,6 @@ class RandTests(TestCase):
         self.assertTrue(rand.status() in (1, 2))
 
 
-    def test_egd_wrong_args(self):
-        """
-        :py:obj:`OpenSSL.rand.egd` raises :py:obj:`TypeError` when called with the wrong
-        number of arguments or with arguments not of type :py:obj:`str` and :py:obj:`int`.
-        """
-        self.assertRaises(TypeError, rand.egd)
-        self.assertRaises(TypeError, rand.egd, None)
-        self.assertRaises(TypeError, rand.egd, "foo", None)
-        self.assertRaises(TypeError, rand.egd, None, 3)
-        self.assertRaises(TypeError, rand.egd, "foo", 3, None)
-
-
-    def test_egd_missing(self):
-        """
-        :py:obj:`OpenSSL.rand.egd` returns :py:obj:`0` or :py:obj:`-1` if the
-        EGD socket passed to it does not exist.
-        """
-        result = rand.egd(self.mktemp())
-        expected = (-1, 0)
-        self.assertTrue(
-            result in expected,
-            "%r not in %r" % (result, expected))
-
-
-    def test_egd_missing_and_bytes(self):
-        """
-        :py:obj:`OpenSSL.rand.egd` returns :py:obj:`0` or :py:obj:`-1` if the
-        EGD socket passed to it does not exist even if a size argument is
-        explicitly passed.
-        """
-        result = rand.egd(self.mktemp(), 1024)
-        expected = (-1, 0)
-        self.assertTrue(
-            result in expected,
-            "%r not in %r" % (result, expected))
-
-
     def test_cleanup_wrong_args(self):
         """
         :py:obj:`OpenSSL.rand.cleanup` raises :py:obj:`TypeError` when called with any

--- a/doc/api/rand.rst
+++ b/doc/api/rand.rst
@@ -31,13 +31,6 @@ declares the following:
     This is a wrapper for the C function :py:func:`RAND_cleanup`.
 
 
-.. py:function:: egd(path[, bytes])
-
-    Query the `Entropy Gathering Daemon <http://www.lothar.com/tech/crypto/>`_ on
-    socket *path* for *bytes* bytes of random data and uses :py:func:`add` to
-    seed the PRNG. The default value of *bytes* is 255.
-
-
 .. py:function:: load_file(path[, bytes])
 
     Read *bytes* bytes (or all of it, if *bytes* is negative) of data from the


### PR DESCRIPTION
EGD was only necessary for some commercial UNIX systems, versions that needed it all reached end of life.
EGD needed until        OS release date
IRIX 6.5.19   feb 2003
Solaris 2.6                     jul 1997
AIX     5.2                     oct 2002
Tru64   5.1B                    sep 2002
HP-UX   11i v2                  sep 2003
https://en.wikipedia.org/wiki//dev/random#EGD_as_an_alternative