### PR TITLE
Add del_extension needed by Zorp

### DIFF
--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -1340,6 +1340,19 @@ class X509(object):
         extension = _lib.X509_EXTENSION_dup(ext._extension)
         ext._extension = _ffi.gc(extension, _lib.X509_EXTENSION_free)
         return ext
+        
+    def del_extension(self, index):
+        """
+        Delete a specific extension of the certificate by index.
+
+        :param index: The index of the extension to delete.
+        :return: The X509Extension object deleted at the specified index.
+        """
+        ext = X509Extension.__new__(X509Extension)
+        ext._extension = _lib.X509_delete_ext(self._x509, index)
+        if ext._extension == _ffi.NULL:
+            raise IndexError("extension index out of bounds")
+        return ext
 
 X509Type = X509
 


### PR DESCRIPTION
[Balabit Zorp](https://github.com/balabit/zorp) application level firewall [relies on the del_extension function](https://github.com/balabit/zorp/blob/master/pylib/Zorp/Keybridge.py#L350) to remove attributes like CRL pathes from the mimicked  certificates when doing man-in-the-middle traffic filtering.

Also needs the ffi lib (python-cryptograpy at hazmat/bindings/openssl/x509.py) to have the definition of:

``` c
X509_EXTENSION *X509_delete_ext(X509 *, int);
```
