### PR TITLE
Don't try to upload coverage from coverage-less jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ script:
     ~/.venv/bin/tox -v
 
 after_script:
-  - source ~/.venv/bin/activate && bash <(curl -s https://codecov.io/bash) -e TRAVIS_OS_NAME,TOXENV,OPENSSL
+  - ./.travis/upload_coverage.sh
 
 notifications:
   email: false

--- a/.travis/upload_coverage.sh
+++ b/.travis/upload_coverage.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+set -x
+
+NO_COVERAGE_TOXENVS=(pypy docs check-manifest pypi-readme flake8 pyroma)
+if ! [[ "${NO_COVERAGE_TOXENVS[*]}" =~ "${TOXENV}" ]]; then
+    source ~/.venv/bin/activate
+    bash <(curl -s https://codecov.io/bash) -e TRAVIS_OS_NAME,TOXENV,OPENSSL
+fi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ recursive-include   examples    *
 recursive-include   rpm         *
 recursive-exclude   leakcheck   *.py *.pem
 prune               doc/_build
+prune               .travis


### PR DESCRIPTION
We're getting a lot of emails from codecov.  This should stop it.

Stolen from pyca/cryptography@b724d98422c3f070b6d9aa9f9b7621f38bbfa8c1