### PR TITLE
Add support for SSL_peek

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
+2015-08-17  Maximilian Hils <pyopenssl@maximilianhils.com>
+
+	* OpenSSL/SSL.py, OpenSSL/test/test_ssl.py: Add support for
+	  the ``MSG_PEEK`` flag to ``Connection.recv()`` and
+	  ``Connection.recv_into()``.
+
 2015-05-27  Jim Shaver <dcypherd@gmail.com>
 
-	* OpenSSL/SSL.py, : Add ``get_protocol_version()`` and 
+	* OpenSSL/SSL.py: Add ``get_protocol_version()`` and
 	  ``get_protocol_version_name()`` to ``Connection``.
 	  Based on work from Rich Moore.
 

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -669,11 +669,12 @@ Connection objects have the following methods:
     (**not** the underlying transport buffer).
 
 
-.. py:method:: Connection.recv(bufsize)
+.. py:method:: Connection.recv(bufsize[, flags])
 
     Receive data from the Connection. The return value is a string representing the
     data received. The maximum amount of data to be received at once, is specified
-    by *bufsize*.
+    by *bufsize*. The only supported flag is ``MSG_PEEK``, all other flags are
+    ignored.
 
 
 .. py:method:: Connection.recv_into(buffer[, nbytes[, flags]])
@@ -681,8 +682,7 @@ Connection objects have the following methods:
     Receive data from the Connection and copy it directly into the provided
     buffer. The return value is the number of bytes read from the connection.
     The maximum amount of data to be received at once is specified by *nbytes*.
-    *flags* is accepted for compatibility with ``socket.recv_into`` but its
-    value is ignored.
+    The only supported flag is ``MSG_PEEK``, all other flags are ignored.
 
 .. py:method:: Connection.bio_write(bytes)
 


### PR DESCRIPTION
This PR adds support for OpenSSL's `SSL_peek` command, which is OpenSSL's (undocumented) equivalent  of `MSG_PEEK` for normal sockets. I went for the straightforward way and mirrored the Python socket API - if you prefer a separate `peek` method, I'm happy to adjust the PR.
Tests may fail for now, as this requires the next cryptography release.