### PR TITLE
test_crypto.py: Enable tests to pass when MD5 verification disabled in OpenSSL.

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -54,8 +54,6 @@ def normalize_privatekey_pem(pem):
 GOOD_CIPHER = "blowfish"
 BAD_CIPHER = "zippers"
 
-#GOOD_DIGEST = "MD5"
-# MD5 verification disabled in some distros OpenSSL
 GOOD_DIGEST = "SHA1"
 BAD_DIGEST = "monkeys"
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -54,7 +54,9 @@ def normalize_privatekey_pem(pem):
 GOOD_CIPHER = "blowfish"
 BAD_CIPHER = "zippers"
 
-GOOD_DIGEST = "MD5"
+#GOOD_DIGEST = "MD5"
+# MD5 verification disabled in some distros OpenSSL
+GOOD_DIGEST = "SHA1"
 BAD_DIGEST = "monkeys"
 
 root_cert_pem = b("""-----BEGIN CERTIFICATE-----


### PR DESCRIPTION
Change GOOD_DIGEST to SHA1 to allow tests to pass for distros that have disabled MD5 verification in OpenSSL. 455 tests pass on Fedora 23.