### PR TITLE
Convert between pyOpenSSL and cryptography objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ Changes:
 
 - Enable use of CRL (and more) in verify context.
   `#483 <https://github.com/pyca/pyopenssl/pull/483>`_
+- ``OpenSSL.crypto.PKey`` can now be constructed from ``cryptography`` objects and also exported as such.
+  `#439 <https://github.com/pyca/pyopenssl/pull/439>`_
 
 
 ----

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -171,6 +171,16 @@ class PKey(object):
         self._initialized = False
 
     def to_cryptography_key(self):
+        """
+        Export as a ``cryptography`` key.
+
+        :rtype: One of ``cryptography``'s `key interfaces`_.
+
+        .. _key interfaces: https://cryptography.io/en/latest/hazmat/\
+            primitives/asymmetric/rsa/#key-interfaces
+
+        .. versionadded:: 16.1.0
+        """
         if self._only_public:
             return backend._evp_pkey_to_public_key(self._pkey)
         else:
@@ -178,6 +188,16 @@ class PKey(object):
 
     @classmethod
     def from_cryptography_key(cls, crypto_key):
+        """
+        Construct based on a ``cryptography`` *crypto_key*.
+
+        :param crypto_key: A ``cryptography`` key.
+        :type crypto_key: One of ``cryptography``'s `key interfaces`_.
+
+        :rtype: PKey
+
+        .. versionadded:: 16.1.0
+        """
         pkey = cls()
         pkey._pkey = crypto_key._evp_pkey
         if isinstance(crypto_key, (rsa.RSAPublicKey, dsa.DSAPublicKey)):

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -12,9 +12,6 @@ from six import (
 
 from cryptography.hazmat.backends.openssl.backend import backend
 from cryptography.hazmat.primitives.asymmetric import dsa, rsa
-from cryptography.hazmat.backends.openssl.x509 import (
-    _Certificate, _CertificateSigningRequest
-)
 
 from OpenSSL._util import (
     ffi as _ffi,

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -199,6 +199,10 @@ class PKey(object):
         .. versionadded:: 16.1.0
         """
         pkey = cls()
+        if not isinstance(crypto_key, (rsa.RSAPublicKey, rsa.RSAPrivateKey,
+                                       dsa.DSAPublicKey, dsa.DSAPrivateKey)):
+            raise TypeError("Unsupported key type")
+
         pkey._pkey = crypto_key._evp_pkey
         if isinstance(crypto_key, (rsa.RSAPublicKey, dsa.DSAPublicKey)):
             pkey._only_public = True

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -10,6 +10,12 @@ from six import (
     text_type as _text_type,
     PY3 as _PY3)
 
+from cryptography.hazmat.backends.openssl.backend import backend
+from cryptography.hazmat.primitives.asymmetric import dsa, rsa
+from cryptography.hazmat.backends.openssl.x509 import (
+    _Certificate, _CertificateSigningRequest
+)
+
 from OpenSSL._util import (
     ffi as _ffi,
     lib as _lib,
@@ -166,6 +172,21 @@ class PKey(object):
         pkey = _lib.EVP_PKEY_new()
         self._pkey = _ffi.gc(pkey, _lib.EVP_PKEY_free)
         self._initialized = False
+
+    def to_cryptography_key(self):
+        if self._only_public:
+            return backend._evp_pkey_to_public_key(self._pkey)
+        else:
+            return backend._evp_pkey_to_private_key(self._pkey)
+
+    @classmethod
+    def from_cryptography_key(cls, crypto_key):
+        pkey = cls()
+        pkey._pkey = crypto_key._evp_pkey
+        if isinstance(crypto_key, (rsa.RSAPublicKey, dsa.DSAPublicKey)):
+            pkey._only_public = True
+        pkey._initialized = True
+        return pkey
 
     def generate_key(self, type, bits):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -20,7 +20,7 @@ from six import u, b, binary_type
 
 from cryptography.hazmat.backends.openssl.backend import backend
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import dsa, rsa
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from OpenSSL.crypto import TYPE_RSA, TYPE_DSA, Error, PKey, PKeyType
 from OpenSSL.crypto import X509, X509Type, X509Name, X509NameType

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -18,6 +18,10 @@ import pytest
 
 from six import u, b, binary_type
 
+from cryptography.hazmat.backends.openssl.backend import backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import dsa, rsa
+
 from OpenSSL.crypto import TYPE_RSA, TYPE_DSA, Error, PKey, PKeyType
 from OpenSSL.crypto import X509, X509Type, X509Name, X509NameType
 from OpenSSL.crypto import (
@@ -747,6 +751,60 @@ class X509ExtTests(TestCase):
                 X509Extension,
                 'authorityKeyIdentifier', False, 'keyid:always,issuer:always',
                 issuer=badObj)
+
+
+class TestPKey(object):
+    """
+    py.test-based tests for :class:`OpenSSL.crypto.PKey`.
+
+    If possible, add new tests here.
+    """
+
+    def test_convert_from_cryptography_private_key(self):
+        """
+        Convert from a cryptography private key to a pyOpenSSL PKey.
+        """
+        key = serialization.load_pem_private_key(
+            intermediate_key_pem, None, backend
+        )
+        pkey = PKey.from_cryptography_key(key)
+
+        assert isinstance(pkey, PKey)
+        assert pkey.bits() == key.key_size
+        assert pkey._only_public is False
+        assert pkey._initialized is True
+
+    def test_convert_from_cryptography_public_key(self):
+        """
+        Convert from a cryptography public key to a pyOpenSSL PKey.
+        """
+        key = serialization.load_pem_public_key(cleartextPublicKeyPEM, backend)
+        pkey = PKey.from_cryptography_key(key)
+
+        assert isinstance(pkey, PKey)
+        assert pkey.bits() == key.key_size
+        assert pkey._only_public is True
+        assert pkey._initialized is True
+
+    def test_convert_public_pkey_to_cryptography_key(self):
+        """
+        Convert from a pyOpenSSL PKey to a cryptography public key.
+        """
+        pkey = load_publickey(FILETYPE_PEM, cleartextPublicKeyPEM)
+        key = pkey.to_cryptography_key()
+
+        assert isinstance(key, rsa.RSAPublicKey)
+        assert pkey.bits() == key.key_size
+
+    def test_convert_private_pkey_to_cryptography_key(self):
+        """
+        Convert from a pyOpenSSL PKey to a cryptography private key.
+        """
+        pkey = load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM)
+        key = pkey.to_cryptography_key()
+
+        assert isinstance(key, rsa.RSAPrivateKey)
+        assert pkey.bits() == key.key_size
 
 
 class PKeyTests(TestCase):

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -762,7 +762,7 @@ class TestPKey(object):
 
     def test_convert_from_cryptography_private_key(self):
         """
-        Convert from a cryptography private key to a pyOpenSSL PKey.
+        PKey.from_cryptography_key creates a proper private PKey.
         """
         key = serialization.load_pem_private_key(
             intermediate_key_pem, None, backend
@@ -776,7 +776,7 @@ class TestPKey(object):
 
     def test_convert_from_cryptography_public_key(self):
         """
-        Convert from a cryptography public key to a pyOpenSSL PKey.
+        PKey.from_cryptography_key creates a proper public PKey.
         """
         key = serialization.load_pem_public_key(cleartextPublicKeyPEM, backend)
         pkey = PKey.from_cryptography_key(key)
@@ -788,7 +788,7 @@ class TestPKey(object):
 
     def test_convert_public_pkey_to_cryptography_key(self):
         """
-        Convert from a pyOpenSSL PKey to a cryptography public key.
+        PKey.to_cryptography_key creates a proper cryptography public key.
         """
         pkey = load_publickey(FILETYPE_PEM, cleartextPublicKeyPEM)
         key = pkey.to_cryptography_key()
@@ -798,7 +798,7 @@ class TestPKey(object):
 
     def test_convert_private_pkey_to_cryptography_key(self):
         """
-        Convert from a pyOpenSSL PKey to a cryptography private key.
+        PKey.to_cryptography_key creates a proper cryptography private key.
         """
         pkey = load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM)
         key = pkey.to_cryptography_key()

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -521,6 +521,13 @@ AYU/QVM4wGt8XGT2KwDFJaxYGKsGDMWmXY04dS+WPuetCbouWUusyFwRb9SzFave
 vYeU7Ab/
 -----END RSA PRIVATE KEY-----""")
 
+ec_private_key_pem = b"""-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgYirTZSx+5O8Y6tlG
+cka6W6btJiocdrdolfcukSoTEk+hRANCAAQkvPNu7Pa1GcsWU4v7ptNfqCJVq8Cx
+zo0MUVPQgwJ3aJtNM1QMOQUayCrRwfklg+D/rFSUwEUqtZh7fJDiFqz3
+-----END PRIVATE KEY-----
+"""
+
 
 class X509ExtTests(TestCase):
     """
@@ -785,6 +792,16 @@ class TestPKey(object):
         assert pkey.bits() == key.key_size
         assert pkey._only_public is True
         assert pkey._initialized is True
+
+    def test_convert_from_cryptography_unsupported_type(self):
+        """
+        PKey.from_cryptography_key raises TypeError with an unsupported type.
+        """
+        key = serialization.load_pem_private_key(
+            ec_private_key_pem, None, backend
+        )
+        with pytest.raises(TypeError):
+            PKey.from_cryptography_key(key)
 
     def test_convert_public_pkey_to_cryptography_key(self):
         """


### PR DESCRIPTION
I'm putting this up so people can comment on this, but it is obviously incomplete:

- [x] tests
- [ ] handle case where a user might send a non-openssl cryptography object.
- [ ] conversion routines for CRLs
- [x] docs (if someone else wants to take a stab at this I'd really appreciate it)

@hynek do we want this in 16.0?