### PR TITLE
add encrypt and decrypt to PKCS7

### DIFF
--- a/doc/api/crypto.rst
+++ b/doc/api/crypto.rst
@@ -222,27 +222,8 @@ PKey objects
 PKCS7 objects
 -------------
 
-PKCS7 objects have the following methods:
-
-.. py:method:: PKCS7.type_is_signed()
-
-    FIXME
-
-.. py:method:: PKCS7.type_is_enveloped()
-
-    FIXME
-
-.. py:method:: PKCS7.type_is_signedAndEnveloped()
-
-    FIXME
-
-.. py:method:: PKCS7.type_is_data()
-
-    FIXME
-
-.. py:method:: PKCS7.get_type_name()
-
-    Get the type name of the PKCS7.
+.. autoclass:: PKCS7
+               :members:
 
 .. _openssl-pkcs12:
 


### PR DESCRIPTION
In Ruby, it's simple to use PKC7 to encrypt/decrypt

```
public_key_pem = File.read public_key 
public_key_x509 = OpenSSL::X509::Certificate.new( public_key_pem )
cipher = OpenSSL::Cipher::AES.new(256, :CBC)
OpenSSL::PKCS7::encrypt([public_key_x509], plaintext, cipher,
```

It's so painful in Python. We could use M2Crypto but Python3 is not yet supported.

So, PyOpenSSL don't provide advanced features for PKCS7 and this PR will try to make it more "pythonic" and more similar to PKCS12.

To use it:

```
from OpenSSL.crypto import PKCS7
from OpenSSL.crypto import FILETYPE_PEM
from OpenSSL.crypto import load_privatekey, load_certificate


data = """-----BEGIN PKCS7-----
...
-----END PKCS7-----"""

public_key = "content of the certificate"
private_key = "content of the private key"

cert_obj = load_certificate(FILETYPE_PEM, public_key)
pkey_obj = load_privatekey(FILETYPE_PEM, private_key)

# From encrypted data
pkcs7_obj = PKCS7.from_data(FILETYPE_PEM, data)
pkcs7_obj.set_certificate(cert_obj)
pkcs7_obj.set_privatekey(pkey_obj)
print("decrypted", pkcs7_obj.decrypt())
('decrypted', 'PyOpenSSL is fun!')


# From clear data
pkcs7_obj = PKCS7.encrypt(cert_obj, "PyOpenSSL is fun!", 'blowfish')
pkcs7_obj.set_privatekey(pkey_obj)
print("decrypted", pkcs7_obj.decrypt())
('decrypted', 'PyOpenSSL is fun!')
print("crypted:" pkcs7_obj.get_encrypted_data())
-----BEGIN PKCS7-----
MIIBVQYJKoZIhvcNAQcDoIIBRjCCAUICAQAxgf4wgfsCAQAwZDBYMQswCQYDVQQG
EwJVUzELMAkGA1UECBMCSUwxEDAOBgNVBAcTB0NoaWNhZ28xEDAOBgNVBAoTB1Rl
c3RpbmcxGDAWBgNVBAMTD1Rlc3RpbmcgUm9vdCBDQQIIPQzE4MbeufQwDQYJKoZI
hvcNAQEBBQAEgYBMaK0ddpuFds46bacHaEu9mcvF4bNGRaqMnjXBDc+qBobzJW/B
NzQ9cTEIk59+e8MjzTT8odAooGCarvVcw3MugkEluaVAH1O6OUjfxHQ+t7+Y+YNm
i+rYGL+ltDwvj1AlL5B+RocjH5KsHd+gCHzAhLvf2MOuGs/hs/i3RTijLTA8Bgkq
hkiG9w0BBwEwFQYJKwYBBAGXVQECBAj4R8pC68gRZ4AYQeKa/KwYUy89T+Wfpvtn
xVfCFXHLKB8m
-----END PKCS7-----
```
