### PR TITLE
Expose some CRL attributes (#181)

### DIFF
--- a/OpenSSL/crypto.py
+++ b/OpenSSL/crypto.py
@@ -2081,6 +2081,80 @@ class CRL(object):
             _raise_current_error()
 
         return _bio_to_string(bio)
+
+
+    def get_issuer(self):
+        """
+        Return the issuer of this CRL.
+
+        :return: A :py:class:`X509Name` object.
+        """
+        name = X509Name.__new__(X509Name)
+        name._name = _lib.X509_CRL_get_issuer(self._crl)
+        if name._name == _ffi.NULL:
+            # TODO: This is untested.
+            _raise_current_error()
+
+        # The name is owned by the CA structure.  As long as the X509Name
+        # Python object is alive, keep the CA Python object alive.
+        name._owner = self
+
+        return name
+
+
+    def get_last_update(self):
+        """
+        Return the last update timestamp of this CRL.
+
+        :return: :py:data:`bytes` in some format, or :py:const:`None`.
+        """
+        tstamp = _lib.X509_CRL_get_lastUpdate(self._crl)
+        if tstamp == _ffi.NULL:
+            return None
+        return _get_asn1_time(tstamp)
+
+
+    def get_next_update(self):
+        """
+        Return the next update timestamp of this CRL.
+
+        :return: :py:data:`bytes` in some format, or :py:const:`None`.
+        """
+        tstamp = _lib.X509_CRL_get_nextUpdate(self._crl)
+        if tstamp == _ffi.NULL:
+            return None
+        return _get_asn1_time(tstamp)
+
+
+    def get_version(self):
+        """
+        Return the version number of this CRL.
+
+        :return: An :py:data:`int`.
+        """
+        return _lib.X509_CRL_get_version(self._crl)
+
+
+    def get_extensions(self):
+        """
+        Return a list of the extensions of this CRL.
+
+        :return: A :py:class:`list` of :py:class:`X509Extension` objects.
+        """
+        exts = []
+        for i in range(_lib.X509_CRL_get_ext_count(self._crl)):
+            native_ext = _lib.X509_CRL_get_ext(self._crl, i)
+            if native_ext == _ffi.NULL:
+                # TODO: This is untested.
+                _raise_current_error()
+            ext = X509Extension.__new__(X509Extension)
+            ext._extension = native_ext
+            # Extensions are owned by the CA structure.  As long as the
+            # extensions Python objects are alive, keep the CA Python object
+            # alive.
+            ext._owner = self
+            exts.append(ext)
+        return exts
 CRLType = CRL
 
 

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -3349,7 +3349,7 @@ class CRLTests(TestCase):
         Load a known CRL and inspect its last update timestamp.
         """
         crl = load_crl(FILETYPE_PEM, crlData)
-        self.assertEqual(crl.get_last_update(), "20090726043456Z")
+        self.assertEqual(crl.get_last_update(), b("20090726043456Z"))
 
 
     def test_get_next_update(self):
@@ -3357,7 +3357,7 @@ class CRLTests(TestCase):
         Load a known CRL and inspect its next update timestamp.
         """
         crl = load_crl(FILETYPE_PEM, crlData)
-        self.assertEqual(crl.get_next_update(), "20120927024152Z")
+        self.assertEqual(crl.get_next_update(), b("20120927024152Z"))
 
 
     def test_get_version(self):

--- a/OpenSSL/test/test_crypto.py
+++ b/OpenSSL/test/test_crypto.py
@@ -3043,6 +3043,11 @@ class CRLTests(TestCase):
         crl = CRL()
         self.assertTrue( isinstance(crl, CRL) )
         self.assertEqual(crl.get_revoked(), None)
+        self.assertEqual(crl.get_issuer().commonName, None)
+        self.assertEqual(crl.get_next_update(), None)
+        self.assertEqual(crl.get_last_update(), None)
+        self.assertEqual(crl.get_version(), 0)
+        self.assertEqual(crl.get_extensions(), [])
 
 
     def test_construction_wrong_args(self):
@@ -3328,6 +3333,47 @@ class CRLTests(TestCase):
         be loaded raises a :py:obj:`OpenSSL.crypto.Error`.
         """
         self.assertRaises(Error, load_crl, FILETYPE_PEM, b"hello, world")
+
+
+    def test_get_issuer(self):
+        """
+        Load a known CRL and inspect its issuer.
+        """
+        crl = load_crl(FILETYPE_PEM, crlData)
+        issuer = crl.get_issuer()
+        self.assertEqual(issuer.commonName, "Testing Root CA")
+
+
+    def test_get_last_update(self):
+        """
+        Load a known CRL and inspect its last update timestamp.
+        """
+        crl = load_crl(FILETYPE_PEM, crlData)
+        self.assertEqual(crl.get_last_update(), "20090726043456Z")
+
+
+    def test_get_next_update(self):
+        """
+        Load a known CRL and inspect its next update timestamp.
+        """
+        crl = load_crl(FILETYPE_PEM, crlData)
+        self.assertEqual(crl.get_next_update(), "20120927024152Z")
+
+
+    def test_get_version(self):
+        """
+        Load a known CRL and inspect its version number.
+        """
+        crl = load_crl(FILETYPE_PEM, crlData)
+        self.assertEqual(crl.get_version(), 0)
+
+
+    def test_get_extensions(self):
+        """
+        Load a known CRL and inspect its extensions.
+        """
+        crl = load_crl(FILETYPE_PEM, crlData)
+        self.assertEqual(crl.get_extensions(), [])
 
 
 


### PR DESCRIPTION
This pull request addresses pyca/pyopenssl#181, exposing some useful attributes of CRL objects:
- Issuer
- Last Update
- Next Update
- CRL extensions
