### PR TITLE
getattr now works when no socket is wrapped

### DIFF
--- a/OpenSSL/SSL.py
+++ b/OpenSSL/SSL.py
@@ -1146,7 +1146,10 @@ class Connection(object):
         Look up attributes on the wrapped socket object if they are not found on
         the Connection object.
         """
-        return getattr(self._socket, name)
+        if self._socket is None:
+            raise AttributeError("'" + self.__class__.__name__ + "' object has no attribute '" + name + "'")
+        else:
+            return getattr(self._socket, name)
 
 
     def _raise_ssl_error(self, ssl, result):

--- a/OpenSSL/test/test_ssl.py
+++ b/OpenSSL/test/test_ssl.py
@@ -2193,6 +2193,17 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         self.assertRaises(TypeError, connection.connect)
         self.assertRaises(TypeError, connection.connect, ("127.0.0.1", 1), None)
 
+    def test_connection_undefined_attr(self):
+        """
+        :py:obj:`Connection.connect` raises :py:obj:`TypeError` if called with a non-address
+        argument or with the wrong number of arguments.
+        """
+        
+        def attr_access_test(connection):
+            return connection.an_attribute_which_is_not_defined
+        
+        connection = Connection(Context(TLSv1_METHOD), None)
+        self.assertRaises(AttributeError, attr_access_test, connection)
 
     def test_connect_refused(self):
         """


### PR DESCRIPTION
When using a Connection object with no socket, _sock is None and the connection throws unhelpful exceptions when an attribute exception should be thrown. This change fixes this issue.