### PR TITLE
De-Sphinx CHANGELOG & add rel info to description

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Versions are year-based with a strict :doc:`backward-compatibility` policy.
+Versions are year-based with a strict backward-compatibility policy.
 The third digit is only for regressions.
 
 
@@ -28,9 +28,9 @@ Deprecations:
 ^^^^^^^^^^^^^
 
 - The support for EGD has been removed.
-  The only affected function :func:`OpenSSL.rand.egd` now uses :func:`os.urandom` to seed the internal PRNG instead.
+  The only affected function ``OpenSSL.rand.egd()`` now uses ``os.urandom()`` to seed the internal PRNG instead.
   Please see `pyca/cryptography#1636 <https://github.com/pyca/cryptography/pull/1636>`_ for more background information on this decision.
-  In accordance with our backward compatibility policy :func:`OpenSSL.rand.egd` will be *removed* no sooner than a year from the release of 16.0.0.
+  In accordance with our backward compatibility policy ``OpenSSL.rand.egd()`` will be *removed* no sooner than a year from the release of 16.0.0.
 
   Please note that you should `use urandom <http://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers/>`_ for all your secure random number needs.
 - Python 2.6 support has been deprecated.
@@ -42,26 +42,28 @@ Changes:
 ^^^^^^^^
 
 - Fixed segmentation fault when using keys larger than 4096-bit to sign data.
-  [`#428 <https://github.com/pyca/pyopenssl/pull/428>`_]
-- Fixed ``AttributeError`` when :meth:`OpenSSL.SSL.Connection.get_app_data` was called before setting any app data.
-  [`#304 <https://github.com/pyca/pyopenssl/pull/304>`_]
-- Added :func:`OpenSSL.crypto.dump_publickey` to dump :class:`OpenSSL.crypto.PKey` objects that represent public keys, and :func:`OpenSSL.crypto.load_publickey` to load such objects from serialized representations.
-  [`#382 <https://github.com/pyca/pyopenssl/pull/382>`_]
-- Added :func:`OpenSSL.crypto.dump_crl` to dump a certificate revocation list out to a string buffer.
-  [`#368 <https://github.com/pyca/pyopenssl/pull/368>`_]
-- Added :meth:`OpenSSL.SSL.Connection.state_string` using the OpenSSL binding ``state_string_long``.
-  [`#358 <https://github.com/pyca/pyopenssl/pull/358>`_]
-- Added support for the ``socket.MSG_PEEK`` flag to :meth:`OpenSSL.SSL.Connection.recv` and :meth:`OpenSSL.SSL.Connection.recv_into`.
-  [`#294 <https://github.com/pyca/pyopenssl/pull/294>`_]
-- Added :meth:`OpenSSL.SSL.Connection.get_protocol_version` and :meth:`OpenSSL.SSL.Connection.get_protocol_version_name`.
-  [`#244 <https://github.com/pyca/pyopenssl/pull/244>`_]
-- Switched to utf8string mask by default.
-  OpenSSL formerly defaulted to a T61String if there were UTF-8 characters present.
-  This was changed to default to UTF8String in the config around 2005, but the actual code didn't change it until late last year.
+  `#428 <https://github.com/pyca/pyopenssl/pull/428>`_
+- Fixed ``AttributeError`` when ``OpenSSL.SSL.Connection.get_app_data()`` was called before setting any app data.
+  `#304 <https://github.com/pyca/pyopenssl/pull/304>`_
+- Added ``OpenSSL.crypto.dump_publickey()`` to dump ``OpenSSL.crypto.PKey`` objects that represent public keys, and ``OpenSSL.crypto.load_publickey()`` to load such objects from serialized representations.
+  `#382 <https://github.com/pyca/pyopenssl/pull/382>`_
+- Added ``OpenSSL.crypto.dump_crl()`` to dump a certificate revocation list out to a string buffer.
+  `#368 <https://github.com/pyca/pyopenssl/pull/368>`_
+- Added ``OpenSSL.SSL.Connection.state_string()`` using the OpenSSL binding ``state_string_long``.
+  `#358 <https://github.com/pyca/pyopenssl/pull/358>`_
+- Added support for the ``socket.MSG_PEEK`` flag to ``OpenSSL.SSL.Connection.recv()`` and ``OpenSSL.SSL.Connection.recv_into()``.
+  `#294 <https://github.com/pyca/pyopenssl/pull/294>`_
+- Added ``OpenSSL.SSL.Connection.get_protocol_version()`` and ``OpenSSL.SSL.Connection.get_protocol_version_name()``.
+  `#244 <https://github.com/pyca/pyopenssl/pull/244>`_
+- Switched to ``utf8string`` mask by default.
+  OpenSSL formerly defaulted to a ``T61String`` if there were UTF-8 characters present.
+  This was changed to default to ``UTF8String`` in the config around 2005, but the actual code didn't change it until late last year.
   This will default us to the setting that actually works.
   To revert this you can call ``OpenSSL.crypto._lib.ASN1_STRING_set_default_mask_asc(b"default")``.
-  [`#234 <https://github.com/pyca/pyopenssl/pull/234>`_]
+  `#234 <https://github.com/pyca/pyopenssl/pull/234>`_
 
+
+----
 
 
 Older Changelog Entries

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -66,7 +66,7 @@ When introducing new functionality, please remember to write documentation.
 
   .. code-block:: rst
 
-     - Added :func:`OpenSSL.crypto.some_func` to do something awesome.
+     - Added ``OpenSSL.crypto.some_func()`` to do something awesome.
        [`#1 <https://github.com/pyca/pyopenssl/pull/1>`_]
 
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
+========================================================
 pyOpenSSL -- A Python wrapper around the OpenSSL library
---------------------------------------------------------
+========================================================
 
 .. image:: https://readthedocs.org/projects/pyopenssl/badge/?version=latest
    :target: https://pyopenssl.readthedocs.org/

--- a/setup.py
+++ b/setup.py
@@ -44,17 +44,29 @@ def find_meta(meta):
     raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
 
 
+URI = find_meta("uri")
+LONG = (
+    read_file("README.rst") + "\n\n" +
+    "Release Information\n" +
+    "===================\n\n" +
+    re.search("(\d{2}.\d.\d \(.*?\)\n.*?)\n\n\n----\n",
+              read_file("CHANGELOG.rst"), re.S).group(1) +
+    "\n\n`Full changelog " +
+    "<{uri}en/stable/changelog.html>`_.\n\n"
+).format(uri=URI)
+
+
 if __name__ == "__main__":
     setup(
         name=find_meta("title"),
         version=find_meta("version"),
         description=find_meta("summary"),
-        long_description=read_file("README.rst"),
+        long_description=LONG,
         author=find_meta("author"),
         author_email=find_meta("email"),
         maintainer="Hynek Schlawack",
         maintainer_email="hs@ox.cx",
-        url=find_meta("uri"),
+        url=URI,
         license=find_meta("license"),
         classifiers=[
             'Development Status :: 6 - Mature',

--- a/src/OpenSSL/version.py
+++ b/src/OpenSSL/version.py
@@ -14,7 +14,7 @@ __all__ = [
 __version__ = "16.0.0.dev0"
 
 __title__ = "pyOpenSSL"
-__uri__ = "https://github.com/pyca/pyopenssl"
+__uri__ = "https://pyopenssl.readthedocs.org/"
 __summary__ = "Python wrapper module around the OpenSSL library"
 __author__ = "The pyOpenSSL developers"
 __email__ = "cryptography-dev@python.org"


### PR DESCRIPTION
These changes give us a very nice release overview for `long_description` and the changelog is nicely readable from GitHub.