### PR TITLE
Implements previously empty renegotiate & renegotiate_pending functions

### DIFF
--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -3210,8 +3210,8 @@ class ConnectionRenegotiateTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
 
-        server.send("hello world")
-        self.assertEquals(client.recv(len("hello world")), "hello world")
+        server.send(b"hello world")
+        self.assertEquals(client.recv(len(b"hello world")), b"hello world")
 
         self.assertEquals(server.total_renegotiations(), 0)
         self.assertTrue(server.renegotiate())
@@ -3224,8 +3224,8 @@ class ConnectionRenegotiateTests(TestCase, _LoopbackMixin):
 
         self.assertEquals(server.total_renegotiations(), 1)
         
-        server.send("hello world")
-        self.assertEquals(client.recv(len("hello world")), "hello world")
+        server.send(b"hello world")
+        self.assertEquals(client.recv(len(b"hello world")), b"hello world")
 
 
 class ErrorTests(TestCase):

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -3205,26 +3205,27 @@ class ConnectionRenegotiateTests(TestCase, _LoopbackMixin):
         self.assertEquals(connection.total_renegotiations(), 0)
 
 
-#     def test_renegotiate(self):
-#         """
-#         """
-#         server, client = self._loopback()
+    def test_renegotiate(self):
+        """
+        """
+        server, client = self._loopback()
 
-#         server.send("hello world")
-#         self.assertEquals(client.recv(len("hello world")), "hello world")
+        server.send("hello world")
+        self.assertEquals(client.recv(len("hello world")), "hello world")
 
-#         self.assertEquals(server.total_renegotiations(), 0)
-#         self.assertTrue(server.renegotiate())
+        self.assertEquals(server.total_renegotiations(), 0)
+        self.assertTrue(server.renegotiate())
 
-#         server.setblocking(False)
-#         client.setblocking(False)
-#         while server.renegotiate_pending():
-#             client.do_handshake()
-#             server.do_handshake()
+        server.setblocking(False)
+        client.setblocking(False)
+        
+        client.do_handshake()
+        server.do_handshake()
 
-#         self.assertEquals(server.total_renegotiations(), 1)
-
-
+        self.assertEquals(server.total_renegotiations(), 1)
+        
+        server.send("hello world")
+        self.assertEquals(client.recv(len("hello world")), "hello world")
 
 
 class ErrorTests(TestCase):

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -595,7 +595,7 @@ Connection objects have the following methods:
 
     Retrieve the list of ciphers used by the Connection object. WARNING: This API
     has changed. It used to take an optional parameter and just return a string,
-    but not it returns the entire list in one go.
+    but now it returns the entire list in one go.
 
 
 .. py:method:: Connection.get_protocol_version()

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,7 +65,7 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master doctree document.
+# The master toctree document.
 master_doc = 'index'
 
 # General information about the project.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,7 +65,7 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
+# The master doctree document.
 master_doc = 'index'
 
 # General information about the project.

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
                 'OpenSSL.test.test_tsafe',
                 'OpenSSL.test.test_util',],
     install_requires=[
-        "cryptography>=0.7",
+        "cryptography>=1.0.1",
         "six>=1.5.2"
     ],
     test_suite="OpenSSL",


### PR DESCRIPTION
This fixes bug https://github.com/pyca/pyopenssl/issues/142, and uses bindings committed in https://github.com/pyca/cryptography/pull/2303