### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: python
+env:
+  global:
+    - LC_ALL=en_US.UTF-8
 
 matrix:
   include:

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist = {pypy,py26,py27,py33,py34}{,-cryptographyMaster},pypi-readme,check-manifest
 
 [testenv]
+passenv =
+    LC_ALL
 deps =
     setuptools>=7.0  # older setuptools pollute CWD with egg files of dependencies
     coverage


### PR DESCRIPTION
`sys.getfilesystemencoding()` seems to be returning `ascii` now which breaks all builds.