### PR TITLE
Ensure OpenSSL CLI matches lib on homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ script:
       export ARCHFLAGS="-arch x86_64"
       export LDFLAGS="-L/usr/local/opt/openssl/lib"
       export CFLAGS="-I/usr/local/opt/openssl/include"
-      export PATH="/usr/local/opt/openssl/bin"
+      export PATH="/usr/local/opt/openssl/bin:$PATH"
     fi
     ~/.venv/bin/tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,7 @@ script:
       export ARCHFLAGS="-arch x86_64"
       export LDFLAGS="-L/usr/local/opt/openssl/lib"
       export CFLAGS="-I/usr/local/opt/openssl/include"
+      export PATH="/usr/local/opt/openssl/bin"
     fi
     ~/.venv/bin/tox
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = {pypy,py26,py27,py33,py34}{,-cryptographyMaster},pypi-readme,check-manifest
 
 [testenv]
-passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS
+passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH
 deps =
     setuptools>=7.0  # older setuptools pollute CWD with egg files of dependencies
     coverage
@@ -12,6 +12,7 @@ setenv =
     # with extra packages.
     PYTHONPATH=
 commands =
+    openssl version
     python -c "import OpenSSL.SSL; print(OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION))"
     python -c "import cryptography; print(cryptography.__version__)"
     coverage run --branch --source=OpenSSL setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist = {pypy,py26,py27,py33,py34}{,-cryptographyMaster},pypi-readme,check-manifest
 
 [testenv]
+whitelist_externals =
+    openssl
 passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH
 deps =
     setuptools>=7.0  # older setuptools pollute CWD with egg files of dependencies


### PR DESCRIPTION
Some of the test failures might be caused by just the CLI version mismatch.

cf. https://github.com/pyca/pyopenssl/issues/239#issuecomment-102052023