### PR TITLE
swap ERR_remove_thread_state for ERR_clear_error

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -49,7 +49,7 @@ class TestCase(TestCase):
         # Clean up some long-lived allocations so they won't be reported as
         # memory leaks.
         lib.CRYPTO_cleanup_all_ex_data()
-        lib.ERR_remove_thread_state(ffi.NULL)
+        lib.ERR_clear_error()
         after = set(memdbg.heap)
 
         if not after - before:
@@ -64,7 +64,7 @@ class TestCase(TestCase):
             # Clean up some long-lived allocations so they won't be reported as
             # memory leaks.
             lib.CRYPTO_cleanup_all_ex_data()
-            lib.ERR_remove_thread_state(ffi.NULL)
+            lib.ERR_clear_error()
 
             after = set(memdbg.heap)
 


### PR DESCRIPTION
ERR_remove_thread_state with a NULL arg clears for the current thread, which is the same behavior as ERR_clear_error. In OpenSSL 1.1.0 ERR_remove_thread_state no longer takes an argument at all so we might as well just switch this test.