### PR TITLE
Harmonize copyright notices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ doc/_build/
 examples/simple/*.cert
 examples/simple/*.pkey
 .cache
+_trial_temp.lock

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include             LICENSE MANIFEST.in *.rst tox.ini docs-requirements.txt .coveragerc
+include             LICENSE NOTICE MANIFEST.in *.rst tox.ini docs-requirements.txt .coveragerc
 exclude             leakcheck
 recursive-include   tests       *.py
 recursive-include   doc         *

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,16 @@
+pyOpenSSL
+Copyright 2001 Martin Sjögren
+
+Initial work has been made while Martin worked at AB Strakt
+<http://www.strakt.com/>.
+
+This product includes software developed by Jean-Paul Calderone
+<http://as.ynchrono.us> who maintained pyOpenSSL from 2008 until 2015.
+
+Portions of this software have been taken from Twisted
+<https://twistedmatrix.com/>.
+
+Some of the examples have been contributed by Michal Wallace
+<http://www.sabren.net/> and Mihai Ibanescu <misa@redhat.com>.
+
+tests/test_rand.py has been originally written by Frederick Dean.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,7 @@ def read_file(*parts):
     Build an absolute path from *parts* and return the contents of the
     resulting file.  Assume UTF-8 encoding.
     """
-    with codecs.open(os.path.join(HERE, *parts), "rb", "ascii") as f:
+    with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
         return f.read()
 
 

--- a/examples/README
+++ b/examples/README
@@ -45,4 +45,3 @@ but uses secure connections. The technique and classes should work for any
 SocketServer style server. However, the code has not been extensively tested.
 
 Contributed by Michal Wallace
-

--- a/examples/SecureXMLRPCServer.py
+++ b/examples/SecureXMLRPCServer.py
@@ -1,23 +1,32 @@
-"""
-SecureXMLRPCServer module using pyOpenSSL 0.5
-Written 0907.2002
-by Michal Wallace
-http://www.sabren.net/
+# -*- coding: utf-8 -*-
 
-This acts exactly like SimpleXMLRPCServer
-from the standard python library, but
-uses secure connections. The technique
-and classes should work for any SocketServer
-style server. However, the code has not
-been extensively tested.
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-This code is in the public domain.
-It is provided AS-IS WITH NO WARRANTY WHATSOEVER.
 """
+SecureXMLRPCServer module using pyOpenSSL
+
+This acts exactly like SimpleXMLRPCServer from the standard python library, but
+uses secure connections. The technique and classes should work for any
+SocketServer style server. However, the code has not been extensively tested.
+"""
+
 import SocketServer
 import os, socket
 import SimpleXMLRPCServer
 from OpenSSL import SSL
+
 
 class SSLWrapper:
     """

--- a/examples/certgen.py
+++ b/examples/certgen.py
@@ -1,8 +1,19 @@
-# -*- coding: latin-1 -*-
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
 #
-# Copyright (C) AB Strakt
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 """
 Certificate generation module.
@@ -78,4 +89,3 @@ def createCertificate(req, issuerCertKey, serial, validityPeriod, digest="sha256
     cert.set_pubkey(req.get_pubkey())
     cert.sign(issuerKey, digest)
     return cert
-

--- a/examples/mk_simple_certs.py
+++ b/examples/mk_simple_certs.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Create certificates and private keys for the 'simple' example.
 """

--- a/examples/proxy.py
+++ b/examples/proxy.py
@@ -1,12 +1,26 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
 #
-# This script demonstrates how one can use pyOpenSSL to speak SSL over an HTTP
-# proxy
-# The challenge here is to start talking SSL over an already connected socket
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Author: Mihai Ibanescu <misa@redhat.com>
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# $Id: proxy.py,v 1.2 2004/07/22 12:01:25 martin Exp $
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This script demonstrates how one can use pyOpenSSL to speak SSL over an HTTP
+proxy.
+The challenge here is to start talking SSL over an already connected socket.
+"""
+
 
 import sys, socket, string
 from OpenSSL import SSL

--- a/examples/simple/client.py
+++ b/examples/simple/client.py
@@ -1,8 +1,18 @@
-# -*- coding: latin-1 -*-
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
 #
-# Copyright (C) AB Strakt
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Simple SSL client, using blocking I/O

--- a/examples/simple/server.py
+++ b/examples/simple/server.py
@@ -1,8 +1,18 @@
-# -*- coding: latin-1 -*-
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
 #
-# Copyright (C) AB Strakt
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Simple echo server, using nonblocking I/O
@@ -37,7 +47,7 @@ ctx.load_verify_locations(os.path.join(dir, 'CA.cert'))
 # Set up server
 server = SSL.Connection(ctx, socket.socket(socket.AF_INET, socket.SOCK_STREAM))
 server.bind(('', int(sys.argv[1])))
-server.listen(3) 
+server.listen(3)
 server.setblocking(0)
 
 clients = {}

--- a/examples/sni/client.py
+++ b/examples/sni/client.py
@@ -1,5 +1,18 @@
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 if __name__ == '__main__':
     import client

--- a/examples/sni/server.py
+++ b/examples/sni/server.py
@@ -1,5 +1,18 @@
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 if __name__ == '__main__':
     import server

--- a/leakcheck/context-info-callback.py
+++ b/leakcheck/context-info-callback.py
@@ -1,11 +1,26 @@
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
 #
-# Stress tester for thread-related bugs in global_info_callback in
-# src/ssl/context.c.  In 0.7 and earlier, this will somewhat reliably
-# segfault or abort after a few dozen to a few thousand iterations on an SMP
-# machine (generally not on a UP machine) due to uses of Python/C API
-# without holding the GIL.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Stress tester for thread-related bugs in global_info_callback in
+src/ssl/context.c.  In 0.7 and earlier, this will somewhat reliably segfault or
+abort after a few dozen to a few thousand iterations on an SMP machine
+(generally not on a UP machine) due to uses of Python/C API without holding the
+GIL.
+"""
 
 from itertools import count
 from threading import Thread

--- a/leakcheck/context-passphrase-callback.py
+++ b/leakcheck/context-passphrase-callback.py
@@ -1,11 +1,26 @@
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
 #
-# Stress tester for thread-related bugs in global_passphrase_callback in
-# src/ssl/context.c.  In 0.7 and earlier, this will somewhat reliably
-# segfault or abort after a few dozen to a few thousand iterations on an SMP
-# machine (generally not on a UP machine) due to uses of Python/C API
-# without holding the GIL.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Stress tester for thread-related bugs in global_passphrase_callback in
+src/ssl/context.c.  In 0.7 and earlier, this will somewhat reliably segfault or
+abort after a few dozen to a few thousand iterations on an SMP machine
+(generally not on a UP machine) due to uses of Python/C API without holding the
+GIL.
+"""
 
 from itertools import count
 from threading import Thread

--- a/leakcheck/context-verify-callback.py
+++ b/leakcheck/context-verify-callback.py
@@ -1,11 +1,26 @@
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
-#
-# Stress tester for thread-related bugs in global_verify_callback in
-# src/ssl/context.c.  This will reliably segfault if context.c isn't a
-# PyThreadState management technique which is compatible with the approach used
-# by ssl.c.
+# -*- coding: utf-8 -*-
 
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Stress tester for thread-related bugs in global_passphrase_callback in
+src/ssl/context.c.  In 0.7 and earlier, this will somewhat reliably segfault or
+abort after a few dozen to a few thousand iterations on an SMP machine
+(generally not on a UP machine) due to uses of Python/C API without holding the
+GIL.
+"""
 
 from itertools import count
 from threading import Thread

--- a/leakcheck/crypto.py
+++ b/leakcheck/crypto.py
@@ -1,5 +1,18 @@
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import sys
 

--- a/leakcheck/thread-crash.py
+++ b/leakcheck/thread-crash.py
@@ -1,13 +1,27 @@
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
-#
-# Stress tester for thread-related bugs in ssl_Connection_send and
-# ssl_Connection_recv in src/ssl/connection.c for usage of a single
-# Connection object simultaneously in multiple threads.  In 0.7 and earlier,
-# this will somewhat reliably cause Python to abort with a "tstate mix-up"
-# almost immediately, due to the incorrect sharing between threads of the
-# `tstate` field of the connection object.
+# -*- coding: utf-8 -*-
 
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Stress tester for thread-related bugs in ssl_Connection_send and
+ssl_Connection_recv in src/ssl/connection.c for usage of a single Connection
+object simultaneously in multiple threads.  In 0.7 and earlier, this will
+somewhat reliably cause Python to abort with a "tstate mix-up" almost
+immediately, due to the incorrect sharing between threads of the `tstate` field
+of the connection object.
+"""
 
 from socket import socket
 from threading import Thread

--- a/leakcheck/thread-key-gen.py
+++ b/leakcheck/thread-key-gen.py
@@ -1,9 +1,24 @@
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
 #
-# Stress tester for thread-related bugs in RSA and DSA key generation.  0.12 and
-# older held the GIL during these operations.  Subsequent versions release it
-# during them.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Stress tester for thread-related bugs in RSA and DSA key generation.  0.12 and
+older held the GIL during these operations.  Subsequent versions release it
+during them.
+"""
 
 from threading import Thread
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
 #
-# Copyright (C) Jean-Paul Calderone 2008-2015, All rights reserved
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Installation script for the OpenSSL module.
@@ -24,7 +35,7 @@ def read_file(*parts):
     Build an absolute path from *parts* and and return the contents of the
     resulting file.  Assume UTF-8 encoding.
     """
-    with codecs.open(os.path.join(HERE, *parts), "rb", "ascii") as f:
+    with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
         return f.read()
 
 

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import socket
 from sys import platform
 from functools import wraps, partial

--- a/src/OpenSSL/__init__.py
+++ b/src/OpenSSL/__init__.py
@@ -1,5 +1,18 @@
-# Copyright (C) AB Strakt
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 pyOpenSSL - A simple wrapper around the OpenSSL library

--- a/src/OpenSSL/_util.py
+++ b/src/OpenSSL/_util.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from warnings import warn
 import sys
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import datetime
 
 from time import mktime

--- a/src/OpenSSL/rand.py
+++ b/src/OpenSSL/rand.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 PRNG management routines, thin wrappers.
 """

--- a/src/OpenSSL/tsafe.py
+++ b/src/OpenSSL/tsafe.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from OpenSSL import SSL
 _ssl = SSL
 del SSL

--- a/src/OpenSSL/version.py
+++ b/src/OpenSSL/version.py
@@ -1,6 +1,18 @@
-# Copyright (C) AB Strakt
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 pyOpenSSL - A simple wrapper around the OpenSSL library

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,18 @@
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Package containing unit tests for :py:mod:`OpenSSL`.

--- a/tests/memdbg.py
+++ b/tests/memdbg.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 sys.modules['ssl'] = None
 sys.modules['_hashlib'] = None

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 This is a legacy file that no-one currently knows how to use.
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,8 +1,21 @@
-# Copyright (c) Jean-Paul Calderone
-# See LICENSE file for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
-Unit tests for :py:mod:`OpenSSL.crypto`.
+Unit tests for :mod:`OpenSSL.crypto`.
 """
 
 from unittest import main

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -1,8 +1,21 @@
-# Copyright (c) Frederick Dean
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
-Unit tests for :py:obj:`OpenSSL.rand`.
+Unit tests for :mod:`OpenSSL.rand`.
 """
 
 import os

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1,8 +1,21 @@
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
-Unit tests for :py:obj:`OpenSSL.SSL`.
+Unit tests for :mod:`OpenSSL.SSL`.
 """
 
 from gc import collect, get_referrers

--- a/tests/test_tsafe.py
+++ b/tests/test_tsafe.py
@@ -1,8 +1,21 @@
-# Copyright (C) Jean-Paul Calderone
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
-Unit tests for :py:obj:`OpenSSL.tsafe`.
+Unit tests for :mod:`OpenSSL.tsafe`.
 """
 
 from OpenSSL.SSL import TLSv1_METHOD, Context

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from OpenSSL._util import exception_from_error_queue, lib
 
 from .util import TestCase

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,10 +1,23 @@
-# Copyright (C) Jean-Paul Calderone
-# Copyright (C) Twisted Matrix Laboratories.
-# See LICENSE for details.
+# -*- coding: utf-8 -*-
+
+# Copyright 2001 Twisted Matrix Laboratories.
+# Copyright 2001 Martin Sjögren and pyOpenSSL contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Helpers for the OpenSSL test suite, largely copied from
-U{Twisted<http://twistedmatrix.com/>}.
+`Twisted <http://twistedmatrix.com/>`_.
 """
 
 import shutil


### PR DESCRIPTION
- According to
https://en.wikipedia.org/wiki/Copyright_notice#Form_of_notice_for_visually_perceptible_copies
, it's enough to mention the year of first release.  If someone has
a connections to VanL, I'd gladly listen. :)
- The copyright notices that were floating around have been all moved into
NOTICE.
- Since Martin's name contains an ö, I've also added an encoding which
shouldn't be a problem in 2015.

***

It would be nice to know whether @exarkun feels violated in his copyrights by these changes in any way (IANAL but it should be all OK).