### PR TITLE
X509_REVOKED_dup is a thing cryptography can do for you

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
         packages=find_packages(where="src"),
         package_dir={"": "src"},
         install_requires=[
-            "cryptography>=0.7",
+            "cryptography>=1.2",
             "six>=1.5.2"
         ],
     )

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1912,7 +1912,7 @@ class CRL(object):
         revoked_stack = self._crl.crl.revoked
         for i in range(_lib.sk_X509_REVOKED_num(revoked_stack)):
             revoked = _lib.sk_X509_REVOKED_value(revoked_stack, i)
-            revoked_copy = _X509_REVOKED_dup(revoked)
+            revoked_copy = _lib.Cryptography_X509_REVOKED_dup(revoked)
             pyrev = Revoked.__new__(Revoked)
             pyrev._revoked = _ffi.gc(revoked_copy, _lib.X509_REVOKED_free)
             results.append(pyrev)

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1707,32 +1707,6 @@ def dump_privatekey(type, pkey, cipher=None, passphrase=None):
     return _bio_to_string(bio)
 
 
-def _X509_REVOKED_dup(original):
-    copy = _lib.X509_REVOKED_new()
-    if copy == _ffi.NULL:
-        # TODO: This is untested.
-        _raise_current_error()
-
-    if original.serialNumber != _ffi.NULL:
-        _lib.ASN1_INTEGER_free(copy.serialNumber)
-        copy.serialNumber = _lib.ASN1_INTEGER_dup(original.serialNumber)
-
-    if original.revocationDate != _ffi.NULL:
-        _lib.ASN1_TIME_free(copy.revocationDate)
-        copy.revocationDate = _lib.M_ASN1_TIME_dup(original.revocationDate)
-
-    if original.extensions != _ffi.NULL:
-        extension_stack = _lib.sk_X509_EXTENSION_new_null()
-        for i in range(_lib.sk_X509_EXTENSION_num(original.extensions)):
-            original_ext = _lib.sk_X509_EXTENSION_value(original.extensions, i)
-            copy_ext = _lib.X509_EXTENSION_dup(original_ext)
-            _lib.sk_X509_EXTENSION_push(extension_stack, copy_ext)
-        copy.extensions = extension_stack
-
-    copy.sequence = original.sequence
-    return copy
-
-
 class Revoked(object):
     """
     A certificate revocation.
@@ -1958,7 +1932,7 @@ class CRL(object):
 
         :return: :py:const:`None`
         """
-        copy = _X509_REVOKED_dup(revoked._revoked)
+        copy = _lib.Cryptography_X509_REVOKED_dup(revoked._revoked)
         if copy == _ffi.NULL:
             # TODO: This is untested.
             _raise_current_error()

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3186,7 +3186,7 @@ class CRLTests(TestCase):
         """
         crl = CRL()
         revoked = Revoked()
-        revoked.set_serial("01")
+        revoked.set_serial(b"01")
         revoked.set_rev_date(b"20160310020145Z")
         crl.add_revoked(revoked=revoked)
         self.assertTrue(isinstance(crl.get_revoked()[0], Revoked))

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3186,6 +3186,8 @@ class CRLTests(TestCase):
         """
         crl = CRL()
         revoked = Revoked()
+        revoked.set_serial("01")
+        revoked.set_rev_date(b"20160310020145Z")
         crl.add_revoked(revoked=revoked)
         self.assertTrue(isinstance(crl.get_revoked()[0], Revoked))
 


### PR DESCRIPTION
This is one way to fix #431. Unfortunately it causes a failure in `test_add_revoked_keyword`. This is because that test attempts to add an invalid (empty) revoked certificate structure, which can't be serialized to ASN.1 (which is how the OpenSSL `dup` functions work). I've altered the test to set a serial and revocation date, which makes it a valid structure and will pass. This should be fine since the current behavior won't actually work if you try to create a CRL with an empty revoked (it will just fail later in the process).