### PR TITLE
Fix test_set_default_verify_paths

### DIFF
--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1061,14 +1061,14 @@ class ContextTests(TestCase, _LoopbackMixin):
         # really test this. -exarkun
 
         # Arg, verisign.com doesn't speak anything newer than TLS 1.0
-        context = Context(TLSv1_METHOD)
+        context = Context(SSLv23_METHOD)
         context.set_default_verify_paths()
         context.set_verify(
             VERIFY_PEER,
             lambda conn, cert, errno, depth, preverify_ok: preverify_ok)
 
         client = socket()
-        client.connect(('verisign.com', 443))
+        client.connect(("encrypted.google.com", 443))
         clientSSL = Connection(context, client)
         clientSSL.set_connect_state()
         clientSSL.do_handshake()


### PR DESCRIPTION
Our OpenSSL 0.9.8 on Linux builder ist failing.  Let's try a more SSL-clueful company.