### PR TITLE
#15 Fix regressions in support for bytes / unicode in certain APIs

### DIFF
--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1,4 +1,3 @@
-import six
 from warnings import warn
 from sys import platform
 from functools import wraps, partial
@@ -8,6 +7,7 @@ from errno import errorcode
 
 from six import text_type as _text_type
 from six import integer_types as integer_types
+from six import PY2 as _PY2
 
 from OpenSSL._util import (
     ffi as _ffi,
@@ -315,7 +315,7 @@ class Context(object):
 
         # Backward compatibility
         if isinstance(cafile, _text_type):
-            if six.PY2:
+            if _PY2:
                 warn("unicode in cafile is no longer accepted, use bytes", DeprecationWarning)
             else:
                 warn("str in cafile is no longer accepted, use bytes", DeprecationWarning)
@@ -984,7 +984,7 @@ class Connection(object):
 
         # Backward compatibility
         if isinstance(buf, _text_type):
-            if six.PY2:
+            if _PY2:
                 warn("unicode in buf is no longer accepted, use bytes", DeprecationWarning)
             else:
                 warn("str in buf is no longer accepted, use bytes", DeprecationWarning)
@@ -1017,7 +1017,7 @@ class Connection(object):
 
         # Backward compatibility
         if isinstance(buf, _text_type):
-            if six.PY2:
+            if _PY2:
                 warn("unicode in buf is no longer accepted, use bytes", DeprecationWarning)
             else:
                 warn("str in buf is no longer accepted, use bytes", DeprecationWarning)
@@ -1111,7 +1111,7 @@ class Connection(object):
 
         # Backward compatibility
         if isinstance(buf, _text_type):
-            if six.PY2:
+            if _PY2:
                 warn("unicode in buf is no longer accepted, use bytes", DeprecationWarning)
             else:
                 warn("str in buf is no longer accepted, use bytes", DeprecationWarning)

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -310,6 +310,12 @@ class Context(object):
         :param capath: In which directory we can find the certificates
         :return: None
         """
+
+        # Backward compatibility
+        if isinstance(cafile, _text_type):
+            DeprecationWarning("str object in cafile is no longer accepted, use bytes")
+            cafile = cafile.encode('utf-8')
+
         if cafile is None:
             cafile = _ffi.NULL
         elif not isinstance(cafile, bytes):
@@ -970,6 +976,12 @@ class Connection(object):
                       API, the value is ignored
         :return: The number of bytes written
         """
+
+        # Backward compatibility
+        if isinstance(buf, _text_type):
+            DeprecationWarning("str object in buf is no longer accepted, use bytes")
+            buf = buf.encode('utf-8')
+
         if isinstance(buf, _memoryview):
             buf = buf.tobytes()
         if isinstance(buf, _buffer):
@@ -994,6 +1006,12 @@ class Connection(object):
                       API, the value is ignored
         :return: The number of bytes written
         """
+
+        # Backward compatibility
+        if isinstance(buf, _text_type):
+            DeprecationWarning("str object in buf is no longer accepted, use bytes")
+            buf = buf.encode('utf-8')
+
         if isinstance(buf, _memoryview):
             buf = buf.tobytes()
         if isinstance(buf, _buffer):
@@ -1079,6 +1097,12 @@ class Connection(object):
         :param buf: The string to put into the memory BIO.
         :return: The number of bytes written
         """
+
+        # Backward compatibility
+        if isinstance(buf, _text_type):
+            DeprecationWarning("str object in buf is no longer accepted, use bytes")
+            buf = buf.encode("ascii")
+
         if self._into_ssl is None:
             raise TypeError("Connection sock was not None")
 

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1,5 +1,5 @@
-import warnings
-from sys import platform
+from warnings import warn
+from sys import platform, version_info
 from functools import wraps, partial
 from itertools import count
 from weakref import WeakValueDictionary
@@ -314,7 +314,12 @@ class Context(object):
 
         # Backward compatibility
         if isinstance(cafile, _text_type):
-            warnings.warn("str object in cafile is no longer accepted, use bytes", DeprecationWarning)
+            if version_info.major == 2:
+                warn("unicode in cafile is no longer accepted, use bytes", DeprecationWarning)
+            elif version_info.major == 3:
+                warn("str in cafile is no longer accepted, use bytes", DeprecationWarning)
+            else:
+                warn("text in cafile is no longer accepted, use bytes", DeprecationWarning)
             cafile = cafile.encode('utf-8')
 
         if cafile is None:
@@ -980,7 +985,12 @@ class Connection(object):
 
         # Backward compatibility
         if isinstance(buf, _text_type):
-            warnings.warn("str object in buf is no longer accepted, use bytes", DeprecationWarning)
+            if version_info.major == 2:
+                warn("unicode in buf is no longer accepted, use bytes", DeprecationWarning)
+            elif version_info.major == 3:
+                warn("str in buf is no longer accepted, use bytes", DeprecationWarning)
+            else:
+                warn("text in buf is no longer accepted, use bytes", DeprecationWarning)
             buf = buf.encode('utf-8')
 
         if isinstance(buf, _memoryview):
@@ -1010,7 +1020,12 @@ class Connection(object):
 
         # Backward compatibility
         if isinstance(buf, _text_type):
-            warnings.warn("str object in buf is no longer accepted, use bytes", DeprecationWarning)
+            if version_info.major == 2:
+                warn("unicode in buf is no longer accepted, use bytes", DeprecationWarning)
+            elif version_info.major == 3:
+                warn("str in buf is no longer accepted, use bytes", DeprecationWarning)
+            else:
+                warn("text in buf is no longer accepted, use bytes", DeprecationWarning)
             buf = buf.encode('utf-8')
 
         if isinstance(buf, _memoryview):
@@ -1101,7 +1116,12 @@ class Connection(object):
 
         # Backward compatibility
         if isinstance(buf, _text_type):
-            warnings.warn("str object in buf is no longer accepted, use bytes", DeprecationWarning)
+            if version_info.major == 2:
+                warn("unicode in buf is no longer accepted, use bytes", DeprecationWarning)
+            elif version_info.major == 3:
+                warn("str in vuf is no longer accepted, use bytes", DeprecationWarning)
+            else:
+                warn("text in buf is no longer accepted, use bytes", DeprecationWarning)
             buf = buf.encode("ascii")
 
         if self._into_ssl is None:

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1,3 +1,4 @@
+import warnings
 from sys import platform
 from functools import wraps, partial
 from itertools import count
@@ -313,7 +314,7 @@ class Context(object):
 
         # Backward compatibility
         if isinstance(cafile, _text_type):
-            DeprecationWarning("str object in cafile is no longer accepted, use bytes")
+            warnings.warn("str object in cafile is no longer accepted, use bytes", DeprecationWarning)
             cafile = cafile.encode('utf-8')
 
         if cafile is None:
@@ -979,7 +980,7 @@ class Connection(object):
 
         # Backward compatibility
         if isinstance(buf, _text_type):
-            DeprecationWarning("str object in buf is no longer accepted, use bytes")
+            warnings.warn("str object in buf is no longer accepted, use bytes", DeprecationWarning)
             buf = buf.encode('utf-8')
 
         if isinstance(buf, _memoryview):
@@ -1009,7 +1010,7 @@ class Connection(object):
 
         # Backward compatibility
         if isinstance(buf, _text_type):
-            DeprecationWarning("str object in buf is no longer accepted, use bytes")
+            warnings.warn("str object in buf is no longer accepted, use bytes", DeprecationWarning)
             buf = buf.encode('utf-8')
 
         if isinstance(buf, _memoryview):
@@ -1100,7 +1101,7 @@ class Connection(object):
 
         # Backward compatibility
         if isinstance(buf, _text_type):
-            DeprecationWarning("str object in buf is no longer accepted, use bytes")
+            warnings.warn("str object in buf is no longer accepted, use bytes", DeprecationWarning)
             buf = buf.encode("ascii")
 
         if self._into_ssl is None:

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1,5 +1,6 @@
+import six
 from warnings import warn
-from sys import platform, version_info
+from sys import platform
 from functools import wraps, partial
 from itertools import count
 from weakref import WeakValueDictionary
@@ -314,12 +315,10 @@ class Context(object):
 
         # Backward compatibility
         if isinstance(cafile, _text_type):
-            if version_info.major == 2:
+            if six.PY2:
                 warn("unicode in cafile is no longer accepted, use bytes", DeprecationWarning)
-            elif version_info.major == 3:
-                warn("str in cafile is no longer accepted, use bytes", DeprecationWarning)
             else:
-                warn("text in cafile is no longer accepted, use bytes", DeprecationWarning)
+                warn("str in cafile is no longer accepted, use bytes", DeprecationWarning)
             cafile = cafile.encode('utf-8')
 
         if cafile is None:
@@ -985,12 +984,10 @@ class Connection(object):
 
         # Backward compatibility
         if isinstance(buf, _text_type):
-            if version_info.major == 2:
+            if six.PY2:
                 warn("unicode in buf is no longer accepted, use bytes", DeprecationWarning)
-            elif version_info.major == 3:
-                warn("str in buf is no longer accepted, use bytes", DeprecationWarning)
             else:
-                warn("text in buf is no longer accepted, use bytes", DeprecationWarning)
+                warn("str in buf is no longer accepted, use bytes", DeprecationWarning)
             buf = buf.encode('utf-8')
 
         if isinstance(buf, _memoryview):
@@ -1020,12 +1017,10 @@ class Connection(object):
 
         # Backward compatibility
         if isinstance(buf, _text_type):
-            if version_info.major == 2:
+            if six.PY2:
                 warn("unicode in buf is no longer accepted, use bytes", DeprecationWarning)
-            elif version_info.major == 3:
-                warn("str in buf is no longer accepted, use bytes", DeprecationWarning)
             else:
-                warn("text in buf is no longer accepted, use bytes", DeprecationWarning)
+                warn("str in buf is no longer accepted, use bytes", DeprecationWarning)
             buf = buf.encode('utf-8')
 
         if isinstance(buf, _memoryview):
@@ -1116,12 +1111,10 @@ class Connection(object):
 
         # Backward compatibility
         if isinstance(buf, _text_type):
-            if version_info.major == 2:
+            if six.PY2:
                 warn("unicode in buf is no longer accepted, use bytes", DeprecationWarning)
-            elif version_info.major == 3:
-                warn("str in vuf is no longer accepted, use bytes", DeprecationWarning)
             else:
-                warn("text in buf is no longer accepted, use bytes", DeprecationWarning)
+                warn("str in buf is no longer accepted, use bytes", DeprecationWarning)
             buf = buf.encode("ascii")
 
         if self._into_ssl is None:

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -1,4 +1,5 @@
-import warnings
+from warnings import warn
+from sys import version_info
 from time import time
 from base64 import b16encode
 from functools import partial
@@ -1956,7 +1957,12 @@ class PKCS12(object):
 
         # Backward compatibility
         if isinstance(passphrase, _text_type):
-            warnings.warn("str object in passphrase is no longer accepted, use bytes", DeprecationWarning)
+            if version_info.major == 2:
+                warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
+            elif version_info.major == 3:
+                warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
+            else:
+                warn("text in passphrase is no longer accepted, use bytes", DeprecationWarning)
             passphrase = passphrase.encode('utf-8')
 
         if self._cacerts is None:
@@ -2259,7 +2265,12 @@ def sign(pkey, data, digest):
 
     # Backward compatibility
     if isinstance(data, _text_type):
-        warnings.warn("str object in passphrase is no longer accepted, use bytes", DeprecationWarning)
+        if version_info.major == 2:
+            warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
+        elif version_info.major == 3:
+            warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
+        else:
+            warn("text in passphrase is no longer accepted, use bytes", DeprecationWarning)
         data = data.encode('utf-8')
 
     digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
@@ -2299,7 +2310,12 @@ def verify(cert, signature, data, digest):
 
     # Backward compatibility
     if isinstance(data, _text_type):
-        warnings.warn("str object in passphrase is no longer accepted, use bytes", DeprecationWarning)
+        if version_info.major == 2:
+            warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
+        elif version_info.major == 3:
+            warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
+        else:
+            warn("text in passphrase is no longer accepted, use bytes", DeprecationWarning)
         data = data.encode('utf-8')
 
     digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
@@ -2396,7 +2412,12 @@ def load_pkcs12(buffer, passphrase=None):
 
     # Backward compatibility
     if isinstance(passphrase, _text_type):
-        warnings.warn("str object in passphrase is no longer accepted, use bytes", DeprecationWarning)
+        if version_info.major == 2:
+            warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
+        elif version_info.major == 3:
+            warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
+        else:
+            warn("text in passphrase is no longer accepted, use bytes", DeprecationWarning)
         passphrase = passphrase.encode('utf-8')
 
     if isinstance(buffer, _text_type):

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -2263,9 +2263,9 @@ def sign(pkey, data, digest):
     # Backward compatibility
     if isinstance(data, _text_type):
         if _PY3:
-            warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
+            warn("str in data is no longer accepted, use bytes", DeprecationWarning)
         else:
-            warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
+            warn("unicode in data is no longer accepted, use bytes", DeprecationWarning)
         data = data.encode('utf-8')
 
     digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
@@ -2306,9 +2306,9 @@ def verify(cert, signature, data, digest):
     # Backward compatibility
     if isinstance(data, _text_type):
         if _PY3:
-            warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
+            warn("str in data is no longer accepted, use bytes", DeprecationWarning)
         else:
-            warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
+            warn("unicode in data is no longer accepted, use bytes", DeprecationWarning)
         data = data.encode('utf-8')
 
     digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -1,3 +1,4 @@
+import warnings
 from time import time
 from base64 import b16encode
 from functools import partial
@@ -1955,7 +1956,7 @@ class PKCS12(object):
 
         # Backward compatibility
         if isinstance(passphrase, _text_type):
-            DeprecationWarning("str object in passphrase is no longer accepted, use bytes")
+            warnings.warn("str object in passphrase is no longer accepted, use bytes", DeprecationWarning)
             passphrase = passphrase.encode('utf-8')
 
         if self._cacerts is None:
@@ -2258,7 +2259,7 @@ def sign(pkey, data, digest):
 
     # Backward compatibility
     if isinstance(data, _text_type):
-        DeprecationWarning("str object in passphrase is no longer accepted, use bytes")
+        warnings.warn("str object in passphrase is no longer accepted, use bytes", DeprecationWarning)
         data = data.encode('utf-8')
 
     digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
@@ -2298,7 +2299,7 @@ def verify(cert, signature, data, digest):
 
     # Backward compatibility
     if isinstance(data, _text_type):
-        DeprecationWarning("str object in passphrase is no longer accepted, use bytes")
+        warnings.warn("str object in passphrase is no longer accepted, use bytes", DeprecationWarning)
         data = data.encode('utf-8')
 
     digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
@@ -2395,7 +2396,7 @@ def load_pkcs12(buffer, passphrase=None):
 
     # Backward compatibility
     if isinstance(passphrase, _text_type):
-        DeprecationWarning("str object in passphrase is no longer accepted, use bytes")
+        warnings.warn("str object in passphrase is no longer accepted, use bytes", DeprecationWarning)
         passphrase = passphrase.encode('utf-8')
 
     if isinstance(buffer, _text_type):

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -1,5 +1,5 @@
+import six
 from warnings import warn
-from sys import version_info
 from time import time
 from base64 import b16encode
 from functools import partial
@@ -1957,12 +1957,10 @@ class PKCS12(object):
 
         # Backward compatibility
         if isinstance(passphrase, _text_type):
-            if version_info.major == 2:
+            if six.PY2:
                 warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
-            elif version_info.major == 3:
-                warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
             else:
-                warn("text in passphrase is no longer accepted, use bytes", DeprecationWarning)
+                warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
             passphrase = passphrase.encode('utf-8')
 
         if self._cacerts is None:
@@ -2265,12 +2263,10 @@ def sign(pkey, data, digest):
 
     # Backward compatibility
     if isinstance(data, _text_type):
-        if version_info.major == 2:
+        if six.PY2:
             warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
-        elif version_info.major == 3:
-            warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
         else:
-            warn("text in passphrase is no longer accepted, use bytes", DeprecationWarning)
+            warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
         data = data.encode('utf-8')
 
     digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
@@ -2310,12 +2306,10 @@ def verify(cert, signature, data, digest):
 
     # Backward compatibility
     if isinstance(data, _text_type):
-        if version_info.major == 2:
+        if six.PY2:
             warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
-        elif version_info.major == 3:
-            warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
         else:
-            warn("text in passphrase is no longer accepted, use bytes", DeprecationWarning)
+            warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
         data = data.encode('utf-8')
 
     digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
@@ -2412,12 +2406,10 @@ def load_pkcs12(buffer, passphrase=None):
 
     # Backward compatibility
     if isinstance(passphrase, _text_type):
-        if version_info.major == 2:
+        if six.PY2:
             warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
-        elif version_info.major == 3:
-            warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
         else:
-            warn("text in passphrase is no longer accepted, use bytes", DeprecationWarning)
+            warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
         passphrase = passphrase.encode('utf-8')
 
     if isinstance(buffer, _text_type):

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -1,4 +1,3 @@
-import six
 from warnings import warn
 from time import time
 from base64 import b16encode
@@ -1957,10 +1956,10 @@ class PKCS12(object):
 
         # Backward compatibility
         if isinstance(passphrase, _text_type):
-            if six.PY2:
-                warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
-            else:
+            if _PY3:
                 warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
+            else:
+                warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
             passphrase = passphrase.encode('utf-8')
 
         if self._cacerts is None:
@@ -2263,10 +2262,10 @@ def sign(pkey, data, digest):
 
     # Backward compatibility
     if isinstance(data, _text_type):
-        if six.PY2:
-            warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
-        else:
+        if _PY3:
             warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
+        else:
+            warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
         data = data.encode('utf-8')
 
     digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
@@ -2306,10 +2305,10 @@ def verify(cert, signature, data, digest):
 
     # Backward compatibility
     if isinstance(data, _text_type):
-        if six.PY2:
-            warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
-        else:
+        if _PY3:
             warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
+        else:
+            warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
         data = data.encode('utf-8')
 
     digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
@@ -2406,10 +2405,10 @@ def load_pkcs12(buffer, passphrase=None):
 
     # Backward compatibility
     if isinstance(passphrase, _text_type):
-        if six.PY2:
-            warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
-        else:
+        if _PY3:
             warn("str in passphrase is no longer accepted, use bytes", DeprecationWarning)
+        else:
+            warn("unicode in passphrase is no longer accepted, use bytes", DeprecationWarning)
         passphrase = passphrase.encode('utf-8')
 
     if isinstance(buffer, _text_type):

--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -1952,6 +1952,12 @@ class PKCS12(object):
 
         :return: The string containing the PKCS12
         """
+
+        # Backward compatibility
+        if isinstance(passphrase, _text_type):
+            DeprecationWarning("str object in passphrase is no longer accepted, use bytes")
+            passphrase = passphrase.encode('utf-8')
+
         if self._cacerts is None:
             cacerts = _ffi.NULL
         else:
@@ -2249,6 +2255,12 @@ def sign(pkey, data, digest):
     :param digest: message digest to use
     :return: signature
     """
+
+    # Backward compatibility
+    if isinstance(data, _text_type):
+        DeprecationWarning("str object in passphrase is no longer accepted, use bytes")
+        data = data.encode('utf-8')
+
     digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
     if digest_obj == _ffi.NULL:
         raise ValueError("No such digest method")
@@ -2283,6 +2295,12 @@ def verify(cert, signature, data, digest):
     :param digest: message digest to use
     :return: None if the signature is correct, raise exception otherwise
     """
+
+    # Backward compatibility
+    if isinstance(data, _text_type):
+        DeprecationWarning("str object in passphrase is no longer accepted, use bytes")
+        data = data.encode('utf-8')
+
     digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
     if digest_obj == _ffi.NULL:
         raise ValueError("No such digest method")
@@ -2374,6 +2392,12 @@ def load_pkcs12(buffer, passphrase=None):
     :param passphrase: (Optional) The password to decrypt the PKCS12 lump
     :returns: The PKCS12 object
     """
+
+    # Backward compatibility
+    if isinstance(passphrase, _text_type):
+        DeprecationWarning("str object in passphrase is no longer accepted, use bytes")
+        passphrase = passphrase.encode('utf-8')
+
     if isinstance(buffer, _text_type):
         buffer = buffer.encode("ascii")
 

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -7,7 +7,7 @@ Unit tests for :py:obj:`OpenSSL.SSL`.
 
 from gc import collect, get_referrers
 from errno import ECONNREFUSED, EINPROGRESS, EWOULDBLOCK, EPIPE, ESHUTDOWN
-from sys import platform, version_info
+from sys import platform
 from socket import SHUT_RDWR, error, socket
 from os import makedirs
 from os.path import join
@@ -931,10 +931,10 @@ class ContextTests(TestCase, _LoopbackMixin):
 
         with catch_warnings(record=True) as w:
             simplefilter("always")
-            if version_info.major == 2:
+            if not PY3:
                 self._load_verify_locations_test(unicode(cafile))
                 self.assertTrue("unicode in cafile is no longer accepted, use bytes" in str(w[-1].message))
-            elif version_info.major == 3:
+            else:
                 self._load_verify_locations_test(cafile.decode())
                 self.assertTrue("str in cafile is no longer accepted, use bytes" in str(w[-1].message))
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
@@ -1615,7 +1615,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         self.assertRaises(
             TypeError, conn.set_tlsext_host_name, b("with\0null"))
 
-        if version_info >= (3,):
+        if PY3:
             # On Python 3.x, don't accidentally implicitly convert from text.
             self.assertRaises(
                 TypeError,


### PR DESCRIPTION
#15 Fix regressions in support for bytes / unicode in certain APIs 
Added a check for _text_type, raise a DeprecationWarning and encode the str to utf-8 or asciii. This should preserve 0.13 API calls.
I used the 0.13 test suite with the 0.14 code and made the necessary changes to make 0.13 and 0.14 tests pass with python 2.X and 3.X using travis.