### PR TITLE
compare datetimes directly for the expiry check

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1,6 +1,5 @@
 import datetime
 
-from time import mktime
 from base64 import b16encode
 from functools import partial
 from operator import __eq__, __ne__, __lt__, __le__, __gt__, __ge__
@@ -1213,11 +1212,9 @@ class X509(object):
         :rtype: :py:class:`bool`
         """
         time_string = _native(self.get_notAfter())
-        timestamp = mktime(datetime.datetime.strptime(
-            time_string, "%Y%m%d%H%M%SZ").timetuple())
-        now = mktime(datetime.datetime.utcnow().timetuple())
+        not_after = datetime.datetime.strptime(time_string, "%Y%m%d%H%M%SZ")
 
-        return timestamp < now
+        return not_after < datetime.datetime.utcnow()
 
     def _get_boundary_time(self, which):
         return _get_asn1_time(which(self._x509))


### PR DESCRIPTION
fixes #414 

This removes the unsafe (and pointless) conversion of the datetime object to a unix timestamp using mktime (as noted by @zed in #378).