### PR TITLE
Remove support for Python 3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,3 @@ __pycache__
 doc/_build/
 .coverage
 .eggs
-examples/simple/*.cert
-examples/simple/*.pkey

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__
 doc/_build/
 .coverage
 .eggs
+examples/simple/*.cert
+examples/simple/*.pkey

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,19 +56,11 @@ matrix:
   - language: generic
     os: osx
     env: TOXENV=py27
-<<<<<<< HEAD
   - env: TOXENV=py26-cryptographyMaster
   - env: TOXENV=py27-cryptographyMaster
   - env: TOXENV=py33-cryptographyMaster
   - env: TOXENV=py34-cryptographyMaster
   - env: TOXENV=pypy-cryptographyMaster
-=======
-  - env: CRYPTOGRAPHY_GIT_MASTER=true TOXENV=py26
-  - env: CRYPTOGRAPHY_GIT_MASTER=true TOXENV=py27
-  - env: CRYPTOGRAPHY_GIT_MASTER=true TOXENV=py33
-  - env: CRYPTOGRAPHY_GIT_MASTER=true TOXENV=py34
-  - env: CRYPTOGRAPHY_GIT_MASTER=true TOXENV=pypy
->>>>>>> e667f0a8af5717d82671c406fc55621f4010301e
   - env: OPENSSL=0.9.8 TOXENV=py27
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
     env: TOXENV=py26
   - python: "2.7"
     env: TOXENV=py27
-  - python: "3.2"
-    env: TOXENV=py32
   - python: "3.3"
     env: TOXENV=py33
   - python: "3.4"
@@ -24,8 +22,6 @@ matrix:
     env: TOXENV=py26-cryptographyMaster
   - python: "2.7"
     env: TOXENV=py27-cryptographyMaster
-  - python: "3.2"
-    env: TOXENV=py32-cryptographyMaster
   - python: "3.3"
     env: TOXENV=py33-cryptographyMaster
   - python: "3.4"
@@ -62,7 +58,6 @@ matrix:
     env: TOXENV=py27
   - env: TOXENV=py26-cryptographyMaster
   - env: TOXENV=py27-cryptographyMaster
-  - env: TOXENV=py32-cryptographyMaster
   - env: TOXENV=py33-cryptographyMaster
   - env: TOXENV=py34-cryptographyMaster
   - env: TOXENV=pypy-cryptographyMaster

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-05-02  Jim Shaver <dcypherd@gmail.com>
+
+	* .travis.yml, setup.py, tox.ini: Removed support for Python 3.2.
+	  This version is rarely used and is now depricated by a major
+	  dependency of pyOpenSSL(cryptography). Affected users should upgrade
+	  to Python 3.3+.
+
 2015-04-15  Paul Kehrer <paul.l.kehrer@gmail.com>
 
 	* OpenSSL/crypto.py, OpenSSL/test/test_crypto.py: Switch to utf8string

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@
 
 	* .travis.yml, setup.py, tox.ini: Removed support for Python 3.2.
 	  This version is rarely used and is now deprecated by a major
-	  dependency of pyOpenSSL(cryptography). Affected users should upgrade
+	  dependency of pyOpenSSL (cryptography).  Affected users should upgrade
 	  to Python 3.3+.
 
 2015-04-15  Paul Kehrer <paul.l.kehrer@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2015-05-02  Jim Shaver <dcypherd@gmail.com>
 
 	* .travis.yml, setup.py, tox.ini: Removed support for Python 3.2.
-	  This version is rarely used and is now depricated by a major
+	  This version is rarely used and is now deprecated by a major
 	  dependency of pyOpenSSL(cryptography). Affected users should upgrade
 	  to Python 3.3+.
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
 
         'Programming Language :: Python :: Implementation :: CPython',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {pypy,py26,py27,py32,py33,py34}{,-cryptographyMaster},pypi-readme,check-manifest
+envlist = {pypy,py26,py27,py33,py34}{,-cryptographyMaster},pypi-readme,check-manifest
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {pypy,py26,py33,py34}{,-cryptographyMaster},pypi-readme,check-manifest
+envlist = {pypy,py26,py27,py33,py34}{,-cryptographyMaster},pypi-readme,check-manifest
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR removes Python 3.2 as @hynek  requested in #241 due to cryptography's deprecation of it in pyca/cryptography#1846.  I did some grepping to see if 3.2 was referenced in the docs(or elsewhere) but didn't see anything.  Let me know if there are any other likely locations.

Only loosely related, is there any reason why we test against 3.4 in tox and travis but don't have it listed in setup.py?  Oversight?