### PR TITLE
Add py.test settings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
+[pytest]
+minversion = 2.8.2
+strict = true
+norecursedirs = build dist .* *.egg doc _trial_temp
+
 [sdist]
 force_manifest=1
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ whitelist_externals =
 passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
 deps =
     coverage
-    pytest
+    pytest>=2.8.2
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
 setenv =
     # Do not allow the executing environment to pollute the test environment


### PR DESCRIPTION
We add _trial_temp to ignores because now we run the Twisted test suite as
part of tox, py.test tries to recurse into it.

We also require py.test 2.8.2 because older version don't properly handle
deprecated_call which we use.