### PR TITLE
Raise NotImplementedError for Unimplemented Functions

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -696,6 +696,7 @@ class Context(object):
         :param cafile: The name of the certificates file
         :return: None
         """
+        raise NotImplementedError()
 
     def set_session_id(self, buf):
         """
@@ -705,6 +706,7 @@ class Context(object):
         :param buf: A Python object that can be safely converted to a string
         :returns: None
         """
+        raise NotImplementedError()
 
     def set_session_cache_mode(self, mode):
         """
@@ -1406,6 +1408,7 @@ class Connection(object):
 
         :return: True if the renegotiation can be started, false otherwise
         """
+        raise NotImplementedError()
 
     def do_handshake(self):
         """
@@ -1424,6 +1427,7 @@ class Connection(object):
 
         :return: Whether there's a renegotiation in progress
         """
+        raise NotImplementedError()
 
     def total_renegotiations(self):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1293,8 +1293,15 @@ class ContextTests(TestCase, _LoopbackMixin):
             Error, context.use_certificate_chain_file, self.mktemp()
         )
 
-    # XXX load_client_ca
-    # XXX set_session_id
+    def test_load_client_ca(self):
+        context = Context(TLSv1_METHOD)
+        with pytest.raises(NotImplementedError):
+            context.load_client_ca(None)
+
+    def test_set_session_id(self):
+        context = Context(TLSv1_METHOD)
+        with pytest.raises(NotImplementedError):
+            context.set_session_id("session")
 
     def test_get_verify_mode_wrong_args(self):
         """
@@ -3159,6 +3166,16 @@ class ConnectionRenegotiateTests(TestCase, _LoopbackMixin):
         """
         connection = Connection(Context(TLSv1_METHOD), None)
         self.assertEquals(connection.total_renegotiations(), 0)
+
+    def test_renegotiate(self):
+        connection = Connection(Context(TLSv1_METHOD), None)
+        with pytest.raises(NotImplementedError):
+            connection.renegotiate()
+
+    def test_renegotiate_pending(self):
+        connection = Connection(Context(TLSv1_METHOD), None)
+        with pytest.raises(NotImplementedError):
+            connection.renegotiate_pending()
 
 #     def test_renegotiate(self):
 #         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2540,7 +2540,6 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         ctx = Context(TLSv1_METHOD)
         ctx.use_privatekey(key)
         ctx.use_certificate(cert)
-        ctx.set_session_id("unity-test")
 
         def makeServer(socket):
             server = Connection(ctx, socket)
@@ -2580,7 +2579,6 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         ctx = Context(TLSv1_METHOD)
         ctx.use_privatekey(key)
         ctx.use_certificate(cert)
-        ctx.set_session_id("unity-test")
 
         def makeServer(socket):
             server = Connection(ctx, socket)


### PR DESCRIPTION
As the title says - just silently doing nothing is really unexpected.

refs #387, refs #388