### PR TITLE
Skip test_set_default_verify_paths on own 0.9.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ cache:
 #    - $HOME/.cache/pip
     - $HOME/ossl-098
 
-env:
-  global:
-    - LC_ALL=en_US.UTF-8
-
 matrix:
   include:
   - language: generic
@@ -78,7 +74,6 @@ matrix:
   - env: TOXENV=py33-cryptographyMaster
   - env: TOXENV=py34-cryptographyMaster
   - env: TOXENV=pypy-cryptographyMaster
-  - env: OPENSSL=0.9.8 TOXENV=py27
   - env: TOXENV=pypy
 
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = {pypy,py26,py27,py33,py34}{,-cryptographyMaster},pypi-readme,check-man
 [testenv]
 whitelist_externals =
     openssl
-passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH
+passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH OPENSSL TRAVIS
 deps =
     setuptools>=7.0  # older setuptools pollute CWD with egg files of dependencies
     coverage


### PR DESCRIPTION
I had a closer look at the new fail on 0.9.8 and in the light of limited visibility within Travis it seems clear to me that the problem is that our self-compiled OpenSSL doesn't know about the system's trust store.

There's probably some compile option to make it use it?  Either that, of we can just skip the test as done in this PR.  I don't really care either way and leave it to @reaperhulk who knows much more, how much effort it would be to smarten up our OpenSSl.