### PR TITLE
Don't randomly fail with KeyError in shutdown().

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-04-14  Glyph Lefkowitz  <glyph@twistedmatrix.com>
+
+	* OpenSSL/SSL.py, OpenSSL/test/test_ssl.py: Fix a regression
+	  present in 0.15, which caused Connection.shutdown() to raise an
+	  SSL error when the connection had been truncated.
+
 2015-04-12  Jean-Paul Calderone  <exarkun@twistedmatrix.com>
 
 	* OpenSSL/rand.py, OpenSSL/SSL.py: APIs which previously accepted

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,10 @@
 2015-04-14  Glyph Lefkowitz  <glyph@twistedmatrix.com>
 
 	* OpenSSL/SSL.py, OpenSSL/test/test_ssl.py: Fix a regression
-	  present in 0.15, which caused Connection.shutdown() to raise an
-	  SSL error when the connection had been truncated.
+	  present in 0.15, where when an error occurs and no errno() is set,
+	  a KeyError is raised.  This happens, for example, if
+	  Connection.shutdown() is called when the underlying transport has
+	  gone away.
 
 2015-04-12  Jean-Paul Calderone  <exarkun@twistedmatrix.com>
 

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1175,7 +1175,7 @@ class Connection(object):
                         errno = _ffi.getwinerror()[0]
                     else:
                         errno = _ffi.errno
-                    raise SysCallError(errno, errorcode[errno])
+                    raise SysCallError(errno, errorcode.get(errno))
                 else:
                     raise SysCallError(-1, "Unexpected EOF")
             else:

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -2303,6 +2303,17 @@ class ConnectionTests(TestCase, _LoopbackMixin):
             self.assertEqual(exc.args[0], EPIPE)
 
 
+    def test_shutdown_shutdown(self):
+        """
+        :obj:`Connection.shutdown` raises :obj:`Error` when called for a second
+        time on the same connection.
+        """
+        server, client = self._loopback()
+        client.send(b"AN BYTES")
+        server.shutdown()
+        self.assertRaises(Error, server.shutdown)
+
+
     def test_set_shutdown(self):
         """
         :py:obj:`Connection.set_shutdown` sets the state of the SSL connection shutdown


### PR DESCRIPTION
Fixes #224 