### PR TITLE
Updating certificate generation in examples

### DIFF
--- a/examples/certgen.py
+++ b/examples/certgen.py
@@ -25,7 +25,7 @@ def createKeyPair(type, bits):
     pkey.generate_key(type, bits)
     return pkey
 
-def createCertRequest(pkey, digest="md5", **name):
+def createCertRequest(pkey, digest="sha256", **name):
     """
     Create a certificate request.
 

--- a/examples/mk_simple_certs.py
+++ b/examples/mk_simple_certs.py
@@ -7,15 +7,15 @@ from certgen import *   # yes yes, I know, I'm lazy
 cakey = createKeyPair(TYPE_RSA, 2048)
 careq = createCertRequest(cakey, CN='Certificate Authority')
 cacert = createCertificate(careq, (careq, cakey), 0, (0, 60*60*24*365*5)) # five years
-print('Creating Certificate Authority private key in \"simple/CA.pkey\"')
+print('Creating Certificate Authority private key in "simple/CA.pkey"')
 open('simple/CA.pkey', 'w').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, cakey))
-print('Creating Certificate Authority certificate in \"simple/CA.cert\"')
+print('Creating Certificate Authority certificate in "simple/CA.cert"')
 open('simple/CA.cert', 'w').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cacert))
 for (fname, cname) in [('client', 'Simple Client'), ('server', 'Simple Server')]:
     pkey = createKeyPair(TYPE_RSA, 2048)
     req = createCertRequest(pkey, CN=cname)
     cert = createCertificate(req, (cacert, cakey), 1, (0, 60*60*24*365*5)) # five years
-    print('Creating Certificate %s private key in \"simple/%s.pkey\"' % (fname, fname))
+    print('Creating Certificate %s private key in "simple/%s.pkey"' % (fname, fname))
     open('simple/%s.pkey' % (fname,), 'w').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey))
-    print('Creating Certificate %s certificate in \"simple/%s.cert\"' % (fname, fname))
+    print('Creating Certificate %s certificate in "simple/%s.cert"' % (fname, fname))
     open('simple/%s.cert' % (fname,), 'w').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))

--- a/examples/mk_simple_certs.py
+++ b/examples/mk_simple_certs.py
@@ -4,14 +4,18 @@ Create certificates and private keys for the 'simple' example.
 
 from OpenSSL import crypto
 from certgen import *   # yes yes, I know, I'm lazy
-cakey = createKeyPair(TYPE_RSA, 1024)
+cakey = createKeyPair(TYPE_RSA, 2048)
 careq = createCertRequest(cakey, CN='Certificate Authority')
 cacert = createCertificate(careq, (careq, cakey), 0, (0, 60*60*24*365*5)) # five years
+print('Creating Certificate Authority private key in \"simple/CA.pkey\"')
 open('simple/CA.pkey', 'w').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, cakey))
+print('Creating Certificate Authority certificate in \"simple/CA.cert\"')
 open('simple/CA.cert', 'w').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cacert))
 for (fname, cname) in [('client', 'Simple Client'), ('server', 'Simple Server')]:
-    pkey = createKeyPair(TYPE_RSA, 1024)
+    pkey = createKeyPair(TYPE_RSA, 2048)
     req = createCertRequest(pkey, CN=cname)
     cert = createCertificate(req, (cacert, cakey), 1, (0, 60*60*24*365*5)) # five years
+    print('Creating Certificate %s private key in \"simple/%s.pkey\"' % (fname, fname))
     open('simple/%s.pkey' % (fname,), 'w').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey))
+    print('Creating Certificate %s certificate in \"simple/%s.cert\"' % (fname, fname))
     open('simple/%s.cert' % (fname,), 'w').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))


### PR DESCRIPTION
Hi all,

I was looking through the examples and noticed that they had not been looked at in a while, I thought that perhaps we should update them to be more in line with what is considered contemporary good practice.  In this pull request:
* md5->sha256 for signature
* 1024->2048 for key length
* added print statements to inform the user what keys were going where 