### PR TITLE
Switch to a nicer changelog format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,63 @@
+Changelog
+=========
+
+Versions are year-based with a strict :doc:`backward-compatibility` policy.
+The third digit is only for regressions.
+
+
+15.2.0 (UNRELEASED)
+-------------------
+
+This is the first release under full stewardship of PyCA.
+We have made *many* changes to make local development more pleasing.
+The test suite now passes both on Linux and OS X with OpenSSL 0.9.8, 1.0.1, and 1.0.2.
+It has been moved to `py.test <http://pytest.org/latest/>`_, all CI test runs are part of `tox <https://testrun.org/tox/>`_ and the source code has been made fully `flake8 <https://flake8.readthedocs.org/en/>`_ compliant.
+
+We hope to have lowered the barrier for contributions significantly but are open to hear about any remaining frustrations. 
+
+
+Backward-incompatible changes:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Python 3.2 support has been dropped.
+  It never had significant real world usage and has been dropped by our main dependency ``cryptography``.
+  Affected users should upgrade to Python 3.3 or later.
+
+
+Deprecations:
+^^^^^^^^^^^^^
+
+- The support for EGD has been removed.
+  The only affected function :func:`OpenSSL.rand.egd` now uses :func:`os.urandom` to seed the internal PRNG instead.
+  Please see `pyca/cryptography#1636 <https://github.com/pyca/cryptography/pull/1636>`_ for more background information on this decision.
+
+  Please note that you should `use urandom <http://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers/>`_ for all your secure random number needs.
+
+
+In accordance with our backward compatibility policy :func:`OpenSSL.rand.egd` will be *removed* no sooner than a year from the release of 15.2.0
+
+
+Changes:
+^^^^^^^^
+
+- Added :func:`OpenSSL.crypto.dump_crl` to dump a certificate revocation list out to a string buffer.
+  [`#368 <https://github.com/pyca/pyopenssl/pull/368>`_]
+- Added :meth:`OpenSSL.SSL.Connection.state_string` using the OpenSSL binding ``state_string_long``.
+  [`#358 <https://github.com/pyca/pyopenssl/pull/358>`_]
+- Added support for the ``socket.MSG_PEEK`` flag to :meth:`OpenSSL.SSL.Connection.recv` and :meth:`OpenSSL.SSL.Connection.recv_into`.
+  [`#294 <https://github.com/pyca/pyopenssl/pull/294>`_]
+- Added :meth:`OpenSSL.SSL.Connection.get_protocol_version` and :meth:`OpenSSL.SSL.Connection.get_protocol_version_name`.
+  [`#244 <https://github.com/pyca/pyopenssl/pull/244>`_]
+- Switched to utf8string mask by default.
+  OpenSSL formerly defaulted to a T61String if there were UTF-8 characters present.
+  This was changed to default to UTF8String in the config around 2005, but the actual code didn't change it until late last year.
+  This will default us to the setting that actually works.
+  To revert this you can call ``OpenSSL.crypto._lib.ASN1_STRING_set_default_mask_asc(b"default")``.
+  [`#234 <https://github.com/pyca/pyopenssl/pull/234>`_]
+
+
+
+Older Changelog Entries
+-----------------------
+
+The changes from before release 15.2.0 are preserved in the `repository <https://github.com/pyca/pyopenssl/blob/master/doc/ChangeLog_old.txt>`_.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -38,7 +38,7 @@ These pull requests should satisfy the following properties:
 - Pull requests are not allowed to break existing tests.
   We usually don't comment on pull requests that are breaking the CI because we consider them work in progress.
   Please note that not having 100% code coverage for the code you wrote/touched also causes our CI to fail.
-- Pull requests that introduce features or fix bugs should note those changes in the ``ChangeLog`` text file in the root of the repository.
+- Pull requests that introduce features or fix bugs should note those changes in ``CHANGELOG.rst`` in the root of the repository.
   They should also document the changes, both in docstrings and in the documentation in the ``doc/`` directory.
 
 Finally, pull requests must be reviewed before merging.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include             LICENSE ChangeLog MANIFEST.in *.rst tox.ini docs-requirements.txt .coveragerc
+include             LICENSE MANIFEST.in *.rst tox.ini docs-requirements.txt .coveragerc
 exclude             leakcheck
 recursive-include   tests       *.py
 recursive-include   doc         *

--- a/doc/ChangeLog_old.txt
+++ b/doc/ChangeLog_old.txt
@@ -1,42 +1,7 @@
-2015-10-13 Dominic Chen <d.c.ddcc@gmail.com>
+This file only contains the changes up to release 0.15.1.  Newer changes can be
+found at <https://pyopenssl.readthedocs.org/en/latest/changelog.html>.
 
-	* OpenSSL/crypto.py: Implement the ``dump_crl()`` function to dump a
-	  certificate revocation list out to a string buffer.
-
-2015-09-07 Sam Lee <sam.rr.lee@gmail.com>
-
-	* OpenSSL/SSL.py, OpenSSL/test/test_ssl.py: Implemented
-	  the ``Connection.state_string()`` function, using
-	  the OpenSSL binding state_string_long.
-
-2015-08-17  Maximilian Hils <pyopenssl@maximilianhils.com>
-
-	* OpenSSL/SSL.py, OpenSSL/test/test_ssl.py: Add support for
-	  the ``MSG_PEEK`` flag to ``Connection.recv()`` and
-	  ``Connection.recv_into()``.
-
-2015-05-27  Jim Shaver <dcypherd@gmail.com>
-
-	* OpenSSL/SSL.py: Add ``get_protocol_version()`` and
-	  ``get_protocol_version_name()`` to ``Connection``.
-	  Based on work from Rich Moore.
-
-2015-05-02  Jim Shaver <dcypherd@gmail.com>
-
-	* .travis.yml, setup.py, tox.ini: Removed support for Python 3.2.
-	  This version is rarely used and is now deprecated by a major
-	  dependency of pyOpenSSL (cryptography).  Affected users should upgrade
-	  to Python 3.3+.
-
-2015-04-15  Paul Kehrer <paul.l.kehrer@gmail.com>
-
-	* OpenSSL/crypto.py, OpenSSL/test/test_crypto.py: Switch to utf8string
-	  mask by default. OpenSSL formerly defaulted to a T61String if there
-	  were UTF-8 characters present.  This was changed to default to
-	  UTF8String in the config around 2005, but the actual code didn't
-	  change it until late last year. This will default us to the setting
-	  that actually works. To revert this you can call
-	  crypto._lib.ASN1_STRING_set_default_mask_asc(b"default")
+***
 
 2015-04-14  Hynek Schlawack  <hs@ox.cx>
 

--- a/doc/backward-compatibility.rst
+++ b/doc/backward-compatibility.rst
@@ -1,0 +1,11 @@
+Backward Compatibility
+======================
+
+pyOpenSSL has a very strong backward compatibility policy.
+Generally speaking, you shouldn't ever be afraid of updating.
+
+If breaking changes are needed do be done, they are:
+
+#. …announced in the :doc:`changelog`.
+#. …the old behavior raises a :exc:`DeprecationWarning` for a year.
+#. …are done with another announcement in the :doc:`changelog`.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGELOG.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,6 +2,7 @@
 Welcome to pyOpenSSL's documentation!
 =====================================
 
+Release v\ |release| (:doc:`What's new? <changelog>`).
 
 pyOpenSSL is a rather thin wrapper around (a subset of) the OpenSSL library.
 With thin wrapper we mean that a lot of the object methods do nothing more than
@@ -18,6 +19,16 @@ Contents:
    install
    api
    internals
+
+
+Meta
+----
+
+.. toctree::
+   :maxdepth: 1
+
+   backward-compatibility
+   changelog
 
 
 Indices and tables


### PR DESCRIPTION
The old format is tedious to read and write.  Let’s do better from now on.

Also document the general backward compatibility.