### PR TITLE
Make pyOpenSSL future-proof

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,21 @@ matrix:
   - python: "pypy"
     env: TOXENV=pypy-cryptographyMaster
 
+  # And older cryptography versions.
+  - python: "2.6"
+    env: TOXENV=py26-cryptographyLegacy
+  - python: "2.7"
+    env: TOXENV=py27-cryptographyLegacy
+  - python: "3.3"
+    env: TOXENV=py33-cryptographyLegacy
+  - python: "3.4"
+    env: TOXENV=py34-cryptographyLegacy
+  - python: "3.5"
+    env: TOXENV=py35-cryptographyLegacy
+  - python: "pypy"
+    env: TOXENV=pypy-cryptographyLegacy
+
+
   # Make sure we don't break Twisted
   - python: "2.7"
     env: TOXENV=py27-twistedMaster

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,7 @@ matrix:
   - env: TOXENV=py34-cryptographyMaster
   - env: TOXENV=py35-cryptographyMaster
   - env: TOXENV=pypy-cryptographyMaster
+  - env: TOXENV=pypy-cryptographyLegacy
   - env: TOXENV=pypy
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,17 +47,17 @@ matrix:
 
   # And older cryptography versions.
   - python: "2.6"
-    env: TOXENV=py26-cryptographyLegacy
+    env: TOXENV=py26-cryptography1.1
   - python: "2.7"
-    env: TOXENV=py27-cryptographyLegacy
+    env: TOXENV=py27-cryptography1.1
   - python: "3.3"
-    env: TOXENV=py33-cryptographyLegacy
+    env: TOXENV=py33-cryptography1.1
   - python: "3.4"
-    env: TOXENV=py34-cryptographyLegacy
+    env: TOXENV=py34-cryptography1.1
   - python: "3.5"
-    env: TOXENV=py35-cryptographyLegacy
+    env: TOXENV=py35-cryptography1.1
   - python: "pypy"
-    env: TOXENV=pypy-cryptographyLegacy
+    env: TOXENV=pypy-cryptography1.1
 
 
   # Make sure we don't break Twisted
@@ -100,7 +100,7 @@ matrix:
   - env: TOXENV=py34-cryptographyMaster
   - env: TOXENV=py35-cryptographyMaster
   - env: TOXENV=pypy-cryptographyMaster
-  - env: TOXENV=pypy-cryptographyLegacy
+  - env: TOXENV=pypy-cryptography1.1
   - env: TOXENV=pypy
 
 install:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pytest]
-minversion = 2.8.2
+minversion = 2.8.5
 strict = true
 testpaths = tests
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -247,7 +247,7 @@ class PKey(object):
         if self._only_public:
             raise TypeError("public key only")
 
-        if _lib.EVP_PKEY_type(self._pkey.type) != _lib.EVP_PKEY_RSA:
+        if _lib.EVP_PKEY_type(self.type()) != _lib.EVP_PKEY_RSA:
             raise TypeError("key type unsupported")
 
         rsa = _lib.EVP_PKEY_get1_RSA(self._pkey)
@@ -263,7 +263,12 @@ class PKey(object):
 
         :return: The type of the key.
         """
-        return self._pkey.type
+        try:
+            # cryptography 1.2+
+            return _lib.Cryptography_EVP_PKEY_id(self._pkey)
+        except AttributeError:
+            # Older releases of cryptography.
+            return self._pkey.type
 
     def bits(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,{pypy,py26,py27,py33,py34,py35}{,-cryptographyMaster,-cryptographyLegacy},py27-twistedMaster,pypi-readme,check-manifest,flake8,docs,coverage-report
+envlist = coverage-clean,{pypy,py26,py27,py33,py34,py35}{,-cryptographyMaster,-cryptography1.1},py27-twistedMaster,pypi-readme,check-manifest,flake8,docs,coverage-report
 
 [testenv]
 whitelist_externals =
@@ -9,7 +9,7 @@ deps =
     coverage
     pytest>=2.8.5
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
-    cryptographyLegacy: cryptography<1.2
+    cryptography1.1: cryptography<1.2
 setenv =
     # Do not allow the executing environment to pollute the test environment
     # with extra packages.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,{pypy,py26,py27,py33,py34,py35}{,-cryptographyMaster},py27-twistedMaster,pypi-readme,check-manifest,flake8,docs,coverage-report
+envlist = coverage-clean,{pypy,py26,py27,py33,py34,py35}{,-cryptographyMaster,-cryptographyLegacy},py27-twistedMaster,pypi-readme,check-manifest,flake8,docs,coverage-report
 
 [testenv]
 whitelist_externals =
@@ -7,8 +7,9 @@ whitelist_externals =
 passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
 deps =
     coverage
-    pytest>=2.8.2,!=2.8.4
+    pytest>=2.8.5
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
+    cryptographyLegacy: cryptography<1.2
 setenv =
     # Do not allow the executing environment to pollute the test environment
     # with extra packages.


### PR DESCRIPTION
Notably stop breaking cryptography 1.3.

Based on #406.