### PR TITLE
switch to OPENSSL_free

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -2318,7 +2318,7 @@ class NetscapeSPKI(object):
         """
         encoded = _lib.NETSCAPE_SPKI_b64_encode(self._spki)
         result = _ffi.string(encoded)
-        _lib.CRYPTO_free(encoded)
+        _lib.OPENSSL_free(encoded)
         return result
 
     def get_pubkey(self):


### PR DESCRIPTION
CRYPTO_free's function signature is changing in 1.1.0 and OPENSSL_free does the same thing for this purpose.