### PR TITLE
Support for serializing/deserializing public keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,8 @@ In accordance with our backward compatibility policy :func:`OpenSSL.rand.egd` wi
 Changes:
 ^^^^^^^^
 
+- Added :func:`OpenSSL.crypto.dump_publickey` to dump :class:`OpenSSL.crypto.PKey` objects that represent public keys, and :func:`OpenSSL.crypto.load_publickey` to load such objects from serialized representations.
+  [`#382 <https://github.com/pyca/pyopenssl/pull/382>`_]
 - Added :func:`OpenSSL.crypto.dump_crl` to dump a certificate revocation list out to a string buffer.
   [`#368 <https://github.com/pyca/pyopenssl/pull/368>`_]
 - Added :meth:`OpenSSL.SSL.Connection.state_string` using the OpenSSL binding ``state_string_long``.
@@ -54,10 +56,6 @@ Changes:
   This will default us to the setting that actually works.
   To revert this you can call ``OpenSSL.crypto._lib.ASN1_STRING_set_default_mask_asc(b"default")``.
   [`#234 <https://github.com/pyca/pyopenssl/pull/234>`_]
-- Added :func:`OpenSSL.crypto.dump_publickey` to dump :class:`OpenSSL.crypto.PKey` objects that represent public keys.
-  [`#382 <https://github.com/pyca/pyopenssl/pull/382>`_]
-- Added :func:`OpenSSL.crypto.load_publickey` to load :class:`OpenSSL.crypto.PKey` objects that represent public keys from serialized representations.
-  [`#382 <https://github.com/pyca/pyopenssl/pull/382>`_]
 
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ We have made *many* changes to make local development more pleasing.
 The test suite now passes both on Linux and OS X with OpenSSL 0.9.8, 1.0.1, and 1.0.2.
 It has been moved to `py.test <http://pytest.org/latest/>`_, all CI test runs are part of `tox <https://testrun.org/tox/>`_ and the source code has been made fully `flake8 <https://flake8.readthedocs.org/en/>`_ compliant.
 
-We hope to have lowered the barrier for contributions significantly but are open to hear about any remaining frustrations. 
+We hope to have lowered the barrier for contributions significantly but are open to hear about any remaining frustrations.
 
 
 Backward-incompatible changes:
@@ -54,8 +54,10 @@ Changes:
   This will default us to the setting that actually works.
   To revert this you can call ``OpenSSL.crypto._lib.ASN1_STRING_set_default_mask_asc(b"default")``.
   [`#234 <https://github.com/pyca/pyopenssl/pull/234>`_]
-- Added :func:`OpenSSL.crypto.dump_publickey` to dump :class:`OpenSSL.crypto.PKey` objects that represent public keys. [`#382 <https://github.com/pyca/pyopenssl/pull/382>`_]
-- Added :func:`OpenSSL.crypto.load_publickey` to load :class:`OpenSSL.crypto.PKey` objects that represent public keys from serialized representations. [`#382 <https://github.com/pyca/pyopenssl/pull/382>`_]
+- Added :func:`OpenSSL.crypto.dump_publickey` to dump :class:`OpenSSL.crypto.PKey` objects that represent public keys.
+  [`#382 <https://github.com/pyca/pyopenssl/pull/382>`_]
+- Added :func:`OpenSSL.crypto.load_publickey` to load :class:`OpenSSL.crypto.PKey` objects that represent public keys from serialized representations.
+  [`#382 <https://github.com/pyca/pyopenssl/pull/382>`_]
 
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,8 @@ Changes:
   This will default us to the setting that actually works.
   To revert this you can call ``OpenSSL.crypto._lib.ASN1_STRING_set_default_mask_asc(b"default")``.
   [`#234 <https://github.com/pyca/pyopenssl/pull/234>`_]
+- Added :func:`OpenSSL.crypto.dump_publickey` to dump :class:`OpenSSL.crypto.PKey` objects that represent public keys. [`#382 <https://github.com/pyca/pyopenssl/pull/382>`_]
+- Added :func:`OpenSSL.crypto.load_publickey` to load :class:`OpenSSL.crypto.PKey` objects that represent public keys from serialized representations. [`#382 <https://github.com/pyca/pyopenssl/pull/382>`_]
 
 
 

--- a/doc/api/crypto.rst
+++ b/doc/api/crypto.rst
@@ -87,6 +87,13 @@ Private keys
     *passphrase* must be either a string or a callback for providing the pass
     phrase.
 
+Public keys
+~~~~~~~~~~~
+
+.. autofunction:: dump_publickey
+
+.. autofunction:: load_publickey
+
 Certificate revocation lists
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1629,7 +1629,8 @@ def dump_publickey(type, pkey):
 
     :param type: The file type (one of :data:`FILETYPE_PEM` or
         :data:`FILETYPE_ASN1`).
-    :param pkey: The :class:`PKey` to dump.
+    :param pkey: The PKey to dump.
+    :type pkey: :class:`PKey`
     :return: The buffer with the dumped key in it.
     :rtype: bytes
     """
@@ -2435,9 +2436,10 @@ def load_publickey(type, buffer):
 
     :param type: The file type (one of :data:`FILETYPE_PEM`,
         :data:`FILETYPE_ASN1`).
-    :param buffer: The buffer the key is stored in. Must be a Python string
-        object, either unicode or bytestring.
-    :return: The :class:`PKey` object.
+    :param buffer: The buffer the key is stored in.
+    :type buffer: A Python string object, either unicode or bytestring.
+    :return: The PKey object.
+    :rtype: :class:`PKey`
     """
     if isinstance(buffer, _text_type):
         buffer = buffer.encode("ascii")

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1625,12 +1625,13 @@ def dump_certificate(type, cert):
 
 def dump_publickey(type, pkey):
     """
-    Dump a public key to a buffer
+    Dump a public key to a buffer.
 
-    :param type: The file type (one of FILETYPE_PEM or FILETYPE_ASN1).
-    :param pkey: The PKey to dump.
+    :param type: The file type (one of :py:data:`FILETYPE_PEM` or
+        :py:data:`FILETYPE_ASN1`).
+    :param pkey: The :py:class:`PKey` to dump.
     :return: The buffer with the dumped key in it.
-    :rtype: :py:data:`bytes`
+    :rtype: bytes
     """
     bio = _new_mem_buf()
     if type == FILETYPE_PEM:
@@ -2431,11 +2432,12 @@ class _PassphraseHelper(object):
 
 def load_publickey(type, buffer):
     """
-    Load a public key from a buffer
+    Load a public key from a buffer.
 
-    :param type: The file type (one of FILETYPE_PEM, FILETYPE_ASN1)
-    :param buffer: The buffer the key is stored in
-    :return: The PKey object
+    :param type: The file type (one of :py:data:`FILETYPE_PEM`,
+        :py:data:`FILETYPE_ASN1`).
+    :param buffer: The buffer the key is stored in.
+    :return: The :py:class:`PKey` object.
     """
     if isinstance(buffer, _text_type):
         buffer = buffer.encode("ascii")

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1627,7 +1627,7 @@ def dump_publickey(type, pkey):
     """
     Dump a public key to a buffer.
 
-    :param type: The file type (one of :py:data:`FILETYPE_PEM` or
+    :param type: The file type (one of :data:`FILETYPE_PEM` or
         :data:`FILETYPE_ASN1`).
     :param pkey: The :class:`PKey` to dump.
     :return: The buffer with the dumped key in it.
@@ -2433,9 +2433,10 @@ def load_publickey(type, buffer):
     """
     Load a public key from a buffer.
 
-    :param type: The file type (one of :py:data:`FILETYPE_PEM`,
+    :param type: The file type (one of :data:`FILETYPE_PEM`,
         :data:`FILETYPE_ASN1`).
-    :param buffer: The buffer the key is stored in.
+    :param buffer: The buffer the key is stored in. Must be a Python string
+        object, either unicode or bytestring.
     :return: The :class:`PKey` object.
     """
     if isinstance(buffer, _text_type):

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1629,8 +1629,7 @@ def dump_publickey(type, pkey):
 
     :param type: The file type (one of :data:`FILETYPE_PEM` or
         :data:`FILETYPE_ASN1`).
-    :param pkey: The PKey to dump.
-    :type pkey: :class:`PKey`
+    :param PKey pkey: The public key to dump
     :return: The buffer with the dumped key in it.
     :rtype: bytes
     """

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1642,8 +1642,7 @@ def dump_publickey(type, pkey):
         raise ValueError("type argument must be FILETYPE_PEM or FILETYPE_ASN1")
 
     result_code = write_bio(bio, pkey._pkey)
-    if result_code != 1:
-        # TODO: This is untested.
+    if result_code != 1:  # pragma: no cover
         _raise_current_error()
 
     return _bio_to_string(bio)

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1628,8 +1628,8 @@ def dump_publickey(type, pkey):
     Dump a public key to a buffer.
 
     :param type: The file type (one of :py:data:`FILETYPE_PEM` or
-        :py:data:`FILETYPE_ASN1`).
-    :param pkey: The :py:class:`PKey` to dump.
+        :data:`FILETYPE_ASN1`).
+    :param pkey: The :class:`PKey` to dump.
     :return: The buffer with the dumped key in it.
     :rtype: bytes
     """
@@ -2435,9 +2435,9 @@ def load_publickey(type, buffer):
     Load a public key from a buffer.
 
     :param type: The file type (one of :py:data:`FILETYPE_PEM`,
-        :py:data:`FILETYPE_ASN1`).
+        :data:`FILETYPE_ASN1`).
     :param buffer: The buffer the key is stored in.
-    :return: The :py:class:`PKey` object.
+    :return: The :class:`PKey` object.
     """
     if isinstance(buffer, _text_type):
         buffer = buffer.encode("ascii")

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2577,7 +2577,7 @@ class FunctionTests(TestCase):
 
     def test_dump_publickey_pem(self):
         """
-        :py:obj:`dump_publickey` writes a PEM
+        dump_publickey writes a PEM.
         """
         key = load_publickey(FILETYPE_PEM, cleartextPublicKeyPEM)
         dumped_pem = dump_publickey(FILETYPE_PEM, key)
@@ -2585,7 +2585,7 @@ class FunctionTests(TestCase):
 
     def test_dump_publickey_asn1(self):
         """
-        :py:obj:`dump_publickey` writes a DER
+        dump_publickey writes a DER.
         """
         key = load_publickey(FILETYPE_PEM, cleartextPublicKeyPEM)
         dumped_der = dump_publickey(FILETYPE_ASN1, key)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2581,7 +2581,7 @@ class FunctionTests(TestCase):
         """
         key = load_publickey(FILETYPE_PEM, cleartextPublicKeyPEM)
         dumped_pem = dump_publickey(FILETYPE_PEM, key)
-        self.assertEqual(dumped_pem, cleartextPublicKeyPEM)
+        assert dumped_pem == cleartextPublicKeyPEM
 
     def test_dump_publickey_asn1(self):
         """
@@ -2591,7 +2591,7 @@ class FunctionTests(TestCase):
         dumped_der = dump_publickey(FILETYPE_ASN1, key)
         key2 = load_publickey(FILETYPE_ASN1, dumped_der)
         dumped_pem2 = dump_publickey(FILETYPE_PEM, key2)
-        self.assertEqual(dumped_pem2, cleartextPublicKeyPEM)
+        assert dumped_pem2 == cleartextPublicKeyPEM
 
     def test_dump_certificate_request(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2593,6 +2593,38 @@ class FunctionTests(TestCase):
         dumped_pem2 = dump_publickey(FILETYPE_PEM, key2)
         assert dumped_pem2 == cleartextPublicKeyPEM
 
+    def test_dump_publickey_invalid_type(self):
+        """
+        dump_publickey doesn't support FILETYPE_TEXT.
+        """
+        key = load_publickey(FILETYPE_PEM, cleartextPublicKeyPEM)
+
+        with pytest.raises(ValueError):
+            dump_publickey(FILETYPE_TEXT, key)
+
+    def test_load_publickey_invalid_type(self):
+        """
+        load_publickey doesn't support FILETYPE_TEXT.
+        """
+        with pytest.raises(ValueError):
+            load_publickey(FILETYPE_TEXT, cleartextPublicKeyPEM)
+
+    def test_load_publickey_invalid_key_format(self):
+        """
+        load_publickey explodes on incorrect keys.
+        """
+        with pytest.raises(Error):
+            load_publickey(FILETYPE_ASN1, cleartextPublicKeyPEM)
+
+    def test_load_publickey_tolerates_unicode_strings(self):
+        """
+        load_publickey works with text strings, not just bytes.
+        """
+        serialized = cleartextPublicKeyPEM.decode('ascii')
+        key = load_publickey(FILETYPE_PEM, serialized)
+        dumped_pem = dump_publickey(FILETYPE_PEM, key)
+        assert dumped_pem == cleartextPublicKeyPEM
+
     def test_dump_certificate_request(self):
         """
         :py:obj:`dump_certificate_request` writes a PEM, DER, and text.

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -26,6 +26,7 @@ from OpenSSL.crypto import (
 from OpenSSL.crypto import X509Req, X509ReqType
 from OpenSSL.crypto import X509Extension, X509ExtensionType
 from OpenSSL.crypto import load_certificate, load_privatekey
+from OpenSSL.crypto import load_publickey, dump_publickey
 from OpenSSL.crypto import FILETYPE_PEM, FILETYPE_ASN1, FILETYPE_TEXT
 from OpenSSL.crypto import dump_certificate, load_certificate_request
 from OpenSSL.crypto import dump_certificate_request, dump_privatekey
@@ -299,6 +300,18 @@ MbzjS007Oe4qqBnCWaFPSnJX6uLApeTbqAxAeyCql56ULW5x6vDMNC3dwjvS/CEh
 """)
 
 encryptedPrivateKeyPEMPassphrase = b("foobar")
+
+
+cleartextPublicKeyPEM = b("""-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxszlc+b71LvlLS0ypt/l
+gT/JzSVJtnEqw9WUNGeiChywX2mmQLHEt7KP0JikqUFZOtPclNY823Q4pErMTSWC
+90qlUxI47vNJbXGRfmO2q6Zfw6SE+E9iUb74xezbOJLjBuUIkQzEKEFV+8taiRV+
+ceg1v01yCT2+OjhQW3cxG42zxyRFmqesbQAUWgS3uhPrUQqYQUEiTmVhh4FBUKZ5
+XIneGUpX1S7mXRxTLH6YzRoGFqRoc9A0BBNcoXHTWnxV215k4TeHMFYE5RG0KYAS
+8Xk5iKICEXwnZreIt3jyygqoOKsKZMK/Zl2VhMGhJR6HXRpQCyASzEG7bgtROLhL
+ywIDAQAB
+-----END PUBLIC KEY-----
+""")
 
 # Some PKCS#7 stuff.  Generated with the openssl command line:
 #
@@ -2561,6 +2574,24 @@ class FunctionTests(TestCase):
         dumped_text = dump_privatekey(FILETYPE_TEXT, key)
         good_text = _runopenssl(dumped_pem, b"rsa", b"-noout", b"-text")
         self.assertEqual(dumped_text, good_text)
+
+    def test_dump_publickey_pem(self):
+        """
+        :py:obj:`dump_publickey` writes a PEM
+        """
+        key = load_publickey(FILETYPE_PEM, cleartextPublicKeyPEM)
+        dumped_pem = dump_publickey(FILETYPE_PEM, key)
+        self.assertEqual(dumped_pem, cleartextPublicKeyPEM)
+
+    def test_dump_publickey_asn1(self):
+        """
+        :py:obj:`dump_publickey` writes a DER
+        """
+        key = load_publickey(FILETYPE_PEM, cleartextPublicKeyPEM)
+        dumped_der = dump_publickey(FILETYPE_ASN1, key)
+        key2 = load_publickey(FILETYPE_ASN1, dumped_der)
+        dumped_pem2 = dump_publickey(FILETYPE_PEM, key2)
+        self.assertEqual(dumped_pem2, cleartextPublicKeyPEM)
 
     def test_dump_certificate_request(self):
         """


### PR DESCRIPTION
This is needed for HPKP in urllib3, to avoid using lots of cryptography private functions. It also adds symmetry to the equivalent private key functions.