### PR TITLE
alter has_expired to fix bugs related to ASN1_UTCTIME_cmp_time_t

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1,5 +1,6 @@
 import datetime
-from time import mktime, time
+
+from time import mktime
 from base64 import b16encode
 from functools import partial
 from operator import __eq__, __ne__, __lt__, __le__, __gt__, __ge__
@@ -1209,7 +1210,7 @@ class X509(object):
             :py:const:`False` otherwise.
         :rtype: :py:class:`bool`
         """
-        time_string = self.get_notAfter()
+        time_string = _native(self.get_notAfter())
         timestamp = mktime(datetime.datetime.strptime(
             time_string, "%Y%m%d%H%M%SZ").timetuple())
         now = mktime(datetime.datetime.utcnow().timetuple())

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1,4 +1,5 @@
-from time import time
+import datetime
+from time import mktime, time
 from base64 import b16encode
 from functools import partial
 from operator import __eq__, __ne__, __lt__, __le__, __gt__, __ge__
@@ -1208,10 +1209,12 @@ class X509(object):
             :py:const:`False` otherwise.
         :rtype: :py:class:`bool`
         """
-        now = int(time())
-        notAfter = _lib.X509_get_notAfter(self._x509)
-        return _lib.ASN1_UTCTIME_cmp_time_t(
-            _ffi.cast('ASN1_UTCTIME*', notAfter), now) < 0
+        time_string = self.get_notAfter()
+        timestamp = mktime(datetime.datetime.strptime(
+            time_string, "%Y%m%d%H%M%SZ").timetuple())
+        now = mktime(datetime.datetime.utcnow().timetuple())
+
+        return timestamp < now
 
     def _get_boundary_time(self, which):
         return _get_asn1_time(which(self._x509))


### PR DESCRIPTION
RFC 5280 states that UTCTime must be used for validity dates through 2049 and GeneralizedTime must be used for 2050 or later. To be safe, we get the string form of the date using get_notAfter, which eventually calls _get_asn1_time. This function converts an ASN1_TIME to GeneralizedTime, so we have a UTC time string of the form %Y%m%d%H%M%SZ. Finally, we convert that to a timestamp and then compare it against the current UTC time to see if it has expired.

Fixes #192.

Time zones are tricky business so I'd like someone to carefully check my work here :)