### PR TITLE
Rename state_name to get_state_name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,7 +49,7 @@ Changes:
   `#382 <https://github.com/pyca/pyopenssl/pull/382>`_
 - Added ``OpenSSL.crypto.dump_crl()`` to dump a certificate revocation list out to a string buffer.
   `#368 <https://github.com/pyca/pyopenssl/pull/368>`_
-- Added ``OpenSSL.SSL.Connection.state_string()`` using the OpenSSL binding ``state_string_long``.
+- Added ``OpenSSL.SSL.Connection.get_state_string()`` using the OpenSSL binding ``state_string_long``.
   `#358 <https://github.com/pyca/pyopenssl/pull/358>`_
 - Added support for the ``socket.MSG_PEEK`` flag to ``OpenSSL.SSL.Connection.recv()`` and ``OpenSSL.SSL.Connection.recv_into()``.
   `#294 <https://github.com/pyca/pyopenssl/pull/294>`_

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -770,10 +770,7 @@ Connection objects have the following methods:
     BIO.
 
 
-.. py:method:: Connection.state_string()
-
-    Retrieve a verbose string detailing the state of the Connection.
-
+.. automethod:: Connection.get_state_string
 
 .. py:method:: Connection.client_random()
 

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1590,11 +1590,12 @@ class Connection(object):
 
         _lib.SSL_set_shutdown(self._ssl, state)
 
-    def state_string(self):
+    def get_state_string(self):
         """
-        Get a verbose state description
+        Retrieve a verbose string detailing the state of the Connection.
 
         :return: A string representing the state
+        :rtype: bytes
         """
         return _ffi.string(_lib.SSL_state_string_long(self._ssl))
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2353,8 +2353,8 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         server = self._loopbackServerFactory(server)
         client = self._loopbackClientFactory(client)
 
-        assert b"before/accept initialization" == server.state_string()
-        assert b"before/connect initialization" == client.state_string()
+        assert b"before/accept initialization" == server.get_state_string()
+        assert b"before/connect initialization" == client.get_state_string()
 
     def test_app_data_wrong_args(self):
         """


### PR DESCRIPTION
A bit more consistent naming.  Rename is possible because the method
hasn't been part of a release yet.