### PR TITLE
Do not litter working dir

### DIFF
--- a/OpenSSL/test/test_rand.py
+++ b/OpenSSL/test/test_rand.py
@@ -205,8 +205,7 @@ class RandTests(TestCase):
         Random data can be saved and loaded to files with paths specified as
         bytes.
         """
-        path = self.mktemp()
-        path += NON_ASCII.encode(sys.getfilesystemencoding())
+        path = self.mktemp(suffix=NON_ASCII)
         self._read_write_test(path)
 
 
@@ -215,7 +214,7 @@ class RandTests(TestCase):
         Random data can be saved and loaded to files with paths specified as
         unicode.
         """
-        path = self.mktemp().decode('utf-8') + NON_ASCII
+        path = self.mktemp(suffix=NON_ASCII).decode('utf-8')
         self._read_write_test(path)
 
 

--- a/OpenSSL/test/test_rand.py
+++ b/OpenSSL/test/test_rand.py
@@ -205,7 +205,8 @@ class RandTests(TestCase):
         Random data can be saved and loaded to files with paths specified as
         bytes.
         """
-        path = self.mktemp(suffix=NON_ASCII)
+        path = self.mktemp()
+        path += NON_ASCII.encode(sys.getfilesystemencoding())
         self._read_write_test(path)
 
 
@@ -214,7 +215,7 @@ class RandTests(TestCase):
         Random data can be saved and loaded to files with paths specified as
         unicode.
         """
-        path = self.mktemp(suffix=NON_ASCII).decode('utf-8')
+        path = self.mktemp().decode('utf-8') + NON_ASCII
         self._read_write_test(path)
 
 

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -436,7 +436,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         instance giving the file name to ``Context.use_privatekey_file``.
         """
         self._use_privatekey_file_test(
-            self.mktemp() + NON_ASCII.encode(getfilesystemencoding()),
+            self.mktemp(suffix=NON_ASCII),
             FILETYPE_PEM,
         )
 
@@ -447,7 +447,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         instance giving the file name to ``Context.use_privatekey_file``.
         """
         self._use_privatekey_file_test(
-            self.mktemp().decode(getfilesystemencoding()) + NON_ASCII,
+            self.mktemp(suffix=NON_ASCII).decode(getfilesystemencoding()),
             FILETYPE_PEM,
         )
 
@@ -545,7 +545,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         ``bytes`` filename) which will be used to identify connections created
         using the context.
         """
-        filename = self.mktemp() + NON_ASCII.encode(getfilesystemencoding())
+        filename = self.mktemp(suffix=NON_ASCII)
         self._use_certificate_file_test(filename)
 
 
@@ -555,7 +555,9 @@ class ContextTests(TestCase, _LoopbackMixin):
         ``bytes`` filename) which will be used to identify connections created
         using the context.
         """
-        filename = self.mktemp().decode(getfilesystemencoding()) + NON_ASCII
+        filename = self.mktemp(
+            suffix=NON_ASCII
+        ).decode(getfilesystemencoding())
         self._use_certificate_file_test(filename)
 
 
@@ -990,7 +992,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         ``bytes`` instance and uses the certificates within for verification
         purposes.
         """
-        cafile = self.mktemp() + NON_ASCII.encode(getfilesystemencoding())
+        cafile = self.mktemp(suffix=NON_ASCII)
         self._load_verify_cafile(cafile)
 
 
@@ -1001,7 +1003,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         purposes.
         """
         self._load_verify_cafile(
-            self.mktemp().decode(getfilesystemencoding()) + NON_ASCII
+            self.mktemp(suffix=NON_ASCII).decode(getfilesystemencoding())
         )
 
 
@@ -1041,7 +1043,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         purposes.
         """
         self._load_verify_directory_locations_capath(
-            self.mktemp() + NON_ASCII.encode(getfilesystemencoding())
+            self.mktemp(suffix=NON_ASCII)
         )
 
 
@@ -1052,7 +1054,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         purposes.
         """
         self._load_verify_directory_locations_capath(
-            self.mktemp().decode(getfilesystemencoding()) + NON_ASCII
+            self.mktemp(suffix=NON_ASCII)
         )
 
 
@@ -1287,7 +1289,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         construct and verify a trust chain.
         """
         self._use_certificate_chain_file_test(
-            self.mktemp() + NON_ASCII.encode(getfilesystemencoding())
+            self.mktemp(suffix=NON_ASCII)
         )
 
 
@@ -1298,7 +1300,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         to construct and verify a trust chain.
         """
         self._use_certificate_chain_file_test(
-            self.mktemp().decode(getfilesystemencoding()) + NON_ASCII
+            self.mktemp(suffix=NON_ASCII)
         )
 
 
@@ -1395,7 +1397,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         specified file (given as ``bytes``).
         """
         self._load_tmp_dh_test(
-            self.mktemp() + NON_ASCII.encode(getfilesystemencoding()),
+            self.mktemp(suffix=NON_ASCII)
         )
 
 
@@ -1405,7 +1407,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         specified file (given as ``unicode``).
         """
         self._load_tmp_dh_test(
-            self.mktemp().decode(getfilesystemencoding()) + NON_ASCII,
+            self.mktemp(suffix=NON_ASCII).decode(getfilesystemencoding())
         )
 
 

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -1221,7 +1221,9 @@ class ContextTests(TestCase, _LoopbackMixin):
             fObj.write(dump_certificate(FILETYPE_PEM, cert).decode('ascii'))
             fObj.close()
 
-        for key, name in [(cakey, 'ca.key'), (ikey, 'i.key'), (skey, 's.key')]:
+        for key, name in [(cakey, 'ca.key'),
+                          (ikey, 'i.key'),
+                          (skey, 's.key')]:
             fObj = open(join(self.tmpdir, name), 'w')
             fObj.write(dump_privatekey(FILETYPE_PEM, key).decode('ascii'))
             fObj.close()

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -1217,16 +1217,14 @@ class ContextTests(TestCase, _LoopbackMixin):
         for cert, name in [(cacert, 'ca.pem'),
                            (icert, 'i.pem'),
                            (scert, 's.pem')]:
-            fObj = open(join(self.tmpdir, name), 'w')
-            fObj.write(dump_certificate(FILETYPE_PEM, cert).decode('ascii'))
-            fObj.close()
+            with open(join(self.tmpdir, name), 'w') as f:
+                f.write(dump_certificate(FILETYPE_PEM, cert).decode('ascii'))
 
         for key, name in [(cakey, 'ca.key'),
                           (ikey, 'i.key'),
                           (skey, 's.key')]:
-            fObj = open(join(self.tmpdir, name), 'w')
-            fObj.write(dump_privatekey(FILETYPE_PEM, key).decode('ascii'))
-            fObj.close()
+            with open(join(self.tmpdir, name), 'w') as f:
+                f.write(dump_privatekey(FILETYPE_PEM, key).decode('ascii'))
 
         # Create the server context
         serverContext = Context(TLSv1_METHOD)

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -436,7 +436,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         instance giving the file name to ``Context.use_privatekey_file``.
         """
         self._use_privatekey_file_test(
-            self.mktemp(suffix=NON_ASCII),
+            self.mktemp() + NON_ASCII.encode(getfilesystemencoding()),
             FILETYPE_PEM,
         )
 
@@ -447,7 +447,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         instance giving the file name to ``Context.use_privatekey_file``.
         """
         self._use_privatekey_file_test(
-            self.mktemp(suffix=NON_ASCII).decode(getfilesystemencoding()),
+            self.mktemp().decode(getfilesystemencoding()) + NON_ASCII,
             FILETYPE_PEM,
         )
 
@@ -545,7 +545,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         ``bytes`` filename) which will be used to identify connections created
         using the context.
         """
-        filename = self.mktemp(suffix=NON_ASCII)
+        filename = self.mktemp() + NON_ASCII.encode(getfilesystemencoding())
         self._use_certificate_file_test(filename)
 
 
@@ -555,9 +555,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         ``bytes`` filename) which will be used to identify connections created
         using the context.
         """
-        filename = self.mktemp(
-            suffix=NON_ASCII
-        ).decode(getfilesystemencoding())
+        filename = self.mktemp().decode(getfilesystemencoding()) + NON_ASCII
         self._use_certificate_file_test(filename)
 
 
@@ -992,7 +990,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         ``bytes`` instance and uses the certificates within for verification
         purposes.
         """
-        cafile = self.mktemp(suffix=NON_ASCII)
+        cafile = self.mktemp() + NON_ASCII.encode(getfilesystemencoding())
         self._load_verify_cafile(cafile)
 
 
@@ -1003,7 +1001,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         purposes.
         """
         self._load_verify_cafile(
-            self.mktemp(suffix=NON_ASCII).decode(getfilesystemencoding())
+            self.mktemp().decode(getfilesystemencoding()) + NON_ASCII
         )
 
 
@@ -1043,7 +1041,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         purposes.
         """
         self._load_verify_directory_locations_capath(
-            self.mktemp(suffix=NON_ASCII)
+            self.mktemp() + NON_ASCII.encode(getfilesystemencoding())
         )
 
 
@@ -1054,7 +1052,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         purposes.
         """
         self._load_verify_directory_locations_capath(
-            self.mktemp(suffix=NON_ASCII)
+            self.mktemp().decode(getfilesystemencoding()) + NON_ASCII
         )
 
 
@@ -1201,11 +1199,11 @@ class ContextTests(TestCase, _LoopbackMixin):
 
     def test_add_extra_chain_cert(self):
         """
-        :py:obj:`Context.add_extra_chain_cert` accepts an :py:obj:`X509` instance to add to
-        the certificate chain.
+        :py:obj:`Context.add_extra_chain_cert` accepts an :py:obj:`X509`
+        instance to add to the certificate chain.
 
-        See :py:obj:`_create_certificate_chain` for the details of the certificate
-        chain tested.
+        See :py:obj:`_create_certificate_chain` for the details of the
+        certificate chain tested.
 
         The chain is tested by starting a server with scert and connecting
         to it with a client which trusts cacert and requires verification to
@@ -1216,13 +1214,15 @@ class ContextTests(TestCase, _LoopbackMixin):
 
         # Dump the CA certificate to a file because that's the only way to load
         # it as a trusted CA in the client context.
-        for cert, name in [(cacert, 'ca.pem'), (icert, 'i.pem'), (scert, 's.pem')]:
-            fObj = open(name, 'w')
+        for cert, name in [(cacert, 'ca.pem'),
+                           (icert, 'i.pem'),
+                           (scert, 's.pem')]:
+            fObj = open(join(self.tmpdir, name), 'w')
             fObj.write(dump_certificate(FILETYPE_PEM, cert).decode('ascii'))
             fObj.close()
 
         for key, name in [(cakey, 'ca.key'), (ikey, 'i.key'), (skey, 's.key')]:
-            fObj = open(name, 'w')
+            fObj = open(join(self.tmpdir, name), 'w')
             fObj.write(dump_privatekey(FILETYPE_PEM, key).decode('ascii'))
             fObj.close()
 
@@ -1237,7 +1237,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         clientContext = Context(TLSv1_METHOD)
         clientContext.set_verify(
             VERIFY_PEER | VERIFY_FAIL_IF_NO_PEER_CERT, verify_cb)
-        clientContext.load_verify_locations(b"ca.pem")
+        clientContext.load_verify_locations(join(self.tmpdir, "ca.pem"))
 
         # Try it out.
         self._handshake_test(serverContext, clientContext)
@@ -1289,7 +1289,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         construct and verify a trust chain.
         """
         self._use_certificate_chain_file_test(
-            self.mktemp(suffix=NON_ASCII)
+            self.mktemp() + NON_ASCII.encode(getfilesystemencoding())
         )
 
 
@@ -1300,7 +1300,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         to construct and verify a trust chain.
         """
         self._use_certificate_chain_file_test(
-            self.mktemp(suffix=NON_ASCII)
+            self.mktemp().decode(getfilesystemencoding()) + NON_ASCII
         )
 
 
@@ -1397,7 +1397,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         specified file (given as ``bytes``).
         """
         self._load_tmp_dh_test(
-            self.mktemp(suffix=NON_ASCII)
+            self.mktemp() + NON_ASCII.encode(getfilesystemencoding()),
         )
 
 
@@ -1407,7 +1407,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         specified file (given as ``unicode``).
         """
         self._load_tmp_dh_test(
-            self.mktemp(suffix=NON_ASCII).decode(getfilesystemencoding())
+            self.mktemp().decode(getfilesystemencoding()) + NON_ASCII,
         )
 
 

--- a/OpenSSL/test/util.py
+++ b/OpenSSL/test/util.py
@@ -163,7 +163,7 @@ class TestCase(TestCase):
         Subclasses must invoke this method if they override it or the
         cleanup will not occur.
         """
-        if False and self._temporaryFiles is not None:
+        if self._temporaryFiles is not None:
             for temp in self._temporaryFiles:
                 if os.path.isdir(temp):
                     shutil.rmtree(temp)

--- a/OpenSSL/test/util.py
+++ b/OpenSSL/test/util.py
@@ -296,13 +296,13 @@ class TestCase(TestCase):
 
 
     _temporaryFiles = None
-    def mktemp(self):
+    def mktemp(self, suffix=""):
         """
         Pathetic substitute for twisted.trial.unittest.TestCase.mktemp.
         """
         if self._temporaryFiles is None:
             self._temporaryFiles = []
-        temp = b(mktemp(dir="."))
+        temp = mktemp(suffix=suffix, dir=".").encode("utf-8")
         self._temporaryFiles.append(temp)
         return temp
 


### PR DESCRIPTION
This PR cleans up the handling of temporary files such that the CWD is not filled with them.

It changes the approach to creating a directory which it kills afterwards instead of keeping track of single files.

Some adjacent lines have been also cleaned up.

No code except tests is touched by this PR.