### PR TITLE
Fix set_cipher_list on modern OpenSSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,15 +85,7 @@ matrix:
 
   # - Let the cryptography master builds fail because they might be triggered by
   #   cryptography changes beyond our control.
-  # - Also allow OS X and 0.9.8 to fail at the moment while we fix these new
-  #   build configurations.
-  # - Also allow lint to fail while we fix existing lint.
-  # - We alloy pypy to fail until Travis fixes their infrastructure to a pypy
-  #   with a recent enought CFFI library to run cryptography 1.0+.
   allow_failures:
-  - language: generic
-    os: osx
-    env: TOXENV=py27 OSX_OPENSSL=homebrew
   - env: TOXENV=py26-cryptographyMaster
   - env: TOXENV=py27-cryptographyMaster
   - env: TOXENV=py33-cryptographyMaster

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -333,11 +333,7 @@ Context objects have the following methods:
     later using the :py:meth:`get_app_data` method.
 
 
-.. py:method:: Context.set_cipher_list(ciphers)
-
-    Set the list of ciphers to be used in this context. See the OpenSSL manual for
-    more information (e.g. :manpage:`ciphers(1)`)
-
+.. automethod:: Context.set_cipher_list
 
 .. py:method:: Context.set_info_callback(callback)
 
@@ -592,11 +588,7 @@ Connection objects have the following methods:
     Retrieve application data as set by :py:meth:`set_app_data`.
 
 
-.. py:method:: Connection.get_cipher_list()
-
-    Retrieve the list of ciphers used by the Connection object. WARNING: This API
-    has changed. It used to take an optional parameter and just return a string,
-    but now it returns the entire list in one go.
+.. automethod:: Connection.get_cipher_list
 
 
 .. py:method:: Connection.get_protocol_version()
@@ -610,7 +602,7 @@ Connection objects have the following methods:
 
     Retrieve the version of the SSL or TLS protocol used by the Connection as
     a unicode string. For example, it will return ``TLSv1`` for connections
-    made over TLS version 1, or ``Unknown`` for connections that were not 
+    made over TLS version 1, or ``Unknown`` for connections that were not
     successfully established.
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 #
 
 """
-Installation script for the OpenSSL module.
+Installation script for the OpenSSL package.
 """
 
 import codecs

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -823,7 +823,7 @@ class Context(object):
             raise TypeError("cipher_list must be a byte string.")
 
         _openssl_assert(
-            _lib.SSL_CTX_set_cipher_list(self._context, cipher_list)
+            _lib.SSL_CTX_set_cipher_list(self._context, cipher_list) == 1
         )
 
     def set_client_ca_list(self, certificate_authorities):

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -820,7 +820,7 @@ class Context(object):
         cipher_list = _text_to_bytes_and_warn("cipher_list", cipher_list)
 
         if not isinstance(cipher_list, bytes):
-            raise TypeError("cipher_list must be a bytes string.")
+            raise TypeError("cipher_list must be a byte string.")
 
         _openssl_assert(
             _lib.SSL_CTX_set_cipher_list(self._context, cipher_list)

--- a/src/OpenSSL/_util.py
+++ b/src/OpenSSL/_util.py
@@ -58,7 +58,7 @@ def make_assert(error):
         """
         If ok is not true-ish, retrieve the error from OpenSSL and raise it.
         """
-        if not ok:
+        if ok is not True:
             exception_from_error_queue(error)
 
     return openssl_assert

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -362,9 +362,9 @@ class TestContext(object):
     ])
     def test_set_cipher_list(self, context, cipher_string):
         """
-        :meth:`Context.set_cipher_list` accepts both :py:obj:`bytes` naming the
-        ciphers which connections created with the context object will be able
-        to choose from.
+        :meth:`Context.set_cipher_list` accepts both byte and unicode strings
+        for naming the ciphers which connections created with the context
+        object will be able to choose from.
         """
         context.set_cipher_list(cipher_string)
         conn = Connection(context, None)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2,7 +2,7 @@
 # See LICENSE for details.
 
 """
-Unit tests for :py:obj:`OpenSSL.SSL`.
+Unit tests for :mod:`OpenSSL.SSL`.
 """
 
 from gc import collect, get_referrers
@@ -17,7 +17,7 @@ from warnings import catch_warnings, simplefilter
 
 import pytest
 
-from six import PY3, text_type, u
+from six import PY3, text_type
 
 from OpenSSL.crypto import TYPE_RSA, FILETYPE_PEM
 from OpenSSL.crypto import PKey, X509, X509Extension, X509Store
@@ -345,6 +345,44 @@ class VersionTests(TestCase):
             versions[version] = t
             self.assertTrue(isinstance(version, bytes))
         self.assertEqual(len(versions), 5)
+
+
+@pytest.fixture
+def context():
+    """
+    A simple TLS 1.0 context.
+    """
+    return Context(TLSv1_METHOD)
+
+
+class TestContext(object):
+    @pytest.mark.parametrize("cipher_string", [
+        b"hello world:AES128-SHA",
+        u"hello world:AES128-SHA",
+    ])
+    def test_set_cipher_list(self, context, cipher_string):
+        """
+        :meth:`Context.set_cipher_list` accepts both :py:obj:`bytes` naming the
+        ciphers which connections created with the context object will be able
+        to choose from.
+        """
+        context.set_cipher_list(cipher_string)
+        conn = Connection(context, None)
+
+        assert "AES128-SHA" in conn.get_cipher_list()
+
+    @pytest.mark.parametrize("cipher_list,error", [
+        (object(), TypeError),
+        ("imaginary-cipher", Error),
+    ])
+    def test_set_cipher_list_wrong_args(self, context, cipher_list, error):
+        """
+        :meth:`Context.set_cipher_list` raises :exc:`TypeError` when passed a
+        non-string argument and raises :exc:`OpenSSL.SSL.Error` when passed an
+        incorrect cipher list string.
+        """
+        with pytest.raises(error):
+            context.set_cipher_list(cipher_list)
 
 
 class ContextTests(TestCase, _LoopbackMixin):
@@ -1393,44 +1431,6 @@ class ContextTests(TestCase, _LoopbackMixin):
             # The only easily "assertable" thing is that it does not raise an
             # exception.
             context.set_tmp_ecdh(curve)
-
-    def test_set_cipher_list_bytes(self):
-        """
-        :py:obj:`Context.set_cipher_list` accepts a :py:obj:`bytes` naming the
-        ciphers which connections created with the context object will be able
-        to choose from.
-        """
-        context = Context(TLSv1_METHOD)
-        context.set_cipher_list(b"hello world:EXP-RC4-MD5")
-        conn = Connection(context, None)
-        self.assertEquals(conn.get_cipher_list(), ["EXP-RC4-MD5"])
-
-    def test_set_cipher_list_text(self):
-        """
-        :py:obj:`Context.set_cipher_list` accepts a :py:obj:`unicode` naming
-        the ciphers which connections created with the context object will be
-        able to choose from.
-        """
-        context = Context(TLSv1_METHOD)
-        context.set_cipher_list(u("hello world:EXP-RC4-MD5"))
-        conn = Connection(context, None)
-        self.assertEquals(conn.get_cipher_list(), ["EXP-RC4-MD5"])
-
-    def test_set_cipher_list_wrong_args(self):
-        """
-        :py:obj:`Context.set_cipher_list` raises :py:obj:`TypeError` when
-        passed zero arguments or more than one argument or when passed a
-        non-string single argument and raises :py:obj:`OpenSSL.SSL.Error` when
-        passed an incorrect cipher list string.
-        """
-        context = Context(TLSv1_METHOD)
-        self.assertRaises(TypeError, context.set_cipher_list)
-        self.assertRaises(TypeError, context.set_cipher_list, object())
-        self.assertRaises(
-            TypeError, context.set_cipher_list, b"EXP-RC4-MD5", object()
-        )
-
-        self.assertRaises(Error, context.set_cipher_list, "imaginary-cipher")
 
     def test_set_session_cache_mode_wrong_args(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
     openssl version
     python -c "import OpenSSL.SSL; print(OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION))"
     python -c "import cryptography; print(cryptography.__version__)"
-    coverage run --parallel -m pytest tests
+    coverage run --parallel -m pytest {posargs}
 
 [testenv:py27-twistedMaster]
 deps =


### PR DESCRIPTION
So I’ve changed my mind on #436 and did it right away while forward-porting the useful changes from #422 so they don’t linger around and we have to do without them.  The warnings change is btw for deprecation warning checks in py.test.