### PR TITLE
Begin making examples Python 3 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__
 doc/_build/
 .coverage
 .eggs
+examples/simple/*.cert
+examples/simple/*.pkey

--- a/examples/certgen.py
+++ b/examples/certgen.py
@@ -45,14 +45,14 @@ def createCertRequest(pkey, digest="md5", **name):
     req = crypto.X509Req()
     subj = req.get_subject()
 
-    for (key,value) in name.items():
+    for (key,value) in list(name.items()):
         setattr(subj, key, value)
 
     req.set_pubkey(pkey)
     req.sign(pkey, digest)
     return req
 
-def createCertificate(req, (issuerCert, issuerKey), serial, (notBefore, notAfter), digest="md5"):
+def createCertificate(req, issuerCertKey, serial, validityPeriod, digest="md5"):
     """
     Generate a certificate given a certificate request.
 
@@ -67,6 +67,8 @@ def createCertificate(req, (issuerCert, issuerKey), serial, (notBefore, notAfter
                digest     - Digest method to use for signing, default is md5
     Returns:   The signed certificate in an X509 object
     """
+    (issuerCert, issuerKey) = issuerCertKey
+    (notBefore, notAfter) = validityPeriod
     cert = crypto.X509()
     cert.set_serial_number(serial)
     cert.gmtime_adj_notBefore(notBefore)

--- a/examples/certgen.py
+++ b/examples/certgen.py
@@ -45,7 +45,7 @@ def createCertRequest(pkey, digest="sha256", **name):
     req = crypto.X509Req()
     subj = req.get_subject()
 
-    for (key,value) in list(name.items()):
+    for key,value in name.items():
         setattr(subj, key, value)
 
     req.set_pubkey(pkey)
@@ -67,8 +67,8 @@ def createCertificate(req, issuerCertKey, serial, validityPeriod, digest="sha256
                digest     - Digest method to use for signing, default is sha256
     Returns:   The signed certificate in an X509 object
     """
-    (issuerCert, issuerKey) = issuerCertKey
-    (notBefore, notAfter) = validityPeriod
+    issuerCert, issuerKey = issuerCertKey
+    notBefore, notAfter = validityPeriod
     cert = crypto.X509()
     cert.set_serial_number(serial)
     cert.gmtime_adj_notBefore(notBefore)

--- a/examples/certgen.py
+++ b/examples/certgen.py
@@ -25,7 +25,7 @@ def createKeyPair(type, bits):
     pkey.generate_key(type, bits)
     return pkey
 
-def createCertRequest(pkey, digest="md5", **name):
+def createCertRequest(pkey, digest="sha256", **name):
     """
     Create a certificate request.
 
@@ -52,7 +52,7 @@ def createCertRequest(pkey, digest="md5", **name):
     req.sign(pkey, digest)
     return req
 
-def createCertificate(req, issuerCertKey, serial, validityPeriod, digest="md5"):
+def createCertificate(req, issuerCertKey, serial, validityPeriod, digest="sha256"):
     """
     Generate a certificate given a certificate request.
 

--- a/examples/certgen.py
+++ b/examples/certgen.py
@@ -45,7 +45,7 @@ def createCertRequest(pkey, digest="sha256", **name):
     req = crypto.X509Req()
     subj = req.get_subject()
 
-    for key,value in name.items():
+    for key, value in name.items():
         setattr(subj, key, value)
 
     req.set_pubkey(pkey)

--- a/examples/certgen.py
+++ b/examples/certgen.py
@@ -30,7 +30,7 @@ def createCertRequest(pkey, digest="sha256", **name):
     Create a certificate request.
 
     Arguments: pkey   - The key to associate with the request
-               digest - Digestion method to use for signing, default is md5
+               digest - Digestion method to use for signing, default is sha256
                **name - The name of the subject of the request, possible
                         arguments are:
                           C     - Country name
@@ -64,7 +64,7 @@ def createCertificate(req, issuerCertKey, serial, validityPeriod, digest="sha256
                             starts being valid
                notAfter   - Timestamp (relative to now) when the certificate
                             stops being valid
-               digest     - Digest method to use for signing, default is md5
+               digest     - Digest method to use for signing, default is sha256
     Returns:   The signed certificate in an X509 object
     """
     (issuerCert, issuerKey) = issuerCertKey

--- a/examples/mk_simple_certs.py
+++ b/examples/mk_simple_certs.py
@@ -7,11 +7,15 @@ from certgen import *   # yes yes, I know, I'm lazy
 cakey = createKeyPair(TYPE_RSA, 1024)
 careq = createCertRequest(cakey, CN='Certificate Authority')
 cacert = createCertificate(careq, (careq, cakey), 0, (0, 60*60*24*365*5)) # five years
-open('simple/CA.pkey', 'w').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, cakey))
-open('simple/CA.cert', 'w').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cacert))
+open('simple/CA.pkey', 'w').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, cakey).decode('utf-8')
+)
+open('simple/CA.cert', 'w').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cacert).decode('utf-8')
+)
 for (fname, cname) in [('client', 'Simple Client'), ('server', 'Simple Server')]:
     pkey = createKeyPair(TYPE_RSA, 1024)
     req = createCertRequest(pkey, CN=cname)
     cert = createCertificate(req, (cacert, cakey), 1, (0, 60*60*24*365*5)) # five years
-    open('simple/%s.pkey' % (fname,), 'w').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey))
-    open('simple/%s.cert' % (fname,), 'w').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+    open('simple/%s.pkey' % (fname,), 'w').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey).decode('utf-8')
+)
+    open('simple/%s.cert' % (fname,), 'w').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode('utf-8')
+)

--- a/examples/mk_simple_certs.py
+++ b/examples/mk_simple_certs.py
@@ -9,9 +9,11 @@ careq = createCertRequest(cakey, CN='Certificate Authority')
 cacert = createCertificate(careq, (careq, cakey), 0, (0, 60*60*24*365*5)) # five years
 
 print('Creating Certificate Authority private key in "simple/CA.pkey"')
-open('simple/CA.pkey', 'w').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, cakey).decode('utf-8'))
+with open('simple/CA.pkey', 'w') as capkey:
+    capkey.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, cakey).decode('utf-8'))
 print('Creating Certificate Authority certificate in "simple/CA.cert"')
-open('simple/CA.cert', 'w').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cacert).decode('utf-8'))
+with open('simple/CA.cert', 'w') as ca:
+    ca.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cacert).decode('utf-8'))
 
 for (fname, cname) in [('client', 'Simple Client'), ('server', 'Simple Server')]:
     pkey = createKeyPair(TYPE_RSA, 2048)
@@ -19,6 +21,9 @@ for (fname, cname) in [('client', 'Simple Client'), ('server', 'Simple Server')]
     cert = createCertificate(req, (cacert, cakey), 1, (0, 60*60*24*365*5)) # five years
 
     print('Creating Certificate %s private key in "simple/%s.pkey"' % (fname, fname))
-    open('simple/%s.pkey' % (fname,), 'w').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey).decode('utf-8'))
+    with open('simple/%s.pkey' % (fname,), 'w') as leafpkey:
+        leafpkey.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey).decode('utf-8'))
     print('Creating Certificate %s certificate in "simple/%s.cert"' % (fname, fname))
-    open('simple/%s.cert' % (fname,), 'w').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode('utf-8'))
+    with open('simple/%s.cert' % (fname,), 'w') as leafcert:
+        leafcert.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode('utf-8'))
+

--- a/examples/mk_simple_certs.py
+++ b/examples/mk_simple_certs.py
@@ -19,7 +19,6 @@ for (fname, cname) in [('client', 'Simple Client'), ('server', 'Simple Server')]
     pkey = createKeyPair(TYPE_RSA, 2048)
     req = createCertRequest(pkey, CN=cname)
     cert = createCertificate(req, (cacert, cakey), 1, (0, 60*60*24*365*5)) # five years
-
     print('Creating Certificate %s private key in "simple/%s.pkey"' % (fname, fname))
     with open('simple/%s.pkey' % (fname,), 'w') as leafpkey:
         leafpkey.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey).decode('utf-8'))

--- a/examples/simple/client.py
+++ b/examples/simple/client.py
@@ -17,7 +17,7 @@ def verify_cb(conn, cert, errnum, depth, ok):
     return ok
 
 if len(sys.argv) < 3:
-    print('Usage: python[2] client.py HOST PORT')
+    print('Usage: python client.py HOST PORT')
     sys.exit(1)
 
 dir = os.path.dirname(sys.argv[0])

--- a/examples/simple/client.py
+++ b/examples/simple/client.py
@@ -13,11 +13,11 @@ import sys, os, select, socket
 
 def verify_cb(conn, cert, errnum, depth, ok):
     # This obviously has to be updated
-    print 'Got certificate: %s' % cert.get_subject()
+    print('Got certificate: %s' % cert.get_subject())
     return ok
 
 if len(sys.argv) < 3:
-    print 'Usage: python[2] client.py HOST PORT'
+    print('Usage: python[2] client.py HOST PORT')
     sys.exit(1)
 
 dir = os.path.dirname(sys.argv[0])
@@ -44,7 +44,7 @@ while 1:
         sys.stdout.write(sock.recv(1024))
         sys.stdout.flush()
     except SSL.Error:
-        print 'Connection died unexpectedly'
+        print('Connection died unexpectedly')
         break
 
 

--- a/examples/simple/client.py
+++ b/examples/simple/client.py
@@ -12,7 +12,6 @@ from OpenSSL import SSL, crypto
 import sys, os, select, socket
 
 def verify_cb(conn, cert, errnum, depth, ok):
-    # This obviously has to be updated
     certsubject = crypto.X509Name(cert.get_subject())
     commonname = certsubject.commonName
     print('Got certificate: ' + commonname)

--- a/examples/simple/client.py
+++ b/examples/simple/client.py
@@ -8,12 +8,14 @@
 Simple SSL client, using blocking I/O
 """
 
-from OpenSSL import SSL
+from OpenSSL import SSL, crypto
 import sys, os, select, socket
 
 def verify_cb(conn, cert, errnum, depth, ok):
     # This obviously has to be updated
-    print('Got certificate: %s' % cert.get_subject())
+    certsubject = crypto.X509Name(cert.get_subject())
+    commonname = certsubject.commonName
+    print('Got certificate: ' + commonname)
     return ok
 
 if len(sys.argv) < 3:
@@ -41,7 +43,7 @@ while 1:
         break
     try:
         sock.send(line)
-        sys.stdout.write(sock.recv(1024))
+        sys.stdout.write(sock.recv(1024).decode('utf-8'))
         sys.stdout.flush()
     except SSL.Error:
         print('Connection died unexpectedly')

--- a/examples/simple/server.py
+++ b/examples/simple/server.py
@@ -14,11 +14,11 @@ import sys, os, select, socket
 
 def verify_cb(conn, cert, errnum, depth, ok):
     # This obviously has to be updated
-    print 'Got certificate: %s' % cert.get_subject()
+    print('Got certificate: %s' % cert.get_subject())
     return ok
 
 if len(sys.argv) < 2:
-    print 'Usage: python[2] server.py PORT'
+    print('Usage: python[2] server.py PORT')
     sys.exit(1)
 
 dir = os.path.dirname(sys.argv[0])
@@ -44,12 +44,12 @@ writers = {}
 
 def dropClient(cli, errors=None):
     if errors:
-        print 'Client %s left unexpectedly:' % (clients[cli],)
-        print '  ', errors
+        print('Client %s left unexpectedly:' % (clients[cli],))
+        print('  ', errors)
     else:
-        print 'Client %s left politely' % (clients[cli],)
+        print('Client %s left politely' % (clients[cli],))
     del clients[cli]
-    if writers.has_key(cli):
+    if cli in writers:
         del writers[cli]
     if not errors:
         cli.shutdown()
@@ -57,14 +57,14 @@ def dropClient(cli, errors=None):
 
 while 1:
     try:
-        r,w,_ = select.select([server]+clients.keys(), writers.keys(), [])
+        r,w,_ = select.select([server]+list(clients.keys()), list(writers.keys()), [])
     except:
         break
 
     for cli in r:
         if cli == server:
             cli,addr = server.accept()
-            print 'Connection from %s' % (addr,)
+            print('Connection from %s' % (addr,))
             clients[cli] = addr
 
         else:
@@ -74,10 +74,10 @@ while 1:
                 pass
             except SSL.ZeroReturnError:
                 dropClient(cli)
-            except SSL.Error, errors:
+            except SSL.Error as errors:
                 dropClient(cli, errors)
             else:
-                if not writers.has_key(cli):
+                if cli not in writers:
                     writers[cli] = ''
                 writers[cli] = writers[cli] + ret
 
@@ -88,13 +88,13 @@ while 1:
             pass
         except SSL.ZeroReturnError:
             dropClient(cli)
-        except SSL.Error, errors:
+        except SSL.Error as errors:
             dropClient(cli, errors)
         else:
             writers[cli] = writers[cli][ret:]
             if writers[cli] == '':
                 del writers[cli]
 
-for cli in clients.keys():
+for cli in list(clients.keys()):
     cli.close()
 server.close()

--- a/examples/simple/server.py
+++ b/examples/simple/server.py
@@ -95,6 +95,6 @@ while 1:
             if writers[cli] == '':
                 del writers[cli]
 
-for cli in list(clients.keys()):
+for cli in clients.keys():
     cli.close()
 server.close()

--- a/examples/simple/server.py
+++ b/examples/simple/server.py
@@ -13,7 +13,6 @@ import sys, os, select, socket
 
 
 def verify_cb(conn, cert, errnum, depth, ok):
-    # This obviously has to be updated
     certsubject = crypto.X509Name(cert.get_subject())
     commonname = certsubject.commonName
     print(('Got certificate: ' + commonname))

--- a/examples/simple/server.py
+++ b/examples/simple/server.py
@@ -57,7 +57,7 @@ def dropClient(cli, errors=None):
 
 while 1:
     try:
-        r,w,_ = select.select([server]+list(clients.keys()), list(writers.keys()), [])
+        r, w, _ = select.select([server]+clients.keys(), writers.keys(), [])
     except:
         break
 

--- a/examples/simple/server.py
+++ b/examples/simple/server.py
@@ -18,7 +18,7 @@ def verify_cb(conn, cert, errnum, depth, ok):
     return ok
 
 if len(sys.argv) < 2:
-    print('Usage: python[2] server.py PORT')
+    print('Usage: python server.py PORT')
     sys.exit(1)
 
 dir = os.path.dirname(sys.argv[0])


### PR DESCRIPTION
This PR makes a few of the examples work under Python 3 in addition to Python 2.  I ran some tests under 2.7.8 and 3.4.2.

I also found a couple of md5s being used during signing in certgen.py, I'm proposing that they be bumped up to SHA-256.