### PR TITLE
Add smoke tests for urllib3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,11 @@ matrix:
     env: TOXENV=pypy-cryptography1.1
 
 
-  # Make sure we don't break Twisted
+  # Make sure we don't break Twisted or urllib3
   - python: "2.7"
     env: TOXENV=py27-twistedMaster
+  - python: "3.5"
+    env: TOXENV=py35-urllib3Master
 
 
   # Also run at least a little bit against an older version of OpenSSL.

--- a/.travis/install_urllib3.sh
+++ b/.travis/install_urllib3.sh
@@ -3,6 +3,6 @@
 set -e
 set -x
 
-git clone https://github.com/shazow/urllib3.git
+git clone --depth 1 https://github.com/shazow/urllib3.git
 pip install -r ./urllib3/dev-requirements.txt
 pip install ./urllib3[socks]

--- a/.travis/install_urllib3.sh
+++ b/.travis/install_urllib3.sh
@@ -4,4 +4,5 @@ set -e
 set -x
 
 git clone https://github.com/shazow/urllib3.git
+pip install -r ./urllib3/dev-requirements.txt
 pip install ./urllib3[socks]

--- a/.travis/install_urllib3.sh
+++ b/.travis/install_urllib3.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+set -x
+
+git clone https://github.com/shazow/urllib3.git
+pip install ./urllib3[socks]

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,22 @@ commands =
     python -c "import cryptography; print(cryptography.__version__)"
     trial twisted
 
+[testenv:py35-urllib3Master]
+basepython=python3.5
+deps =
+    pyasn1
+    ndg-httpsclient
+    nose
+    mock
+    tornado
+passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
+commands =
+    python -c "import OpenSSL.SSL; print(OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION))"
+    python -c "import cryptography; print(cryptography.__version__)"
+    {toxinidir}/.travis/install_urllib3.sh
+    nosetests urllib3/test
+    rm -rf ./urllib3
+
 [testenv:flake8]
 deps =
      flake8

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,8 @@ deps =
     pyasn1
     ndg-httpsclient
 passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
+whitelist_externals =
+    rm
 commands =
     python -c "import OpenSSL.SSL; print(OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION))"
     python -c "import cryptography; print(cryptography.__version__)"

--- a/tox.ini
+++ b/tox.ini
@@ -36,9 +36,6 @@ basepython=python3.5
 deps =
     pyasn1
     ndg-httpsclient
-    nose
-    mock
-    tornado
 passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
 commands =
     python -c "import OpenSSL.SSL; print(OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION))"


### PR DESCRIPTION
@hynek is worried about breaking urllib3 with changes, so he wants some smoke tests for urllib3. This adds them to the Travis environment.

Because urllib3 doesn't install its test suites when pip installed, we need to do a git clone of the repository. This means that this test failing can potentially severely dirty the user's working copy, so it's deliberately excluded from the Travis envlist.