### PR TITLE
Allow for using the raw OpenSSL verify callback

### DIFF
--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -785,7 +785,12 @@ class Context(object):
 
     def set_raw_verify(self, mode, callback):
         """
-        Set the verify mode and verify callback
+        Set the verify mode and verify callback. Unlike set_verify, this method
+        does not provide you with any extra help to pull out useful features:
+        you are exposed directly to OpenSSL objects and functions.
+
+        This is an advanced function, and should almost never be used: instead,
+        use set_verify.
 
         :param mode: The verify mode, this is either VERIFY_NONE or
                      VERIFY_PEER combined with possible other flags

--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -231,7 +231,7 @@ class _VerifyHelper(_CallbackExceptionHelper):
             "int (*)(int, X509_STORE_CTX *)", wrapper)
 
 
-class _ExplicitVerifyHelper(_CallbackExceptionHelper):
+class _RawVerifyHelper(_CallbackExceptionHelper):
     """
     Wrap a callback such that it can be used as a certificate verification
     callback without the extra wrapping of ``_VerifyHelper``.
@@ -783,7 +783,7 @@ class Context(object):
         _lib.SSL_CTX_set_verify(self._context, mode, self._verify_callback)
 
 
-    def set_explicit_verify(self, mode, callback):
+    def set_raw_verify(self, mode, callback):
         """
         Set the verify mode and verify callback
 
@@ -800,7 +800,7 @@ class Context(object):
         if not callable(callback):
             raise TypeError("callback must be callable")
 
-        self._verify_helper = _ExplicitVerifyHelper(callback)
+        self._verify_helper = _RawVerifyHelper(callback)
         self._verify_callback = self._verify_helper.callback
         _lib.SSL_CTX_set_verify(self._context, mode, self._verify_callback)
 

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -2017,11 +2017,11 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
 
 
 
-class ExplicitVerifyTests(TestCase, _LoopbackMixin):
+class RawVerifyTests(TestCase, _LoopbackMixin):
     """
-    Unit tests for the explicit verification helper.
+    Unit tests for the raw verification helper.
     """
-    def test_explicit_verify_success(self):
+    def test_raw_verify_success(self):
         """
         Test that returning True from the verify helper allows verification to
         succeed.
@@ -2041,7 +2041,7 @@ class ExplicitVerifyTests(TestCase, _LoopbackMixin):
 
         # Create the client
         clientContext = Context(TLSv1_METHOD)
-        clientContext.set_explicit_verify(VERIFY_PEER, verify)
+        clientContext.set_raw_verify(VERIFY_PEER, verify)
         client = Connection(clientContext, None)
         client.set_connect_state()
 
@@ -2053,7 +2053,7 @@ class ExplicitVerifyTests(TestCase, _LoopbackMixin):
         self.assertEqual(client, call_args[0][0])
 
 
-    def test_explicit_verify_fail(self):
+    def test_raw_verify_fail(self):
         """
         Returning False from the verify helper destroys the connection.
         """
@@ -2072,7 +2072,7 @@ class ExplicitVerifyTests(TestCase, _LoopbackMixin):
 
         # Create the client
         clientContext = Context(TLSv1_METHOD)
-        clientContext.set_explicit_verify(VERIFY_PEER, verify)
+        clientContext.set_raw_verify(VERIFY_PEER, verify)
         client = Connection(clientContext, None)
         client.set_connect_state()
 
@@ -2082,7 +2082,7 @@ class ExplicitVerifyTests(TestCase, _LoopbackMixin):
         self.assertEqual(len(call_args), 1)
 
 
-    def test_explicit_verify_exception(self):
+    def test_raw_verify_exception(self):
         """
         Throwing exceptions from the verify helper destroys the connection.
         """
@@ -2100,7 +2100,7 @@ class ExplicitVerifyTests(TestCase, _LoopbackMixin):
 
         # Create the client
         clientContext = Context(TLSv1_METHOD)
-        clientContext.set_explicit_verify(VERIFY_PEER, verify)
+        clientContext.set_raw_verify(VERIFY_PEER, verify)
         client = Connection(clientContext, None)
         client.set_connect_state()
 

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -421,6 +421,26 @@ Context objects have the following methods:
     and false otherwise.
 
 
+.. py:method:: Context.set_raw_verify(mode, callback)
+
+    A version of :py:meth:`set_verify` that provides OpenSSL objects directly
+    to *callback*, rather than unwrapping them. This is an expert-level
+    function and should only be used when you know what you're doing: in almost
+    all cases prefer :py:meth:`set_verify`.
+
+    Set the verification flags for this Context object to *mode* and specify
+    that *callback* should be used for verification callbacks. *mode* should be
+    one of :py:const:`VERIFY_NONE` and :py:const:`VERIFY_PEER`. If
+    :py:const:`VERIFY_PEER` is used, *mode* can be OR:ed with
+    :py:const:`VERIFY_FAIL_IF_NO_PEER_CERT` and :py:const:`VERIFY_CLIENT_ONCE`
+    to further control the behaviour.
+
+    *callback* should take two arguments: A Connection object, and an OpenSSL
+    X509 Store Context object. This second object can only be manipulated using
+    functions provided by the ``cryptography`` project. *callback* should
+    return true if verification passes and false otherwise.
+
+
 .. py:method:: Context.set_verify_depth(depth)
 
     Set the maximum depth for the certificate chain verification that shall be


### PR DESCRIPTION
PyOpenSSL has the ability to set the verify callback, but it tries to be all 'helpful' and 'user friendly' and all that hippy crap, so it hides the terrible OpenSSL nonsense from me.

Sadly, for shazow/urllib3#607 I need access to the X509_STORE_CTX that PyOpenSSL is hiding. This patch allows me to set a _different_ verify callback that does that.

This is only a proposed API, I'm not wedded to it at all, so feedback on the API and naming is totally welcomed.
