### PR TITLE
Let’s try to fix the build once again, shall we?

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,13 @@ whitelist_externals =
 passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
 deps =
     coverage
-    pytest>=2.8.2
+    pytest>=2.8.2,!=2.8.4
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
 setenv =
     # Do not allow the executing environment to pollute the test environment
     # with extra packages.
     PYTHONPATH=
+    PIP_NO_BINARY=:all:
 commands =
     openssl version
     python -c "import OpenSSL.SSL; print(OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION))"

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv =
     # Do not allow the executing environment to pollute the test environment
     # with extra packages.
     PYTHONPATH=
-    PIP_NO_BINARY=:all:
+    PIP_NO_BINARY=cryptography
 commands =
     openssl version
     python -c "import OpenSSL.SSL; print(OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION))"


### PR DESCRIPTION
py.test has broken deprecation behavior in 2.8.4, wheels make testing of
various OpenSSLs on OS X impossible.