### PR TITLE
Add support for querying the negotiated TLS version.  The Quickening

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,12 @@
 
 2015-04-15  Paul Kehrer <paul.l.kehrer@gmail.com>
 
+	* OpenSSL/SSL.py, : Add ``get_protocol_version()`` to Connection
+	  Based on work from Rich Moore
+	* OpenSSL/test/test_crypto.py: tests for ``get_protocol_version``
+
+2015-04-15  Paul Kehrer <paul.l.kehrer@gmail.com>
+
 	* OpenSSL/crypto.py, OpenSSL/test/test_crypto.py: Switch to utf8string
 	  mask by default. OpenSSL formerly defaulted to a T61String if there
 	  were UTF-8 characters present.  This was changed to default to

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,9 +7,11 @@
 
 2015-04-15  Paul Kehrer <paul.l.kehrer@gmail.com>
 
-	* OpenSSL/SSL.py, : Add ``get_protocol_version()`` to Connection
+	* OpenSSL/SSL.py, : Add ``get_protocol_version()`` and 
+	  ``get_protocol_version_name()`` to Connection
 	  Based on work from Rich Moore
-	* OpenSSL/test/test_crypto.py: tests for ``get_protocol_version``
+	* OpenSSL/test/test_crypto.py: tests for ``get_protocol_version()``
+	  and ``get_protocol_version_name()``
 
 2015-04-15  Paul Kehrer <paul.l.kehrer@gmail.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,8 @@
 2015-05-27  Jim Shaver <dcypherd@gmail.com>
 
 	* OpenSSL/SSL.py, : Add ``get_protocol_version()`` and 
-	  ``get_protocol_version_name()`` to Connection
-	  Based on work from Rich Moore
+	  ``get_protocol_version_name()`` to ``Connection``.
+	  Based on work from Rich Moore.
 
 2015-05-02  Jim Shaver <dcypherd@gmail.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,17 +1,17 @@
-2015-05-02  Jim Shaver <dcypherd@gmail.com>
-
-	* .travis.yml, setup.py, tox.ini: Removed support for Python 3.2.
-	  This version is rarely used and is now deprecated by a major
-	  dependency of pyOpenSSL (cryptography).  Affected users should upgrade
-	  to Python 3.3+.
-
-2015-04-15  Paul Kehrer <paul.l.kehrer@gmail.com>
+2015-05-27  Jim Shaver <dcypherd@gmail.com>
 
 	* OpenSSL/SSL.py, : Add ``get_protocol_version()`` and 
 	  ``get_protocol_version_name()`` to Connection
 	  Based on work from Rich Moore
 	* OpenSSL/test/test_crypto.py: tests for ``get_protocol_version()``
 	  and ``get_protocol_version_name()``
+
+2015-05-02  Jim Shaver <dcypherd@gmail.com>
+
+	* .travis.yml, setup.py, tox.ini: Removed support for Python 3.2.
+	  This version is rarely used and is now deprecated by a major
+	  dependency of pyOpenSSL (cryptography).  Affected users should upgrade
+	  to Python 3.3+.
 
 2015-04-15  Paul Kehrer <paul.l.kehrer@gmail.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,8 +3,6 @@
 	* OpenSSL/SSL.py, : Add ``get_protocol_version()`` and 
 	  ``get_protocol_version_name()`` to Connection
 	  Based on work from Rich Moore
-	* OpenSSL/test/test_crypto.py: tests for ``get_protocol_version()``
-	  and ``get_protocol_version_name()``
 
 2015-05-02  Jim Shaver <dcypherd@gmail.com>
 

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1888,11 +1888,12 @@ class Connection(object):
         Obtain the protocol version of the current connection.
 
         :returns: The TLS version of the current connection, for example
-            the value for TLS 1.2 would be ``b'TLSv1.2'``.
-        :rtype: :py:class:`bytes`
+            the value for TLS 1.2 would be ``TLSv1.2``or ``Unknown``
+            for connections that were not successfully.
+        :rtype: :py:class:`unicode`
         """
         version = _ffi.string(_lib.SSL_get_version(self._ssl))
-        return version
+        return version.decode("utf-8")
 
 
     def get_protocol_version(self):

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1883,16 +1883,16 @@ class Connection(object):
             return version.decode("utf-8")
 
 
-    def get_protocol_version(self):
+    def get_protocol_version_name(self):
         """
         Obtain the protocol version of the current connection.
 
         :returns: The TLS version of the current connection, for example
-            the value for TLS 1.2 would be ``TLSv1.2``.
+            the value for TLS 1.2 would be ``b'TLSv1.2'``.
         :rtype: :py:class:`unicode`
         """
-        version = _ffi.string(_lib.SSL_get_version(self._ssl))
-        return version.decode("utf-8")
+        version = _lib.SSL_get_version(self._ssl)
+        return version
 
 
     @_requires_npn

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1938,6 +1938,17 @@ class Connection(object):
         return _ffi.buffer(data[0], data_len[0])[:]
 
 
+    def get_protocol_version(self):
+        """
+        Obtain the protocol version of the current connection.
+
+        :returns: The TLS version of the current connection, for example
+            the value for TLS 1.2 would be 0x303.
+        :rtype: :py:class:`int`
+        """
+        version = _lib.SSL_version(self._ssl)
+        return version
+
 
 ConnectionType = Connection
 

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1891,7 +1891,7 @@ class Connection(object):
             the value for TLS 1.2 would be ``b'TLSv1.2'``.
         :rtype: :py:class:`unicode`
         """
-        version = _lib.SSL_get_version(self._ssl)
+        version = _ffi.string(_lib.SSL_get_version(self._ssl))
         return version
 
 

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1889,11 +1889,11 @@ class Connection(object):
 
         :returns: The TLS version of the current connection, for example
             the value for TLS 1.2 would be 0x303.
-        :rtype: :py:class:`int`
+        :rtype: :py:class:`unicode`
         """
-        version = _lib.SSL_get_version(self._ssl)
-        return version
-	
+        version = _ffi.string(_lib.SSL_get_version(self._ssl))
+        return version.decode("utf-8")
+
 
     @_requires_npn
     def get_next_proto_negotiated(self):

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1889,9 +1889,21 @@ class Connection(object):
 
         :returns: The TLS version of the current connection, for example
             the value for TLS 1.2 would be ``b'TLSv1.2'``.
-        :rtype: :py:class:`unicode`
+        :rtype: :py:class:`bytes`
         """
         version = _ffi.string(_lib.SSL_get_version(self._ssl))
+        return version
+
+
+    def get_protocol_version(self):
+        """
+        Obtain the protocol version of the current connection.
+
+        :returns: The TLS version of the current connection, for example
+            the value for TLS 1 would be 0x769.
+        :rtype: :py:class:`int`
+        """
+        version = _lib.SSL_version(self._ssl)
         return version
 
 
@@ -1949,17 +1961,6 @@ class Connection(object):
 
         return _ffi.buffer(data[0], data_len[0])[:]
 
-
-    def get_protocol_version(self):
-        """
-        Obtain the protocol version of the current connection.
-
-        :returns: The TLS version of the current connection, for example
-            the value for TLS 1.2 would be 0x303.
-        :rtype: :py:class:`int`
-        """
-        version = _lib.SSL_version(self._ssl)
-        return version
 
 
 ConnectionType = Connection

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1883,6 +1883,18 @@ class Connection(object):
             return version.decode("utf-8")
 
 
+    def get_protocol_version(self):
+        """
+        Obtain the protocol version of the current connection.
+
+        :returns: The TLS version of the current connection, for example
+            the value for TLS 1.2 would be 0x303.
+        :rtype: :py:class:`int`
+        """
+        version = _lib.SSL_get_version(self._ssl)
+        return version
+	
+
     @_requires_npn
     def get_next_proto_negotiated(self):
         """

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1888,7 +1888,7 @@ class Connection(object):
         Obtain the protocol version of the current connection.
 
         :returns: The TLS version of the current connection, for example
-            the value for TLS 1.2 would be 0x303.
+            the value for TLS 1.2 would be ``TLSv1.2``.
         :rtype: :py:class:`unicode`
         """
         version = _ffi.string(_lib.SSL_get_version(self._ssl))

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1889,7 +1889,7 @@ class Connection(object):
 
         :returns: The TLS version of the current connection, for example
             the value for TLS 1.2 would be ``TLSv1.2``or ``Unknown``
-            for connections that were not successfully.
+            for connections that were not successfully established.
         :rtype: :py:class:`unicode`
         """
         version = _ffi.string(_lib.SSL_get_version(self._ssl))

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -2747,7 +2747,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
 
     def test_get_protocol_version(self):
         """
-        :py:obj:`Connection.get_protocol_version` returns a string
+        :py:obj:`Connection.get_protocol_version()` returns a string
         giving the protocol version of the current connection.
         """
         server, client = self._loopback()

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -2754,8 +2754,8 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         client_protocol_version_name = client.get_protocol_version_name()
         server_protocol_version_name = server.get_protocol_version_name()
 
-        self.assertIsInstance(server_protocol_version_name, bytes)
-        self.assertIsInstance(client_protocol_version_name, bytes)
+        self.assertIsInstance(server_protocol_version_name, text_type)
+        self.assertIsInstance(client_protocol_version_name, text_type)
 
         self.assertEqual(server_protocol_version_name, client_protocol_version_name)
 

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -142,7 +142,7 @@ def socket_pair():
     # Most of our callers want non-blocking sockets, make it easy for them.
     server.setblocking(False)
     client.setblocking(False)
-
+    port.close()
     return (server, client)
 
 

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -2745,17 +2745,32 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         self.assertEqual(server_cipher_bits, client_cipher_bits)
 
 
+    def test_get_protocol_version_name(self):
+        """
+        :py:obj:`Connection.get_protocol_version_name()` returns a string
+        giving the protocol version of the current connection.
+        """
+        server, client = self._loopback()
+        client_protocol_version_name = client.get_protocol_version_name()
+        server_protocol_version_name = server.get_protocol_version_name()
+
+        self.assertIsInstance(server_protocol_version_name, bytes)
+        self.assertIsInstance(client_protocol_version_name, bytes)
+
+        self.assertEqual(server_protocol_version_name, client_protocol_version_name)
+
+
     def test_get_protocol_version(self):
         """
-        :py:obj:`Connection.get_protocol_version()` returns a string
+        :py:obj:`Connection.get_protocol_version()` returns an integer 
         giving the protocol version of the current connection.
         """
         server, client = self._loopback()
         client_protocol_version = client.get_protocol_version()
         server_protocol_version = server.get_protocol_version()
 
-        self.assertIsInstance(server_protocol_version, text_type)
-        self.assertIsInstance(client_protocol_version, text_type)
+        self.assertIsInstance(server_protocol_version, int)
+        self.assertIsInstance(client_protocol_version, int)
 
         self.assertEqual(server_protocol_version, client_protocol_version)
 

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -142,7 +142,7 @@ def socket_pair():
     # Most of our callers want non-blocking sockets, make it easy for them.
     server.setblocking(False)
     client.setblocking(False)
-    port.close()
+
     return (server, client)
 
 

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -2747,15 +2747,15 @@ class ConnectionTests(TestCase, _LoopbackMixin):
 
     def test_get_protocol_version(self):
         """
-        :py:obj:`Connection.get_protocol_version` returns a :py:class:`int`
+        :py:obj:`Connection.get_protocol_version` returns a string
         giving the protocol version of the current connection.
         """
         server, client = self._loopback()
         server_protocol_version, client_protocol_version = \
             server.get_protocol_version(), client.get_protocol_version()
 
-        self.assertIsInstance(server_protocol_version, int)
-        self.assertIsInstance(client_protocol_version, int)
+        self.assertIsInstance(server_protocol_version, text_type)
+        self.assertIsInstance(client_protocol_version, text_type)
 
         self.assertEqual(server_protocol_version, client_protocol_version)
 

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -2751,8 +2751,8 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         giving the protocol version of the current connection.
         """
         server, client = self._loopback()
-        server_protocol_version, client_protocol_version = \
-            server.get_protocol_version(), client.get_protocol_version()
+        client_protocol_version = client.get_protocol_version()
+        server_protocol_version = server.get_protocol_version()
 
         self.assertIsInstance(server_protocol_version, text_type)
         self.assertIsInstance(client_protocol_version, text_type)

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -2745,6 +2745,20 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         self.assertEqual(server_cipher_bits, client_cipher_bits)
 
 
+    def test_get_protocol_version(self):
+        """
+        :py:obj:`Connection.get_protocol_version` returns a :py:class:`int`
+        giving the protocol version of the current connection.
+        """
+        server, client = self._loopback()
+        server_protocol_version, client_protocol_version = \
+            server.get_protocol_version(), client.get_protocol_version()
+
+        self.assertIsInstance(server_protocol_version, int)
+        self.assertIsInstance(client_protocol_version, int)
+
+        self.assertEqual(server_protocol_version, client_protocol_version)
+
 
 class ConnectionGetCipherListTests(TestCase):
     """

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -2775,6 +2775,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         self.assertEqual(server_protocol_version, client_protocol_version)
 
 
+
 class ConnectionGetCipherListTests(TestCase):
     """
     Tests for :py:obj:`Connection.get_cipher_list`.

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -598,6 +598,11 @@ Connection objects have the following methods:
     but not it returns the entire list in one go.
 
 
+.. py:method:: Connection.get_protocol_version()
+
+    Retrieve the version of the SSL or TLS protocol used by the Connection
+
+
 .. py:method:: Connection.get_client_ca_list()
 
     Retrieve the list of preferred client certificate issuers sent by the server

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -600,7 +600,9 @@ Connection objects have the following methods:
 
 .. py:method:: Connection.get_protocol_version()
 
-    Retrieve the version of the SSL or TLS protocol used by the Connection
+    Retrieve the version of the SSL or TLS protocol used by the Connection.  For
+    example, it will return ``TLSv1`` for connections made over TLS version 1, or 
+    ``Unknown`` for connections that were not successfully established.
 
 
 .. py:method:: Connection.get_client_ca_list()

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -601,9 +601,8 @@ Connection objects have the following methods:
 .. py:method:: Connection.get_protocol_version()
 
     Retrieve the version of the SSL or TLS protocol used by the Connection.
-    For example, it will return ``0x303`` for connections made over TLS
-    version 1.2, or ``Unknown`` for connections that were not successfully
-    established.
+    For example, it will return ``0x769`` for connections made over TLS
+    version 1.
 
 
 .. py:method:: Connection.get_protocol_version_name()

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -607,9 +607,10 @@ Connection objects have the following methods:
 
 .. py:method:: Connection.get_protocol_version_name()
 
-    Retrieve the version of the SSL or TLS protocol used by the Connection.
-    For example, it will return ``TLSv1`` for connections made over TLS version
-    1, or ``Unknown`` for connections that were not successfully established.
+    Retrieve the version of the SSL or TLS protocol used by the Connection as
+    a unicode string. For example, it will return ``TLSv1`` for connections
+    made over TLS version 1, or ``Unknown`` for connections that were not 
+    successfully established.
 
 
 .. py:method:: Connection.get_client_ca_list()

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -608,9 +608,8 @@ Connection objects have the following methods:
 .. py:method:: Connection.get_protocol_version_name()
 
     Retrieve the version of the SSL or TLS protocol used by the Connection.
-    For example, it will return ``TLSv1`` in bytes for connections made over
-    TLS version 1, or ``Unknown`` for connections that were not successfully
-    established.
+    For example, it will return ``TLSv1`` for connections made over TLS version
+    1, or ``Unknown`` for connections that were not successfully established.
 
 
 .. py:method:: Connection.get_client_ca_list()

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -600,9 +600,18 @@ Connection objects have the following methods:
 
 .. py:method:: Connection.get_protocol_version()
 
-    Retrieve the version of the SSL or TLS protocol used by the Connection.  For
-    example, it will return ``TLSv1`` for connections made over TLS version 1, or 
-    ``Unknown`` for connections that were not successfully established.
+    Retrieve the version of the SSL or TLS protocol used by the Connection.
+    For example, it will return ``0x303`` for connections made over TLS
+    version 1.2, or ``Unknown`` for connections that were not successfully
+    established.
+
+
+.. py:method:: Connection.get_protocol_version_name()
+
+    Retrieve the version of the SSL or TLS protocol used by the Connection.
+    For example, it will return ``TLSv1`` in bytes for connections made over
+    TLS version 1, or ``Unknown`` for connections that were not successfully
+    established.
 
 
 .. py:method:: Connection.get_client_ca_list()

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
@@ -96,7 +97,6 @@ setup(
         'Topic :: Security :: Cryptography',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Networking',
-<<<<<<< HEAD
     ],
 
     packages=['OpenSSL'],
@@ -126,14 +126,3 @@ setup(
         "test": PyTest,
     }
 )
-=======
-        ],
-      test_suite="OpenSSL",
-      tests_require=[
-          "pytest",
-      ],
-      cmdclass={
-          "test": PyTest,
-      })
-
->>>>>>> switch to SSL_get_version.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ def find_meta(meta):
     raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
 
 
-<<<<<<< HEAD
 class PyTest(TestCommand):
     user_options = [("pytest-args=", "a", "Arguments to pass to py.test")]
 
@@ -79,41 +78,6 @@ setup(
     url=find_meta("uri"),
     license=find_meta("license"),
     classifiers=[
-=======
-# XXX Deduplicate this
-__version__ = '0.14'
-
-setup(name='pyOpenSSL', version=__version__,
-      packages = ['OpenSSL'],
-      package_dir = {'OpenSSL': 'OpenSSL'},
-      py_modules  = ['OpenSSL.__init__',
-                     'OpenSSL.tsafe',
-                     'OpenSSL.rand',
-                     'OpenSSL.crypto',
-                     'OpenSSL.SSL',
-                     'OpenSSL.version',
-                     'OpenSSL.test.__init__',
-                     'OpenSSL.test.util',
-                     'OpenSSL.test.test_crypto',
-                     'OpenSSL.test.test_rand',
-                     'OpenSSL.test.test_ssl'],
-      description = 'Python wrapper module around the OpenSSL library',
-      author = 'Jean-Paul Calderone',
-      author_email = 'exarkun@twistedmatrix.com',
-      maintainer = 'Jean-Paul Calderone',
-      maintainer_email = 'exarkun@twistedmatrix.com',
-      url = 'https://github.com/pyca/pyopenssl',
-      license = 'APL2',
-      install_requires=["cryptography>=0.7.2", "six>=1.5.2"],
-      long_description = """\
-High-level wrapper around a subset of the OpenSSL library, includes
- * SSL.Connection objects, wrapping the methods of Python's portable
-   sockets
- * Callbacks written in Python
- * Extensive error-handling mechanism, mirroring OpenSSL's error codes
-...  and much more ;)""",
-      classifiers = [
->>>>>>> Add support for querying the negotiated TLS version.
         'Development Status :: 6 - Mature',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
@@ -132,6 +96,7 @@ High-level wrapper around a subset of the OpenSSL library, includes
         'Topic :: Security :: Cryptography',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Networking',
+<<<<<<< HEAD
     ],
 
     packages=['OpenSSL'],
@@ -161,3 +126,14 @@ High-level wrapper around a subset of the OpenSSL library, includes
         "test": PyTest,
     }
 )
+=======
+        ],
+      test_suite="OpenSSL",
+      tests_require=[
+          "pytest",
+      ],
+      cmdclass={
+          "test": PyTest,
+      })
+
+>>>>>>> switch to SSL_get_version.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ def find_meta(meta):
     raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
 
 
+<<<<<<< HEAD
 class PyTest(TestCommand):
     user_options = [("pytest-args=", "a", "Arguments to pass to py.test")]
 
@@ -78,6 +79,41 @@ setup(
     url=find_meta("uri"),
     license=find_meta("license"),
     classifiers=[
+=======
+# XXX Deduplicate this
+__version__ = '0.14'
+
+setup(name='pyOpenSSL', version=__version__,
+      packages = ['OpenSSL'],
+      package_dir = {'OpenSSL': 'OpenSSL'},
+      py_modules  = ['OpenSSL.__init__',
+                     'OpenSSL.tsafe',
+                     'OpenSSL.rand',
+                     'OpenSSL.crypto',
+                     'OpenSSL.SSL',
+                     'OpenSSL.version',
+                     'OpenSSL.test.__init__',
+                     'OpenSSL.test.util',
+                     'OpenSSL.test.test_crypto',
+                     'OpenSSL.test.test_rand',
+                     'OpenSSL.test.test_ssl'],
+      description = 'Python wrapper module around the OpenSSL library',
+      author = 'Jean-Paul Calderone',
+      author_email = 'exarkun@twistedmatrix.com',
+      maintainer = 'Jean-Paul Calderone',
+      maintainer_email = 'exarkun@twistedmatrix.com',
+      url = 'https://github.com/pyca/pyopenssl',
+      license = 'APL2',
+      install_requires=["cryptography>=0.7.2", "six>=1.5.2"],
+      long_description = """\
+High-level wrapper around a subset of the OpenSSL library, includes
+ * SSL.Connection objects, wrapping the methods of Python's portable
+   sockets
+ * Callbacks written in Python
+ * Extensive error-handling mechanism, mirroring OpenSSL's error codes
+...  and much more ;)""",
+      classifiers = [
+>>>>>>> Add support for querying the negotiated TLS version.
         'Development Status :: 6 - Mature',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
This PR hopefully finished up the work done by @richmoore in #184.  Thanks to @alex for helping me figure out how to get SSL_get_version implemented.  This PR requires the merge that happened in pyca/cryptography#1869, so do we wait until the next release of cryptography and then bump the required version number in setup.py?

I'm happy to hear feedback on whether the change to strings requires better/different testing?

Also the [OpenSSL docs](https://www.openssl.org/docs/ssl/SSL_get_version.html) have been updated since the original PR in January, and this does actually support TLS1.1 and TLS1.2 :)