### PR TITLE
Update docstrings for get_issuer/get_subject

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1314,11 +1314,13 @@ class X509(object):
         """
         Return the issuer of this certificate.
 
-        This creates a new :py:class:`X509Name`: modifying it does not affect
-        this certificate.
+        This creates a new :class:`X509Name` that wraps the underlying issuer
+        name field on the certificate. Modifying it will modify the underlying
+        certificate, and will have the effect of modifying any other
+        :class:`X509Name` that refers to this issuer.
 
         :return: The issuer of this certificate.
-        :rtype: :py:class:`X509Name`
+        :rtype: :class:`X509Name`
         """
         return self._get_name(_lib.X509_get_issuer_name)
 
@@ -1337,11 +1339,13 @@ class X509(object):
         """
         Return the subject of this certificate.
 
-        This creates a new :py:class:`X509Name`: modifying it does not affect
-        this certificate.
+        This creates a new :class:`X509Name` that wraps the underlying subject
+        name field on the certificate. Modifying it will modify the underlying
+        certificate, and will have the effect of modifying any other
+        :class:`X509Name` that refers to this subject.
 
         :return: The subject of this certificate.
-        :rtype: :py:class:`X509Name`
+        :rtype: :class:`X509Name`
         """
         return self._get_name(_lib.X509_get_subject_name)
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -852,11 +852,13 @@ class X509Req(object):
         """
         Return the subject of this certificate signing request.
 
-        This creates a new :py:class:`X509Name`: modifying it does not affect
-        this request.
+        This creates a new :class:`X509Name` that wraps the underlying subject
+        name field on the certificate signing request. Modifying it will modify
+        the underlying signing request, and will have the effect of modifying
+        any other :class:`X509Name` that refers to this subject.
 
         :return: The subject of this certificate signing request.
-        :rtype: :py:class:`X509Name`
+        :rtype: :class:`X509Name`
         """
         name = X509Name.__new__(X509Name)
         name._name = _lib.X509_REQ_get_subject_name(self._req)


### PR DESCRIPTION
Resolves #395.

This is the *easy* route out of this issue: simply assume the docstrings were in error and update them to reflect the actual behaviour of the code.

This might not be what we want to do though. The particularly confusing thing is that this leads to lots of spooky action at a distance, where multiple objects refer through to the same singleton object. I have terrifying visions of thread safety and weird other nonsense, and it's not clear to me that these are necessarily the best ways to manipulate the subject/issuer fields. *Also*, the `X509` class has `set_issuer`/`set_subject` methods, which further suggests that having the `X509Name` class edit the underlying structure might not have been the original intention.

We can go another way here, and copy the underlying data out when we create these in the `get` methods. This will cause the original docstrings to become correct. We'd also have to add a `set_subject` method to the `X509Req` class.

Thoughts?