### PR TITLE
Get rid of flaky shields.io badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,6 @@
 pyOpenSSL -- A Python wrapper around the OpenSSL library
 --------------------------------------------------------
 
-.. image:: https://img.shields.io/pypi/v/pyOpenSSL.svg
-   :target: https://pypi.python.org/pypi/pyOpenSSL/
-   :alt: Latest Version
-
 .. image:: https://readthedocs.org/projects/pyopenssl/badge/?version=latest
    :target: https://pyopenssl.readthedocs.org/
    :alt: Latest Docs


### PR DESCRIPTION
It’s been error’ing for weeks and months now.  No real use for it either.