### PR TITLE
Implement missing methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,19 +45,19 @@ matrix:
   - python: "pypy"
     env: TOXENV=pypy-cryptographyMaster
 
-  # And older cryptography versions.
+  # And current minimum cryptography version.
   - python: "2.6"
-    env: TOXENV=py26-cryptography1.2
+    env: TOXENV=py26-cryptographyMinimum
   - python: "2.7"
-    env: TOXENV=py27-cryptography1.2
+    env: TOXENV=py27-cryptographyMinimum
   - python: "3.3"
-    env: TOXENV=py33-cryptography1.2
+    env: TOXENV=py33-cryptographyMinimum
   - python: "3.4"
-    env: TOXENV=py34-cryptography1.2
+    env: TOXENV=py34-cryptographyMinimum
   - python: "3.5"
-    env: TOXENV=py35-cryptography1.2
+    env: TOXENV=py35-cryptographyMinimum
   - python: "pypy"
-    env: TOXENV=pypy-cryptography1.2
+    env: TOXENV=pypy-cryptographyMinimum
 
 
   # Make sure we don't break Twisted or urllib3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,9 +41,9 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-- Fixed :meth:`OpenSSL.SSL.Context.set_session_id`, :meth:`OpenSSL.SSL.Connection.renegotiate`, :meth:`OpenSSL.SSL.Connection.renegotiate_pending`, and :meth:`OpenSSL.SSL.Context.load_client_ca`.
+- Fixed ``OpenSSL.SSL.Context.set_session_id``, ``OpenSSL.SSL.Connection.renegotiate``, ``OpenSSL.SSL.Connection.renegotiate_pending``, and ``OpenSSL.SSL.Context.load_client_ca``.
   They were lacking an implementation since 0.14.
-  [`#422 <https://github.com/pyca/pyopenssl/pull/422>`_]
+  `#422 <https://github.com/pyca/pyopenssl/pull/422>`_
 - Fixed segmentation fault when using keys larger than 4096-bit to sign data.
   `#428 <https://github.com/pyca/pyopenssl/pull/428>`_
 - Fixed ``AttributeError`` when ``OpenSSL.SSL.Connection.get_app_data()`` was called before setting any app data.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,9 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
+- Fixed :meth:`OpenSSL.SSL.Context.set_session_id`, :meth:`OpenSSL.SSL.Connection.renegotiate`, :meth:`OpenSSL.SSL.Connection.renegotiate_pending`, and :meth:`OpenSSL.SSL.Context.load_client_ca`.
+  They were lacking an implementation since 0.14.
+  [`#422 <https://github.com/pyca/pyopenssl/pull/422>`_]
 - Fixed segmentation fault when using keys larger than 4096-bit to sign data.
   `#428 <https://github.com/pyca/pyopenssl/pull/428>`_
 - Fixed ``AttributeError`` when ``OpenSSL.SSL.Connection.get_app_data()`` was called before setting any app data.

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -274,10 +274,7 @@ Context objects have the following methods:
     Retrieve the Context object's verify mode, as set by :py:meth:`set_verify`.
 
 
-.. py:method:: Context.load_client_ca(pemfile)
-
-    Read a file with PEM-formatted certificates that will be sent to the client
-    when requesting a client certificate.
+.. automethod:: Context.load_client_ca
 
 
 .. py:method:: Context.set_client_ca_list(certificate_authorities)
@@ -387,12 +384,7 @@ Context objects have the following methods:
     .. versionadded:: 0.14
 
 
-.. py:method:: Context.set_session_id(name)
-
-    Set the context *name* within which a session can be reused for this
-    Context object. This is needed when doing session resumption, because there is
-    no way for a stored session to know which Context object it is associated with.
-    *name* may be any binary data.
+.. automethod:: Context.set_session_id
 
 
 .. py:method:: Context.set_timeout(timeout)
@@ -684,11 +676,11 @@ Connection objects have the following methods:
     bytes (for example, in response to a call to :py:meth:`recv`).
 
 
-.. py:method:: Connection.renegotiate()
+.. automethod:: Connection.renegotiate
 
-    Renegotiate the SSL session. Call this if you wish to change cipher suites or
-    anything like that.
+.. automethod:: Connection.renegotiate_pending
 
+.. automethod:: Connection.total_renegotiations
 
 .. py:method:: Connection.send(string)
 

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             # Fix cryptographyMinimum in tox.ini when changing this!
-            "cryptography>=1.2",
+            "cryptography>=1.3",
             "six>=1.5.2"
         ],
     )

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ if __name__ == "__main__":
         packages=find_packages(where="src"),
         package_dir={"": "src"},
         install_requires=[
+            # Fix cryptographyMinimum in tox.ini when changing this!
             "cryptography>=1.2",
             "six>=1.5.2"
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,{pypy,py26,py27,py33,py34,py35}{,-cryptographyMaster,-cryptography1.2},py27-twistedMaster,pypi-readme,check-manifest,flake8,docs,coverage-report
+envlist = coverage-clean,{pypy,py26,py27,py33,py34,py35}{,-cryptographyMaster,-cryptographyMinimum},py27-twistedMaster,pypi-readme,check-manifest,flake8,docs,coverage-report
 
 [testenv]
 whitelist_externals =
@@ -9,7 +9,7 @@ deps =
     coverage
     pytest>=2.8.5
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
-    cryptography1.2: cryptography<1.3
+    cryptographyMinimum: cryptography<1.4
 setenv =
     # Do not allow the executing environment to pollute the test environment
     # with extra packages.


### PR DESCRIPTION
First shot at #388.

- It would be nice if @tiran (or anyone else understand the matter) could suggest a better docstring.
- If anyone knows what could be checked in the test case I’m all ears.  There doesn’t seem to be a get_session_id?
- We also need to find a way to simulate errors. :-/

N.B. only the `-cryptographyMaster` envs are supposed to pass.  Once this and the other missing methods are signed off, @reaperhulk will release a cryptography 1.2 point release with the necessary bindings.

- [x] set cryptography requirement to `>=1.3` in setup.py once 1.3 is available.