### PR TITLE
Dedup meta data, use README as long_description

### DIFF
--- a/OpenSSL/__init__.py
+++ b/OpenSSL/__init__.py
@@ -6,7 +6,16 @@ pyOpenSSL - A simple wrapper around the OpenSSL library
 """
 
 from OpenSSL import rand, crypto, SSL
-from OpenSSL.version import __version__
+from OpenSSL.version import (
+    __author__, __copyright__, __email__, __license__, __summary__, __title__,
+    __uri__, __version__,
+)
+
+
 
 __all__ = [
-    'rand', 'crypto', 'SSL', 'tsafe', '__version__']
+    "SSL", "crypto", "rand", "tsafe",
+
+    "__author__", "__copyright__", "__email__", "__license__", "__summary__",
+    "__title__", "__uri__", "__version__",
+]

--- a/OpenSSL/version.py
+++ b/OpenSSL/version.py
@@ -11,7 +11,7 @@ __all__ = [
     "__title__", "__uri__", "__version__",
 ]
 
-__version__ = "0.15.1"
+__version__ = "0.16.dev0"
 
 __title__ = "pyOpenSSL"
 __uri__ = "https://github.com/pyca/pyopenssl"

--- a/OpenSSL/version.py
+++ b/OpenSSL/version.py
@@ -6,4 +6,17 @@
 pyOpenSSL - A simple wrapper around the OpenSSL library
 """
 
-__version__ = '0.15.1'
+__all__ = [
+    "__author__", "__copyright__", "__email__", "__license__", "__summary__",
+    "__title__", "__uri__", "__version__",
+]
+
+__version__ = "0.15.1"
+
+__title__ = "pyOpenSSL"
+__uri__ = "https://github.com/pyca/pyopenssl"
+__summary__ = "Python wrapper module around the OpenSSL library"
+__author__ = "The pyOpenSSL developers"
+__email__ = "cryptography-dev@python.org"
+__license__ = "Apache License, Version 2.0"
+__copyright__ = "Copyright 2001-2015 {0}".format(__author__)

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,5 @@
-
-pyOpenSSL - A Python wrapper around the OpenSSL library
--------------------------------------------------------
+pyOpenSSL -- A Python wrapper around the OpenSSL library
+--------------------------------------------------------
 
 .. image:: https://coveralls.io/repos/pyca/pyopenssl/badge.svg
   :target: https://coveralls.io/r/pyca/pyopenssl
@@ -11,6 +10,15 @@ pyOpenSSL - A Python wrapper around the OpenSSL library
 
 .. image:: https://travis-ci.org/pyca/pyopenssl.svg?branch=master
     :target: https://travis-ci.org/pyca/pyopenssl
+
+
+High-level wrapper around a subset of the OpenSSL library.  Includes
+
+* SSL.Connection objects, wrapping the methods of Python's portable sockets
+* Callbacks written in Python
+* Extensive error-handling mechanism, mirroring OpenSSL's error codes
+
+... and much more.
 
 See the file INSTALL.rst for installation instructions.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,33 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import datetime
+import codecs
+import os
+import re
+import sys
+
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def read_file(*parts):
+    """
+    Build an absolute path from *parts* and and return the contents of the
+    resulting file.  Assume UTF-8 encoding.
+    """
+    with codecs.open(os.path.join(HERE, *parts), "rb", "ascii") as f:
+        return f.read()
+
+
+def find_version(*file_paths):
+    version_file = read_file(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 
 DOC_DIR = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.abspath(os.path.join(DOC_DIR, "..")))
@@ -44,14 +70,15 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'pyOpenSSL'
-copyright = u'2011, Jean-Paul Calderone'
+authors = u"The pyOpenSSL developers"
+copyright = u"2001-{0}, {1}".format(datetime.date.today().year, authors)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 # The short X.Y version.
-version = '0.15.1'
+version = find_version("../OpenSSL/version.py")
 # The full version, including alpha/beta/rc tags.
 release = version
 
@@ -182,7 +209,7 @@ htmlhelp_basename = 'pyOpenSSLdoc'
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
   ('index', 'pyOpenSSL.tex', u'pyOpenSSL Documentation',
-   u'Jean-Paul Calderone', 'manual'),
+   authors, 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -215,5 +242,5 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'pyopenssl', u'pyOpenSSL Documentation',
-     [u'Jean-Paul Calderone'], 1)
+     [authors], 1)
 ]

--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,45 @@
 #
 
 """
-Installation script for the OpenSSL module
+Installation script for the OpenSSL module.
 """
 
+import codecs
+import os
+import re
 import sys
 
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 
-# XXX Deduplicate this
-__version__ = '0.15.1'
+HERE = os.path.abspath(os.path.dirname(__file__))
+META_PATH = os.path.join("OpenSSL", "version.py")
+
+
+def read_file(*parts):
+    """
+    Build an absolute path from *parts* and and return the contents of the
+    resulting file.  Assume UTF-8 encoding.
+    """
+    with codecs.open(os.path.join(HERE, *parts), "rb", "ascii") as f:
+        return f.read()
+
+
+META_FILE = read_file(META_PATH)
+
+
+def find_meta(meta):
+    """
+    Extract __*meta*__ from META_FILE.
+    """
+    meta_match = re.search(
+        r"^__{meta}__ = ['\"]([^'\"]*)['\"]".format(meta=meta),
+        META_FILE, re.M
+    )
+    if meta_match:
+        return meta_match.group(1)
+    raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
 
 
 class PyTest(TestCommand):
@@ -38,38 +66,18 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
-setup(name='pyOpenSSL', version=__version__,
-      packages = ['OpenSSL'],
-      package_dir = {'OpenSSL': 'OpenSSL'},
-      py_modules  = ['OpenSSL.__init__',
-                     'OpenSSL.tsafe',
-                     'OpenSSL.rand',
-                     'OpenSSL.crypto',
-                     'OpenSSL.SSL',
-                     'OpenSSL.version',
-                     'OpenSSL.test.__init__',
-                     'OpenSSL.test.util',
-                     'OpenSSL.test.test_crypto',
-                     'OpenSSL.test.test_rand',
-                     'OpenSSL.test.test_ssl',
-                     'OpenSSL.test.test_tsafe',
-                     'OpenSSL.test.test_util',],
-      description = 'Python wrapper module around the OpenSSL library',
-      author = 'Jean-Paul Calderone',
-      author_email = 'exarkun@twistedmatrix.com',
-      maintainer = 'Jean-Paul Calderone',
-      maintainer_email = 'exarkun@twistedmatrix.com',
-      url = 'https://github.com/pyca/pyopenssl',
-      license = 'APL2',
-      install_requires=["cryptography>=0.7", "six>=1.5.2"],
-      long_description = """\
-High-level wrapper around a subset of the OpenSSL library, includes
- * SSL.Connection objects, wrapping the methods of Python's portable
-   sockets
- * Callbacks written in Python
- * Extensive error-handling mechanism, mirroring OpenSSL's error codes
-...  and much more ;)""",
-      classifiers = [
+setup(
+    name=find_meta("title"),
+    version=find_meta("version"),
+    description=find_meta("summary"),
+    long_description=read_file("README.rst"),
+    author=find_meta("author"),
+    author_email=find_meta("email"),
+    maintainer="Hynek Schlawack",
+    maintainer_email="hs@ox.cx",
+    url=find_meta("uri"),
+    license=find_meta("license"),
+    classifiers=[
         'Development Status :: 6 - Mature',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
@@ -77,19 +85,10 @@ High-level wrapper around a subset of the OpenSSL library, includes
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
 
-        # General classifiers to indicate "this project supports Python 2" and
-        # "this project supports Python 3".
         'Programming Language :: Python :: 2',
-        # In particular, this makes pyOpenSSL show up on
-        # https://pypi.python.org/pypi?:action=browse&c=533&show=all and is in
-        # accordance with
-        # http://docs.python.org/2/howto/pyporting.html#universal-bits-of-advice
-        'Programming Language :: Python :: 3',
-
-        # More specific classifiers to indicate more precisely which versions
-        # of those languages the project supports.
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
 
@@ -98,11 +97,32 @@ High-level wrapper around a subset of the OpenSSL library, includes
         'Topic :: Security :: Cryptography',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Networking',
-        ],
-      test_suite="OpenSSL",
-      tests_require=[
-          "pytest",
-      ],
-      cmdclass={
-          "test": PyTest,
-      })
+    ],
+
+    packages=['OpenSSL'],
+    package_dir={'OpenSSL': 'OpenSSL'},
+    py_modules=['OpenSSL.__init__',
+                'OpenSSL.tsafe',
+                'OpenSSL.rand',
+                'OpenSSL.crypto',
+                'OpenSSL.SSL',
+                'OpenSSL.version',
+                'OpenSSL.test.__init__',
+                'OpenSSL.test.util',
+                'OpenSSL.test.test_crypto',
+                'OpenSSL.test.test_rand',
+                'OpenSSL.test.test_ssl',
+                'OpenSSL.test.test_tsafe',
+                'OpenSSL.test.test_util',],
+    install_requires=[
+        "cryptography>=0.7",
+        "six>=1.5.2"
+    ],
+    test_suite="OpenSSL",
+    tests_require=[
+        "pytest",
+    ],
+    cmdclass={
+        "test": PyTest,
+    }
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {pypy,py26,py27,py32,py33,py34}{,-cryptographyMaster}
+envlist = {pypy,py26,py27,py32,py33,py34}{,-cryptographyMaster},pypi-readme
 
 [testenv]
 deps =
@@ -15,3 +15,9 @@ commands =
     python -c "import cryptography; print(cryptography.__version__)"
     coverage run --branch --source=OpenSSL setup.py test
     coverage report -m
+
+[testenv:pypi-readme]
+deps =
+    readme
+commands =
+    python setup.py check -r -s


### PR DESCRIPTION
I’ve moved all the relevant meta data into OpenSSL/version.py (and __init__.py; basically cryptography-style) and extract it from there in setup.py and the Sphinx conf.py.

Fixes #247 

Opinions?