### PR TITLE
Add a twisted target to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
 
   # Make sure we don't break Twisted
   - python: "2.7"
-    env: TOXENV=py27-twisted
+    env: TOXENV=py27-twistedMaster
 
 
   # Also run at least a little bit against an older version of OpenSSL.

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,11 @@ matrix:
   - python: "pypy"
     env: TOXENV=pypy-cryptographyMaster
 
+  # Make sure we don't break Twisted
+  - python: "2.7"
+    env: TOXENV=py27-twisted
+
+
   # Also run at least a little bit against an older version of OpenSSL.
   - python: "2.7"
     env:

--- a/tox.ini
+++ b/tox.ini
@@ -23,10 +23,7 @@ commands =
 deps =
     # [tls,conch] syntax doesn't work here so we enumerate all dependencies.
     git+https://github.com/twisted/twisted
-    gmpy
     idna
-    pyasn1
-    pycrypto
     service_identity
 passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,{pypy,py26,py27,py33,py34,py35}{,-cryptographyMaster},py27-twisted,pypi-readme,check-manifest,flake8,docs,coverage-report
+envlist = coverage-clean,{pypy,py26,py27,py33,py34,py35}{,-cryptographyMaster},py27-twistedMaster,pypi-readme,check-manifest,flake8,docs,coverage-report
 
 [testenv]
 whitelist_externals =
@@ -19,9 +19,15 @@ commands =
     python -c "import cryptography; print(cryptography.__version__)"
     coverage run --parallel -m pytest tests
 
-[testenv:py27-twisted]
+[testenv:py27-twistedMaster]
 deps =
-    twisted
+    # [tls,conch] syntax doesn't work here so we enumerate all dependencies.
+    git+https://github.com/twisted/twisted
+    gmpy
+    idna
+    pyasn1
+    pycrypto
+    service_identity
 passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
 commands =
     python -c "import OpenSSL.SSL; print(OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION))"

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = coverage-clean,{pypy,py26,py27,py33,py34,py35}{,-cryptographyMaster},pypi-readme,check-manifest,flake8,docs,coverage-report
+envlist = coverage-clean,{pypy,py26,py27,py33,py34,py35}{,-cryptographyMaster},py27-twisted,pypi-readme,check-manifest,flake8,docs,coverage-report
 
 [testenv]
 whitelist_externals =
     openssl
-passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH
+passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
 deps =
     coverage
     pytest
@@ -18,6 +18,15 @@ commands =
     python -c "import OpenSSL.SSL; print(OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION))"
     python -c "import cryptography; print(cryptography.__version__)"
     coverage run --parallel -m pytest tests
+
+[testenv:py27-twisted]
+deps =
+    twisted
+passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
+commands =
+    python -c "import OpenSSL.SSL; print(OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION))"
+    python -c "import cryptography; print(cryptography.__version__)"
+    trial twisted
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Twisted is our most important downstream user.  In order to avoid another
regression release like 0.15.1, we add it to our CI