### PR TITLE
Kill stale todo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,14 @@ matrix:
         packages:
           - libssl-dev/lucid
 
+  # Meta
+  - python: "2.7"
+    env: TOXENV=check-manifest
+
+  - python: "2.7"
+    env: TOXENV=pypi-readme
+
+
   # Let the cryptography master builds fail because they might be triggered by
   # cryptography changes beyond our control.
   # Also allow OS X and 0.9.8 to fail at the moment while we fix these new

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,7 @@
-include     LICENSE ChangeLog TODO MANIFEST.in OpenSSL/RATIONALE *.rst tox.ini memdbg.py runtests.py OpenSSL/test/README
-exclude leakcheck
+include             LICENSE ChangeLog MANIFEST.in *.rst tox.ini memdbg.py runtests.py OpenSSL/test/README
+exclude             leakcheck
 recursive-include   doc         *
 recursive-include   examples    *
 recursive-include   rpm         *
 recursive-exclude   leakcheck   *.py *.pem
-global-exclude  *.pyc
 prune               doc/_build

--- a/TODO
+++ b/TODO
@@ -1,8 +1,0 @@
-TODO list
-
-* Think more carefully about the relation between X509 and X509_NAME
-  _set_{subject,issuer} dup the new name and free the old one.
-* Consider Pyrex
-* Updated docs! (rpm, ...)
-* _Somehow_ get makefile to work!
-* httpslib, imapslib, ftpslib?

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {pypy,py26,py27,py32,py33,py34}{,-cryptographyMaster},pypi-readme
+envlist = {pypy,py26,py27,py32,py33,py34}{,-cryptographyMaster},pypi-readme,check-manifest
 
 [testenv]
 deps =
@@ -21,3 +21,9 @@ deps =
     readme
 commands =
     python setup.py check -r -s
+
+[testenv:check-manifest]
+deps =
+    check-manifest
+commands =
+    check-manifest


### PR DESCRIPTION
The TODO is hopelessly outdated.

Since I’ve touched the MANIFEST.in I’ve also added a check to CI.

And while adding it to Travis I’ve noticed that we don’t run pypi-readme so I’ve added it as well.