### PR TITLE
Enable use of CRL (and more) in verify context.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Enable use of CRL (and more) in verify context.
+  `#483 <https://github.com/pyca/pyopenssl/pull/483>`_
 
 
 ----

--- a/doc/api/crypto.rst
+++ b/doc/api/crypto.rst
@@ -207,7 +207,7 @@ X509StoreContext objects
 .. _openssl-pkey:
 
 X509StoreFlags enums
------------------
+--------------------
 
 .. autoclass:: X509StoreFlags
                :members:

--- a/doc/api/crypto.rst
+++ b/doc/api/crypto.rst
@@ -206,6 +206,14 @@ X509StoreContext objects
 
 .. _openssl-pkey:
 
+X509StoreFlags enums
+-----------------
+
+.. autoclass:: X509StoreFlags
+               :members:
+
+.. _openssl-x509storeflags:
+
 PKey objects
 ------------
 

--- a/doc/api/crypto.rst
+++ b/doc/api/crypto.rst
@@ -210,7 +210,18 @@ X509StoreFlags enums
 --------------------
 
 .. autoclass:: X509StoreFlags
-               :members:
+
+    .. data:: CRL_CHECK
+    .. data:: CRL_CHECK_ALL
+    .. data:: IGNORE_CRITICAL
+    .. data:: X509_STRICT
+    .. data:: ALLOW_PROXY_CERTS
+    .. data:: POLICY_CHECK
+    .. data:: EXPLICIT_POLICY
+    .. data:: INHIBIT_MAP
+    .. data:: NOTIFY_POLICY
+    .. data:: CHECK_SS_SIGNATURE
+    .. data:: CB_ISSUER_CHECK
 
 .. _openssl-x509storeflags:
 

--- a/doc/api/crypto.rst
+++ b/doc/api/crypto.rst
@@ -206,8 +206,8 @@ X509StoreContext objects
 
 .. _openssl-pkey:
 
-X509StoreFlags enums
---------------------
+X509StoreFlags constants
+------------------------
 
 .. autoclass:: X509StoreFlags
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -2074,7 +2074,7 @@ class CRL(object):
 
         :param X509 issuer_cert: The issuer's certificate.
         :param PKey issuer_key: The issuer's private key.
-        :param str digest: The digest method to sign the CRL with.
+        :param bytes digest: The digest method to sign the CRL with.
         """
         digest_obj = _lib.EVP_get_digestbyname(digest)
         _openssl_assert(digest_obj != _ffi.NULL)

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1436,7 +1436,7 @@ class X509Store(object):
 
     An X.509 store, being only a description, cannot be used by itself to
     verify a certificate. To carry out the actual verification process, see
-    :py:class:`X509StoreContext`.
+    :class:`X509StoreContext`.
     """
 
     CRL_CHECK = _lib.X509_V_FLAG_CRL_CHECK
@@ -1466,16 +1466,14 @@ class X509Store(object):
         *trusted* certificate.
 
         :param X509 cert: The certificate to add to this store.
-        :raises TypeError: If the certificate is not an :py:class:`X509`.
+        :raises TypeError: If the certificate is not an :class:`X509`.
         :raises Error: If OpenSSL was unhappy with your certificate.
-        :return: :py:data:`None` if the certificate was added successfully.
+        :return: ``None`` if the certificate was added successfully.
         """
         if not isinstance(cert, X509):
             raise TypeError()
 
-        result = _lib.X509_STORE_add_cert(self._store, cert._x509)
-        if not result:
-            _raise_current_error()
+        _openssl_assert(_lib.X509_STORE_add_cert(self._store, cert._x509) != 0)
 
     def add_crl(self, crl):
         """
@@ -1485,10 +1483,10 @@ class X509Store(object):
         the associated flags are configured to check certificate revocation
         lists.
 
-        .. versionadded:: 0.17
+        .. versionadded:: 16.1.0
 
         :param CRL crl: The certificate revocation list to add to this store.
-        :return: :py:data:`None` if the certificate revocation list was added
+        :return: ``None`` if the certificate revocation list was added
             successfully.
         """
         _openssl_assert(_lib.X509_STORE_add_crl(self._store, crl._crl) != 0)
@@ -1509,10 +1507,10 @@ class X509Store(object):
           suitable CRL must be added to the store otherwise an error will be
           raised.
 
-        .. versionadded:: 0.17
+        .. versionadded:: 16.1.0
 
         :param int flags: The verification flags to set on this store.
-        :return: :py:data:`None` if the verification flags were
+        :return: ``None`` if the verification flags were
             successfully set.
         """
         _openssl_assert(_lib.X509_STORE_set_flags(self._store, flags) != 0)
@@ -1541,7 +1539,7 @@ class X509StoreContext(object):
 
     An X.509 store context is used to carry out the actual verification process
     of a certificate in a described context. For describing such a context, see
-    :py:class:`X509Store`.
+    :class:`X509Store`.
 
     :ivar _store_ctx: The underlying X509_STORE_CTX structure used by this
         instance.  It is dynamically allocated and automatically garbage
@@ -1561,7 +1559,7 @@ class X509StoreContext(object):
         self._cert = certificate
         # Make the store context available for use after instantiating this
         # class by initializing it now. Per testing, subsequent calls to
-        # :py:meth:`_init` have no adverse affect.
+        # :meth:`_init` have no adverse affect.
         self._init()
 
     def _init(self):
@@ -1578,8 +1576,7 @@ class X509StoreContext(object):
         """
         Internally cleans up the store context.
 
-        The store context can then be reused with a new call to
-        :py:meth:`_init`.
+        The store context can then be reused with a new call to :meth:`_init`.
         """
         _lib.X509_STORE_CTX_cleanup(self._store_ctx)
 
@@ -1627,7 +1624,7 @@ class X509StoreContext(object):
           indicate which certificate caused the error.
         """
         # Always re-initialize the store context in case
-        # :py:meth:`verify_certificate` is called multiple times.
+        # :meth:`verify_certificate` is called multiple times.
         self._init()
         ret = _lib.X509_verify_cert(self._store_ctx)
         self._cleanup()
@@ -1642,7 +1639,7 @@ def load_certificate(type, buffer):
     :param type: The file type (one of FILETYPE_PEM, FILETYPE_ASN1)
 
     :param buffer: The buffer the certificate is stored in
-    :type buffer: :py:class:`bytes`
+    :type buffer: :class:`bytes`
 
     :return: The X509 object
     """
@@ -1731,7 +1728,7 @@ def dump_privatekey(type, pkey, cipher=None, passphrase=None):
                        the passphrase to use, or a callback for providing the
                        passphrase.
     :return: The buffer with the dumped key in
-    :rtype: :py:data:`bytes`
+    :rtype: :data:`bytes`
     """
     bio = _new_mem_buf()
 
@@ -1800,9 +1797,9 @@ class Revoked(object):
         ASCII.
 
         :param hex_str: The new serial number.
-        :type hex_str: :py:class:`bytes`
+        :type hex_str: :class:`bytes`
 
-        :return: :py:const:`None`
+        :return: :const:`None`
         """
         bignum_serial = _ffi.gc(_lib.BN_new(), _lib.BN_free)
         bignum_ptr = _ffi.new("BIGNUM**")
@@ -1824,7 +1821,7 @@ class Revoked(object):
         ASCII.
 
         :return: The serial number.
-        :rtype: :py:class:`bytes`
+        :rtype: :class:`bytes`
         """
         bio = _new_mem_buf()
 
@@ -1847,16 +1844,16 @@ class Revoked(object):
         """
         Set the reason of this revocation.
 
-        If :py:data:`reason` is :py:const:`None`, delete the reason instead.
+        If :data:`reason` is :const:`None`, delete the reason instead.
 
         :param reason: The reason string.
-        :type reason: :py:class:`bytes` or :py:class:`NoneType`
+        :type reason: :class:`bytes` or :class:`NoneType`
 
-        :return: :py:const:`None`
+        :return: :const:`None`
 
         .. seealso::
 
-            :py:meth:`all_reasons`, which gives you a list of all supported
+            :meth:`all_reasons`, which gives you a list of all supported
             reasons which you might pass to this method.
         """
         if reason is None:
@@ -1890,12 +1887,12 @@ class Revoked(object):
         """
         Get the reason of this revocation.
 
-        :return: The reason, or :py:const:`None` if there is none.
-        :rtype: :py:class:`bytes` or :py:class:`NoneType`
+        :return: The reason, or :const:`None` if there is none.
+        :rtype: :class:`bytes` or :class:`NoneType`
 
         .. seealso::
 
-            :py:meth:`all_reasons`, which gives you a list of all supported
+            :meth:`all_reasons`, which gives you a list of all supported
             reasons this method might return.
         """
         for i in range(_lib.X509_REVOKED_get_ext_count(self._revoked)):
@@ -1923,7 +1920,7 @@ class Revoked(object):
         strings.
 
         :return: A list of reason strings.
-        :rtype: :py:class:`list` of :py:class:`bytes`
+        :rtype: :class:`list` of :class:`bytes`
         """
         return self._crl_reasons[:]
 
@@ -1932,8 +1929,8 @@ class Revoked(object):
         Set the revocation timestamp.
 
         :param when: The timestamp of the revocation, as ASN.1 GENERALIZEDTIME.
-        :type when: :py:class:`bytes`
-        :return: :py:const:`None`
+        :type when: :class:`bytes`
+        :return: :const:`None`
         """
         dt = _lib.X509_REVOKED_get0_revocationDate(self._revoked)
         return _set_asn1_time(dt, when)
@@ -1943,7 +1940,7 @@ class Revoked(object):
         Get the revocation timestamp.
 
         :return: The timestamp of the revocation, as ASN.1 GENERALIZEDTIME.
-        :rtype: :py:class:`bytes`
+        :rtype: :class:`bytes`
         """
         dt = _lib.X509_REVOKED_get0_revocationDate(self._revoked)
         return _get_asn1_time(dt)
@@ -1955,6 +1952,9 @@ class CRL(object):
     """
 
     def __init__(self):
+        """
+        Create a new empty certificate revocation list.
+        """
         crl = _lib.X509_CRL_new()
         self._crl = _ffi.gc(crl, _lib.X509_CRL_free)
 
@@ -1966,7 +1966,7 @@ class CRL(object):
         That means it's okay to mutate them: it won't affect this CRL.
 
         :return: The revocations in this CRL.
-        :rtype: :py:class:`tuple` of :py:class:`Revocation`
+        :rtype: :class:`tuple` of :class:`Revocation`
         """
         results = []
         revoked_stack = _lib.X509_CRL_get_REVOKED(self._crl)
@@ -1988,7 +1988,7 @@ class CRL(object):
         this CRL.
 
         :param Revoked revoked: The new revocation.
-        :return: :py:const:`None`
+        :return: :const:`None`
         """
         copy = _lib.Cryptography_X509_REVOKED_dup(revoked._revoked)
         if copy == _ffi.NULL:
@@ -2004,9 +2004,9 @@ class CRL(object):
         """
         Get the CRL's issuer.
 
-        .. versionadded:: 0.17
+        .. versionadded:: 16.1.0
 
-        :return: :py:class:`X509Name`
+        :return: :class:`X509Name`
         """
         _issuer = _lib.X509_NAME_dup(_lib.X509_CRL_get_issuer(self._crl))
         _openssl_assert(_issuer != _ffi.NULL)
@@ -2019,10 +2019,10 @@ class CRL(object):
         """
         Set the CRL version.
 
-        .. versionadded:: 0.17
+        .. versionadded:: 16.1.0
 
         :param int version: The version of the CRL.
-        :return: :py:const:`None`
+        :return: ``None``
         """
         _openssl_assert(_lib.X509_CRL_set_version(self._crl, version) != 0)
 
@@ -2039,10 +2039,10 @@ class CRL(object):
             YYYYMMDDhhmmss+hhmm
             YYYYMMDDhhmmss-hhmm
 
-        .. versionadded:: 0.17
+        .. versionadded:: 16.1.0
 
         :param bytes when: A timestamp string.
-        :return: :py:const:`None`
+        :return: ``None`
         """
         return self._set_boundary_time(_lib.X509_CRL_get_lastUpdate, when)
 
@@ -2056,10 +2056,10 @@ class CRL(object):
             YYYYMMDDhhmmss+hhmm
             YYYYMMDDhhmmss-hhmm
 
-        .. versionadded:: 0.17
+        .. versionadded:: 16.1.0
 
         :param bytes when: A timestamp string.
-        :return: :py:const:`None`
+        :return: ``None``
         """
         return self._set_boundary_time(_lib.X509_CRL_get_nextUpdate, when)
 
@@ -2074,7 +2074,7 @@ class CRL(object):
         This method implicitly sets the issuer's name based on the issuer
         certificate and private key used to sign the CRL.
 
-        .. versionadded:: 0.17
+        .. versionadded:: 16.1.0
 
         :param X509 issuer_cert: The issuer's certificate.
         :param PKey issuer_key: The issuer's private key.
@@ -2095,15 +2095,15 @@ class CRL(object):
 
         :param X509 cert: The certificate used to sign the CRL.
         :param PKey key: The key used to sign the CRL.
-        :param int type: The export format, either :py:data:`FILETYPE_PEM`,
-            :py:data:`FILETYPE_ASN1`, or :py:data:`FILETYPE_TEXT`.
+        :param int type: The export format, either :data:`FILETYPE_PEM`,
+            :data:`FILETYPE_ASN1`, or :data:`FILETYPE_TEXT`.
         :param int days: The number of days until the next update of this CRL.
         :param bytes digest: The name of the message digest to use (eg
             ``b"sha1"``).
-        :return: :py:data:`bytes`
+        :rtype: bytes
         """
 
-        # TODO: fix this function to use functionality added in version 0.16.
+        # TODO: fix this function to use functionality added in version 16.1.0
         # Doing this without changing the public API is tricky. Checking if
         # lastUpdate, nextUpdate, issuer or signing has happened is hard to do
         # without generating a segmentation fault.

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -183,7 +183,7 @@ class PKey(object):
             of the appropriate type.
         :raises ValueError: If the number of bits isn't an integer of
             the appropriate size.
-        :return: :py:const:`None`
+        :return: ``None``
         """
         if not isinstance(type, int):
             raise TypeError("type must be an integer")
@@ -816,7 +816,7 @@ class X509Req(object):
         :param pkey: The public key to use.
         :type pkey: :py:class:`PKey`
 
-        :return: :py:const:`None`
+        :return: ``None``
         """
         set_result = _lib.X509_REQ_set_pubkey(self._req, pkey._pkey)
         if not set_result:
@@ -845,7 +845,7 @@ class X509Req(object):
         request.
 
         :param int version: The version number.
-        :return: :py:const:`None`
+        :return: ``None``
         """
         set_result = _lib.X509_REQ_set_version(self._req, version)
         if not set_result:
@@ -891,7 +891,7 @@ class X509Req(object):
 
         :param extensions: The X.509 extensions to add.
         :type extensions: iterable of :py:class:`X509Extension`
-        :return: :py:const:`None`
+        :return: ``None``
         """
         stack = _lib.sk_X509_EXTENSION_new_null()
         if stack == _ffi.NULL:
@@ -938,7 +938,7 @@ class X509Req(object):
         :param digest: The name of the message digest to use for the signature,
             e.g. :py:data:`b"sha1"`.
         :type digest: :py:class:`bytes`
-        :return: :py:const:`None`
+        :return: ``None``
         """
         if pkey._only_public:
             raise ValueError("Key has only public part")
@@ -996,7 +996,7 @@ class X509(object):
         :param version: The version number of the certificate.
         :type version: :py:class:`int`
 
-        :return: :py:const:`None`
+        :return: ``None``
         """
         if not isinstance(version, int):
             raise TypeError("version must be an integer")
@@ -1174,7 +1174,7 @@ class X509(object):
         Return the serial number of this certificate.
 
         :return: The serial number.
-        :rtype: :py:class:`int`
+        :rtype: int
         """
         asn1_serial = _lib.X509_get_serialNumber(self._x509)
         bignum_serial = _lib.ASN1_INTEGER_to_BN(asn1_serial, _ffi.NULL)
@@ -1193,10 +1193,9 @@ class X509(object):
         """
         Adjust the time stamp on which the certificate stops being valid.
 
-        :param amount: The number of seconds by which to adjust the timestamp.
-        :type amount: :py:class:`int`
-
-        :return: :py:const:`None`
+        :param int amount: The number of seconds by which to adjust the
+            timestamp.
+        :return: ``None``
         """
         if not isinstance(amount, int):
             raise TypeError("amount must be an integer")
@@ -1209,7 +1208,7 @@ class X509(object):
         Adjust the timestamp on which the certificate starts being valid.
 
         :param amount: The number of seconds by which to adjust the timestamp.
-        :return: :py:const:`None`
+        :return: ``None``
         """
         if not isinstance(amount, int):
             raise TypeError("amount must be an integer")
@@ -1221,9 +1220,8 @@ class X509(object):
         """
         Check whether the certificate has expired.
 
-        :return: :py:const:`True` if the certificate has expired,
-            :py:const:`False` otherwise.
-        :rtype: :py:class:`bool`
+        :return: ``True`` if the certificate has expired, ``False`` otherwise.
+        :rtype: bool
         """
         time_string = _native(self.get_notAfter())
         not_after = datetime.datetime.strptime(time_string, "%Y%m%d%H%M%SZ")
@@ -1243,8 +1241,8 @@ class X509(object):
             YYYYMMDDhhmmss+hhmm
             YYYYMMDDhhmmss-hhmm
 
-        :return: A timestamp string, or :py:const:`None` if there is none.
-        :rtype: :py:class:`bytes` or :py:const:`None`
+        :return: A timestamp string, or ``None`` if there is none.
+        :rtype: bytes or NoneType
         """
         return self._get_boundary_time(_lib.X509_get_notBefore)
 
@@ -1261,10 +1259,8 @@ class X509(object):
             YYYYMMDDhhmmss+hhmm
             YYYYMMDDhhmmss-hhmm
 
-        :param when: A timestamp string.
-        :type when: :py:class:`bytes`
-
-        :return: :py:const:`None`
+        :param bytes when: A timestamp string.
+        :return: ``None``
         """
         return self._set_boundary_time(_lib.X509_get_notBefore, when)
 
@@ -1278,8 +1274,8 @@ class X509(object):
             YYYYMMDDhhmmss+hhmm
             YYYYMMDDhhmmss-hhmm
 
-        :return: A timestamp string, or :py:const:`None` if there is none.
-        :rtype: :py:class:`bytes` or :py:const:`None`
+        :return: A timestamp string, or ``None`` if there is none.
+        :rtype: bytes or NoneType
         """
         return self._get_boundary_time(_lib.X509_get_notAfter)
 
@@ -1293,10 +1289,8 @@ class X509(object):
             YYYYMMDDhhmmss+hhmm
             YYYYMMDDhhmmss-hhmm
 
-        :param when: A timestamp string.
-        :type when: :py:class:`bytes`
-
-        :return: :py:const:`None`
+        :param bytes when: A timestamp string.
+        :return: ``None``
         """
         return self._set_boundary_time(_lib.X509_get_notAfter, when)
 
@@ -1342,7 +1336,7 @@ class X509(object):
         :param issuer: The issuer.
         :type issuer: :py:class:`X509Name`
 
-        :return: :py:const:`None`
+        :return: ``None``
         """
         return self._set_name(_lib.X509_set_issuer_name, issuer)
 
@@ -1367,7 +1361,7 @@ class X509(object):
         :param subject: The subject.
         :type subject: :py:class:`X509Name`
 
-        :return: :py:const:`None`
+        :return: ``None``
         """
         return self._set_name(_lib.X509_set_subject_name, subject)
 
@@ -1388,7 +1382,7 @@ class X509(object):
 
         :param extensions: The extensions to add.
         :type extensions: An iterable of :py:class:`X509Extension` objects.
-        :return: :py:const:`None`
+        :return: ``None``
         """
         for ext in extensions:
             if not isinstance(ext, X509Extension):
@@ -1850,12 +1844,12 @@ class Revoked(object):
         """
         Set the reason of this revocation.
 
-        If :data:`reason` is :const:`None`, delete the reason instead.
+        If :data:`reason` is ``None``, delete the reason instead.
 
         :param reason: The reason string.
         :type reason: :class:`bytes` or :class:`NoneType`
 
-        :return: :const:`None`
+        :return: ``None``
 
         .. seealso::
 
@@ -1893,8 +1887,8 @@ class Revoked(object):
         """
         Get the reason of this revocation.
 
-        :return: The reason, or :const:`None` if there is none.
-        :rtype: :class:`bytes` or :class:`NoneType`
+        :return: The reason, or ``None`` if there is none.
+        :rtype: bytes or NoneType
 
         .. seealso::
 
@@ -1936,7 +1930,7 @@ class Revoked(object):
 
         :param bytes when: The timestamp of the revocation,
             as ASN.1 GENERALIZEDTIME.
-        :return: :const:`None`
+        :return: ``None``
         """
         dt = _lib.X509_REVOKED_get0_revocationDate(self._revoked)
         return _set_asn1_time(dt, when)
@@ -1991,7 +1985,7 @@ class CRL(object):
         this CRL.
 
         :param Revoked revoked: The new revocation.
-        :return: :const:`None`
+        :return: ``None``
         """
         copy = _lib.Cryptography_X509_REVOKED_dup(revoked._revoked)
         if copy == _ffi.NULL:
@@ -2244,7 +2238,7 @@ class PKCS12(object):
         :param cert: The new certificate, or :py:const:`None` to unset it.
         :type cert: :py:class:`X509` or :py:const:`None`
 
-        :return: :py:const:`None`
+        :return: ``None``
         """
         if not isinstance(cert, X509):
             raise TypeError("cert must be an X509 instance")
@@ -2266,7 +2260,7 @@ class PKCS12(object):
         :param pkey: The new private key, or :py:const:`None` to unset it.
         :type pkey: :py:class:`PKey` or :py:const:`None`
 
-        :return: :py:const:`None`
+        :return: ``None``
         """
         if not isinstance(pkey, PKey):
             raise TypeError("pkey must be a PKey instance")
@@ -2291,7 +2285,7 @@ class PKCS12(object):
             them.
         :type cacerts: An iterable of :py:class:`X509` or :py:const:`None`
 
-        :return: :py:const:`None`
+        :return: ``None``
         """
         if cacerts is None:
             self._cacerts = None
@@ -2311,7 +2305,7 @@ class PKCS12(object):
         :param name: The new friendly name, or :py:const:`None` to unset.
         :type name: :py:class:`bytes` or :py:const:`None`
 
-        :return: :py:const:`None`
+        :return: ``None``
         """
         if name is None:
             self._friendlyname = None
@@ -2413,7 +2407,7 @@ class NetscapeSPKI(object):
         :param digest: The message digest to use.
         :type digest: :py:class:`bytes`
 
-        :return: :py:const:`None`
+        :return: ``None``
         """
         if pkey._only_public:
             raise ValueError("Key has only public part")
@@ -2483,7 +2477,7 @@ class NetscapeSPKI(object):
         Set the public key of the certificate
 
         :param pkey: The public key
-        :return: :py:const:`None`
+        :return: ``None``
         """
         set_result = _lib.NETSCAPE_SPKI_set_pubkey(self._spki, pkey._pkey)
         if not set_result:
@@ -2726,8 +2720,7 @@ def verify(cert, signature, data, digest):
     :param signature: signature returned by sign function
     :param data: data to be verified
     :param digest: message digest to use
-    :return: :py:const:`None` if the signature is correct, raise exception
-        otherwise
+    :return: ``None`` if the signature is correct, raise exception otherwise.
     """
     data = _text_to_bytes_and_warn("data", data)
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1512,8 +1512,8 @@ class X509Store(object):
         .. versionadded:: 16.1.0
 
         :param int flags: The verification flags to set on this store.
-        :return: ``None`` if the verification flags were
-            successfully set.
+            See :class:`X509StoreFlags` for available constants.
+        :return: ``None`` if the verification flags were successfully set.
         """
         _openssl_assert(_lib.X509_STORE_set_flags(self._store, flags) != 0)
 
@@ -1551,7 +1551,6 @@ class X509StoreContext(object):
     :param X509Store store: The certificates which will be trusted for the
         purposes of any verifications.
     :param X509 certificate: The certificate to be verified.
-
     """
 
     def __init__(self, store, certificate):

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1946,7 +1946,7 @@ class Revoked(object):
         Get the revocation timestamp.
 
         :return: The timestamp of the revocation, as ASN.1 GENERALIZEDTIME.
-        :rtype: :class:`bytes`
+        :rtype: bytes
         """
         dt = _lib.X509_REVOKED_get0_revocationDate(self._revoked)
         return _get_asn1_time(dt)

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1439,6 +1439,10 @@ class X509Store(object):
     :class:`X509StoreContext`.
     """
 
+    # I found that some of these flags were added in different versions
+    # of OpenSSL. How to conditionally add them if they're present?
+    # Do you have any suggestions on conditionally adding the flag if
+    # it is available in the underlying OpenSSL?
     CRL_CHECK = _lib.X509_V_FLAG_CRL_CHECK
     CRL_CHECK_ALL = _lib.X509_V_FLAG_CRL_CHECK_ALL
     IGNORE_CRITICAL = _lib.X509_V_FLAG_IGNORE_CRITICAL
@@ -1952,9 +1956,6 @@ class CRL(object):
     """
 
     def __init__(self):
-        """
-        Create a new empty certificate revocation list.
-        """
         crl = _lib.X509_CRL_new()
         self._crl = _ffi.gc(crl, _lib.X509_CRL_free)
 
@@ -2063,7 +2064,7 @@ class CRL(object):
         """
         return self._set_boundary_time(_lib.X509_CRL_get_nextUpdate, when)
 
-    def sign(self, issuer_cert, issuer_key, digest='sha1'):
+    def sign(self, issuer_cert, issuer_key, digest):
         """
         Sign the CRL.
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -2099,11 +2099,6 @@ class CRL(object):
         :rtype: bytes
         """
 
-        # TODO: fix this function to use functionality added in version 16.1.0
-        # Doing this without changing the public API is tricky. Checking if
-        # lastUpdate, nextUpdate, issuer or signing has happened is hard to do
-        # without generating a segmentation fault.
-
         if not isinstance(cert, X509):
             raise TypeError("cert must be an X509 instance")
         if not isinstance(key, PKey):

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1647,8 +1647,7 @@ def load_certificate(type, buffer):
 
     :param type: The file type (one of FILETYPE_PEM, FILETYPE_ASN1)
 
-    :param buffer: The buffer the certificate is stored in
-    :type buffer: bytes
+    :param bytes buffer: The buffer the certificate is stored in
 
     :return: The X509 object
     """
@@ -1829,7 +1828,7 @@ class Revoked(object):
         ASCII.
 
         :return: The serial number.
-        :rtype: :class:`bytes`
+        :rtype: bytes
         """
         bio = _new_mem_buf()
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1931,7 +1931,7 @@ class Revoked(object):
         Set the revocation timestamp.
 
         :param bytes when: The timestamp of the revocation,
-        as ASN.1 GENERALIZEDTIME.
+            as ASN.1 GENERALIZEDTIME.
         :return: :const:`None`
         """
         dt = _lib.X509_REVOKED_get0_revocationDate(self._revoked)

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1427,8 +1427,32 @@ X509Type = X509
 
 class X509Store(object):
     """
-    An X509 certificate store.
+    An X.509 store.
+
+    An X.509 store is used to describe a context in which to verify a
+    certificate. A description of a context may include a set of certificates
+    to trust, a set of certificate revocation lists, verification flags and
+    more.
+
+    An X.509 store, being only a description, cannot be used by itself to verify
+    a certificate. To carry out the actual verification process, see
+    :py:class:`X509StoreContext`.
     """
+
+    CRL_CHECK = _lib.X509_V_FLAG_CRL_CHECK
+    CRL_CHECK_ALL = _lib.X509_V_FLAG_CRL_CHECK_ALL
+    IGNORE_CRITICAL = _lib.X509_V_FLAG_IGNORE_CRITICAL
+    X509_STRICT = _lib.X509_V_FLAG_X509_STRICT
+    ALLOW_PROXY_CERTS = _lib.X509_V_FLAG_ALLOW_PROXY_CERTS
+    POLICY_CHECK = _lib.X509_V_FLAG_POLICY_CHECK
+    EXPLICIT_POLICY = _lib.X509_V_FLAG_EXPLICIT_POLICY
+    # FLAG_INHIBIT_ANY = _lib.X509_V_FLAG_FLAG_INHIBIT_ANY
+    INHIBIT_MAP = _lib.X509_V_FLAG_INHIBIT_MAP
+    NOTIFY_POLICY = _lib.X509_V_FLAG_NOTIFY_POLICY
+    # USE_DELTAS = _lib.X509_V_FLAG_USE_DELTAS
+    CHECK_SS_SIGNATURE = _lib.X509_V_FLAG_CHECK_SS_SIGNATURE
+    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
+    # NO_ALT_CHAINS = _lib.X509_V_FLAG_NO_ALT_CHAINS
 
     def __init__(self):
         store = _lib.X509_STORE_new()
@@ -1436,9 +1460,10 @@ class X509Store(object):
 
     def add_cert(self, cert):
         """
-        Adds the certificate :py:data:`cert` to this store.
+        Adds a trusted certificate to this store.
 
-        This is the Python equivalent of OpenSSL's ``X509_STORE_add_cert``.
+        Adding a certificate with this method adds this certificate as a
+        *trusted* certificate.
 
         :param X509 cert: The certificate to add to this store.
         :raises TypeError: If the certificate is not an :py:class:`X509`.
@@ -1451,6 +1476,44 @@ class X509Store(object):
         result = _lib.X509_STORE_add_cert(self._store, cert._x509)
         if not result:
             _raise_current_error()
+
+    def add_crl(self, crl):
+        """
+        Add a certificate revocation list to this store.
+
+        The certificate revocation lists added to a store will only be used if
+        the associated flags are configured to check certificate revocation
+        lists.
+
+        .. versionadded:: 0.17
+
+        :param CRL crl: The certificate revocation list to add to this store.
+        :return: :py:data:`None` if the certificate revocation list was added successfully.
+        """
+        _openssl_assert(_lib.X509_STORE_add_crl(self._store, crl._crl) != 0)
+
+    def set_flags(self, flags):
+        """
+        Set verification flags to this store.
+
+        Verification flags can be combined by oring them together.
+
+        .. note::
+
+          Setting a verification flag sometimes requires clients to add
+          additional information to the store, otherwise a suitable error will
+          be raised.
+
+          For example, in setting flags to enable CRL checking a
+          suitable CRL must be added to the store otherwise an error will be
+          raised.
+
+        .. versionadded:: 0.17
+
+        :param int flags: The verification flags to set on this store.
+        :return: :py:data:`None` if the verification flags were successfully set.
+        """
+        _openssl_assert(_lib.X509_STORE_set_flags(self._store, flags) != 0)
 
 
 X509StoreType = X509Store
@@ -1474,29 +1537,19 @@ class X509StoreContext(object):
     """
     An X.509 store context.
 
-    An :py:class:`X509StoreContext` is used to define some of the criteria for
-    certificate verification.  The information encapsulated in this object
-    includes, but is not limited to, a set of trusted certificates,
-    verification parameters, and revoked certificates.
-
-    .. note::
-
-      Currently, one can only set the trusted certificates on an
-      :py:class:`X509StoreContext`.  Future versions of pyOpenSSL will expose
-      verification parameters and certificate revocation lists.
+    An X.509 store context is used to carry out the actual verification process
+    of a certificate in a described context. For describing such a context, see
+    :py:class:`X509Store`.
 
     :ivar _store_ctx: The underlying X509_STORE_CTX structure used by this
         instance.  It is dynamically allocated and automatically garbage
         collected.
-
     :ivar _store: See the ``store`` ``__init__`` parameter.
-
     :ivar _cert: See the ``certificate`` ``__init__`` parameter.
-
     :param X509Store store: The certificates which will be trusted for the
         purposes of any verifications.
-
     :param X509 certificate: The certificate to be verified.
+
     """
 
     def __init__(self, store, certificate):
@@ -1552,12 +1605,12 @@ class X509StoreContext(object):
 
     def set_store(self, store):
         """
-        Set the context's trust store.
+        Set the context's X.509 store.
 
         .. versionadded:: 0.15
 
-        :param X509Store store: The certificates which will be trusted for the
-            purposes of any *future* verifications.
+        :param X509Store store: The store description which will be used for
+            the purposes of any *future* verifications.
         """
         self._store = store
 
@@ -1566,8 +1619,6 @@ class X509StoreContext(object):
         Verify a certificate in a context.
 
         .. versionadded:: 0.15
-
-        :param store_ctx: The :py:class:`X509StoreContext` to verify.
 
         :raises X509StoreContextError: If an error occurred when validating a
           certificate in the context. Sets ``certificate`` attribute to
@@ -1902,9 +1953,6 @@ class CRL(object):
     """
 
     def __init__(self):
-        """
-        Create a new empty certificate revocation list.
-        """
         crl = _lib.X509_CRL_new()
         self._crl = _ffi.gc(crl, _lib.X509_CRL_free)
 
@@ -1937,9 +1985,7 @@ class CRL(object):
         means it's okay to mutate it after adding: it won't affect
         this CRL.
 
-        :param revoked: The new revocation.
-        :type revoked: :class:`Revoked`
-
+        :param Revoked revoked: The new revocation.
         :return: :py:const:`None`
         """
         copy = _lib.Cryptography_X509_REVOKED_dup(revoked._revoked)
@@ -1952,27 +1998,113 @@ class CRL(object):
             # TODO: This is untested.
             _raise_current_error()
 
+    def get_issuer(self):
+        """
+        Get the CRL's issuer.
+
+        .. versionadded:: 0.17
+
+        :return: :py:class:`X509Name`
+        """
+        _issuer = _lib.X509_NAME_dup(_lib.X509_CRL_get_issuer(self._crl))
+        _openssl_assert(_issuer != _ffi.NULL)
+        _issuer = _ffi.gc(_issuer, _lib.X509_NAME_free)
+        issuer = X509Name.__new__(X509Name)
+        issuer._name = _issuer
+        return issuer
+
+    def set_version(self, version):
+        """
+        Set the CRL version.
+
+        .. versionadded:: 0.17
+
+        :param int version: The version of the CRL.
+        :return: :py:const:`None`
+        """
+        _openssl_assert(_lib.X509_CRL_set_version(self._crl, version) != 0)
+
+    def _set_boundary_time(self, which, when):
+        return _set_asn1_time(which(self._crl), when)
+
+    def set_lastUpdate(self, when):
+        """
+        Set when the CRL was last updated.
+
+        The timestamp is formatted as an ASN.1 GENERALIZEDTIME::
+
+            YYYYMMDDhhmmssZ
+            YYYYMMDDhhmmss+hhmm
+            YYYYMMDDhhmmss-hhmm
+
+        .. versionadded:: 0.17
+
+        :param bytes when: A timestamp string.
+        :return: :py:const:`None`
+        """
+        return self._set_boundary_time(_lib.X509_CRL_get_lastUpdate, when)
+
+    def set_nextUpdate(self, when):
+        """
+        Set when the CRL will next be udpated.
+
+        The timestamp is formatted as an ASN.1 GENERALIZEDTIME::
+
+            YYYYMMDDhhmmssZ
+            YYYYMMDDhhmmss+hhmm
+            YYYYMMDDhhmmss-hhmm
+
+        .. versionadded:: 0.17
+
+        :param bytes when: A timestamp string.
+        :return: :py:const:`None`
+        """
+        return self._set_boundary_time(_lib.X509_CRL_get_nextUpdate, when)
+
+    def sign(self, issuer_cert, issuer_key, digest='sha1'):
+        """
+        Sign the CRL.
+
+        Signing a CRL enables clients to associate the CRL itself with an
+        issuer. Before a CRL is meaningful to other OpenSSL functions, it must
+        be signed by an issuer.
+
+        This method implicitly sets the issuer's name based on the issuer
+        certificate and private key used to sign the CRL.
+
+        .. versionadded:: 0.17
+
+        :param X509 issuer_cert: The issuer's certificate.
+        :param PKey issuer_key: The issuer's private key.
+        :param str digest: The digest method to sign the CRL with.
+        """
+        digest_obj = _lib.EVP_get_digestbyname(digest)
+        _openssl_assert(digest_obj != _ffi.NULL)
+        _lib.X509_CRL_set_issuer_name(self._crl, _lib.X509_get_subject_name(issuer_cert._x509))
+        _lib.X509_CRL_sort(self._crl)
+        sign_result = _lib.X509_CRL_sign(self._crl, issuer_key._pkey, digest_obj)
+        _openssl_assert(sign_result != 0)
+
     def export(self, cert, key, type=FILETYPE_PEM, days=100,
                digest=_UNSPECIFIED):
         """
-        Export a CRL as a string.
+        Export the CRL as a string.
 
-        :param cert: The certificate used to sign the CRL.
-        :type cert: :py:class:`X509`
-
-        :param key: The key used to sign the CRL.
-        :type key: :py:class:`PKey`
-
-        :param type: The export format, either :py:data:`FILETYPE_PEM`,
+        :param X509 cert: The certificate used to sign the CRL.
+        :param PKey key: The key used to sign the CRL.
+        :param int type: The export format, either :py:data:`FILETYPE_PEM`,
             :py:data:`FILETYPE_ASN1`, or :py:data:`FILETYPE_TEXT`.
-
         :param int days: The number of days until the next update of this CRL.
-
         :param bytes digest: The name of the message digest to use (eg
             ``b"sha1"``).
-
         :return: :py:data:`bytes`
         """
+
+        # TODO: fix this function to use functionality added in version 0.16.
+        # Doing this without changing the public API is tricky. Checking if
+        # lastUpdate, nextUpdate, issuer or signing has happened is hard to do
+        # without generating a segmentation fault.
+
         if not isinstance(cert, X509):
             raise TypeError("cert must be an X509 instance")
         if not isinstance(key, PKey):

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -9,6 +9,7 @@ from six import (
     integer_types as _integer_types,
     text_type as _text_type,
     PY3 as _PY3)
+from enum import Enum
 
 from OpenSSL._util import (
     ffi as _ffi,
@@ -1425,6 +1426,23 @@ class X509(object):
 X509Type = X509
 
 
+class X509StoreFlags(Enum):
+    """ Flags for X509 verification
+    https://www.openssl.org/docs/manmaster/crypto/X509_VERIFY_PARAM_set_flags.html
+    """
+    CRL_CHECK = _lib.X509_V_FLAG_CRL_CHECK
+    CRL_CHECK_ALL = _lib.X509_V_FLAG_CRL_CHECK_ALL
+    IGNORE_CRITICAL = _lib.X509_V_FLAG_IGNORE_CRITICAL
+    X509_STRICT = _lib.X509_V_FLAG_X509_STRICT
+    ALLOW_PROXY_CERTS = _lib.X509_V_FLAG_ALLOW_PROXY_CERTS
+    POLICY_CHECK = _lib.X509_V_FLAG_POLICY_CHECK
+    EXPLICIT_POLICY = _lib.X509_V_FLAG_EXPLICIT_POLICY
+    INHIBIT_MAP = _lib.X509_V_FLAG_INHIBIT_MAP
+    NOTIFY_POLICY = _lib.X509_V_FLAG_NOTIFY_POLICY
+    CHECK_SS_SIGNATURE = _lib.X509_V_FLAG_CHECK_SS_SIGNATURE
+    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
+
+
 class X509Store(object):
     """
     An X.509 store.
@@ -1438,18 +1456,6 @@ class X509Store(object):
     verify a certificate. To carry out the actual verification process, see
     :class:`X509StoreContext`.
     """
-
-    CRL_CHECK = _lib.X509_V_FLAG_CRL_CHECK
-    CRL_CHECK_ALL = _lib.X509_V_FLAG_CRL_CHECK_ALL
-    IGNORE_CRITICAL = _lib.X509_V_FLAG_IGNORE_CRITICAL
-    X509_STRICT = _lib.X509_V_FLAG_X509_STRICT
-    ALLOW_PROXY_CERTS = _lib.X509_V_FLAG_ALLOW_PROXY_CERTS
-    POLICY_CHECK = _lib.X509_V_FLAG_POLICY_CHECK
-    EXPLICIT_POLICY = _lib.X509_V_FLAG_EXPLICIT_POLICY
-    INHIBIT_MAP = _lib.X509_V_FLAG_INHIBIT_MAP
-    NOTIFY_POLICY = _lib.X509_V_FLAG_NOTIFY_POLICY
-    CHECK_SS_SIGNATURE = _lib.X509_V_FLAG_CHECK_SS_SIGNATURE
-    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
 
     def __init__(self):
         store = _lib.X509_STORE_new()
@@ -1924,7 +1930,8 @@ class Revoked(object):
         """
         Set the revocation timestamp.
 
-        :param bytes when: The timestamp of the revocation, as ASN.1 GENERALIZEDTIME.
+        :param bytes when: The timestamp of the revocation,
+        as ASN.1 GENERALIZEDTIME.
         :return: :const:`None`
         """
         dt = _lib.X509_REVOKED_get0_revocationDate(self._revoked)

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1427,8 +1427,14 @@ X509Type = X509
 
 
 class X509StoreFlags(Enum):
-    """ Flags for X509 verification
-    https://www.openssl.org/docs/manmaster/crypto/X509_VERIFY_PARAM_set_flags.html
+    """
+    Flags for X509 verification, used to change the behavior of
+    :class:`X509Store`.
+
+    See `OpenSSL Verification Flags`_ for details.
+
+    .. _OpenSSL Verification Flags:
+        https://www.openssl.org/docs/manmaster/crypto/X509_VERIFY_PARAM_set_flags.html
     """
     CRL_CHECK = _lib.X509_V_FLAG_CRL_CHECK
     CRL_CHECK_ALL = _lib.X509_V_FLAG_CRL_CHECK_ALL

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -2043,7 +2043,7 @@ class CRL(object):
         .. versionadded:: 16.1.0
 
         :param bytes when: A timestamp string.
-        :return: ``None`
+        :return: ``None``
         """
         return self._set_boundary_time(_lib.X509_CRL_get_lastUpdate, when)
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1636,7 +1636,7 @@ def load_certificate(type, buffer):
     :param type: The file type (one of FILETYPE_PEM, FILETYPE_ASN1)
 
     :param buffer: The buffer the certificate is stored in
-    :type buffer: :class:`bytes`
+    :type buffer: bytes
 
     :return: The X509 object
     """
@@ -1725,7 +1725,7 @@ def dump_privatekey(type, pkey, cipher=None, passphrase=None):
                        the passphrase to use, or a callback for providing the
                        passphrase.
     :return: The buffer with the dumped key in
-    :rtype: :data:`bytes`
+    :rtype: bytes
     """
     bio = _new_mem_buf()
 
@@ -1793,10 +1793,9 @@ class Revoked(object):
         The serial number is formatted as a hexadecimal number encoded in
         ASCII.
 
-        :param hex_str: The new serial number.
-        :type hex_str: :class:`bytes`
+        :param bytes hex_str: The new serial number.
 
-        :return: :const:`None`
+        :return: ``None``
         """
         bignum_serial = _ffi.gc(_lib.BN_new(), _lib.BN_free)
         bignum_ptr = _ffi.new("BIGNUM**")
@@ -1925,8 +1924,7 @@ class Revoked(object):
         """
         Set the revocation timestamp.
 
-        :param when: The timestamp of the revocation, as ASN.1 GENERALIZEDTIME.
-        :type when: :class:`bytes`
+        :param bytes when: The timestamp of the revocation, as ASN.1 GENERALIZEDTIME.
         :return: :const:`None`
         """
         dt = _lib.X509_REVOKED_get0_revocationDate(self._revoked)
@@ -2000,7 +1998,7 @@ class CRL(object):
 
         .. versionadded:: 16.1.0
 
-        :return: :class:`X509Name`
+        :rtype: X509Name
         """
         _issuer = _lib.X509_NAME_dup(_lib.X509_CRL_get_issuer(self._crl))
         _openssl_assert(_issuer != _ffi.NULL)
@@ -2754,7 +2752,7 @@ def dump_crl(type, crl):
     :param CRL crl: The CRL to dump.
 
     :return: The buffer with the CRL.
-    :rtype: :data:`bytes`
+    :rtype: bytes
     """
     bio = _new_mem_buf()
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1434,8 +1434,8 @@ class X509Store(object):
     to trust, a set of certificate revocation lists, verification flags and
     more.
 
-    An X.509 store, being only a description, cannot be used by itself to verify
-    a certificate. To carry out the actual verification process, see
+    An X.509 store, being only a description, cannot be used by itself to
+    verify a certificate. To carry out the actual verification process, see
     :py:class:`X509StoreContext`.
     """
 
@@ -1488,7 +1488,8 @@ class X509Store(object):
         .. versionadded:: 0.17
 
         :param CRL crl: The certificate revocation list to add to this store.
-        :return: :py:data:`None` if the certificate revocation list was added successfully.
+        :return: :py:data:`None` if the certificate revocation list was added
+            successfully.
         """
         _openssl_assert(_lib.X509_STORE_add_crl(self._store, crl._crl) != 0)
 
@@ -1511,7 +1512,8 @@ class X509Store(object):
         .. versionadded:: 0.17
 
         :param int flags: The verification flags to set on this store.
-        :return: :py:data:`None` if the verification flags were successfully set.
+        :return: :py:data:`None` if the verification flags were
+            successfully set.
         """
         _openssl_assert(_lib.X509_STORE_set_flags(self._store, flags) != 0)
 
@@ -2080,10 +2082,11 @@ class CRL(object):
         """
         digest_obj = _lib.EVP_get_digestbyname(digest)
         _openssl_assert(digest_obj != _ffi.NULL)
-        _lib.X509_CRL_set_issuer_name(self._crl, _lib.X509_get_subject_name(issuer_cert._x509))
+        _lib.X509_CRL_set_issuer_name(
+            self._crl, _lib.X509_get_subject_name(issuer_cert._x509))
         _lib.X509_CRL_sort(self._crl)
-        sign_result = _lib.X509_CRL_sign(self._crl, issuer_key._pkey, digest_obj)
-        _openssl_assert(sign_result != 0)
+        result = _lib.X509_CRL_sign(self._crl, issuer_key._pkey, digest_obj)
+        _openssl_assert(result != 0)
 
     def export(self, cert, key, type=FILETYPE_PEM, days=100,
                digest=_UNSPECIFIED):

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -9,7 +9,6 @@ from six import (
     integer_types as _integer_types,
     text_type as _text_type,
     PY3 as _PY3)
-from enum import Enum
 
 from OpenSSL._util import (
     ffi as _ffi,
@@ -1426,7 +1425,7 @@ class X509(object):
 X509Type = X509
 
 
-class X509StoreFlags(Enum):
+class X509StoreFlags(object):
     """
     Flags for X509 verification, used to change the behavior of
     :class:`X509Store`.

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1439,10 +1439,6 @@ class X509Store(object):
     :class:`X509StoreContext`.
     """
 
-    # I found that some of these flags were added in different versions
-    # of OpenSSL. How to conditionally add them if they're present?
-    # Do you have any suggestions on conditionally adding the flag if
-    # it is available in the underlying OpenSSL?
     CRL_CHECK = _lib.X509_V_FLAG_CRL_CHECK
     CRL_CHECK_ALL = _lib.X509_V_FLAG_CRL_CHECK_ALL
     IGNORE_CRITICAL = _lib.X509_V_FLAG_IGNORE_CRITICAL
@@ -1450,13 +1446,10 @@ class X509Store(object):
     ALLOW_PROXY_CERTS = _lib.X509_V_FLAG_ALLOW_PROXY_CERTS
     POLICY_CHECK = _lib.X509_V_FLAG_POLICY_CHECK
     EXPLICIT_POLICY = _lib.X509_V_FLAG_EXPLICIT_POLICY
-    # FLAG_INHIBIT_ANY = _lib.X509_V_FLAG_FLAG_INHIBIT_ANY
     INHIBIT_MAP = _lib.X509_V_FLAG_INHIBIT_MAP
     NOTIFY_POLICY = _lib.X509_V_FLAG_NOTIFY_POLICY
-    # USE_DELTAS = _lib.X509_V_FLAG_USE_DELTAS
     CHECK_SS_SIGNATURE = _lib.X509_V_FLAG_CHECK_SS_SIGNATURE
     CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
-    # NO_ALT_CHAINS = _lib.X509_V_FLAG_NO_ALT_CHAINS
 
     def __init__(self):
         store = _lib.X509_STORE_new()

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3400,7 +3400,8 @@ class CRLTests(TestCase):
 
     def test_get_issuer(self):
         """
-        Load a known CRL and inspect its issuer's common name.
+        Load a known CRL and assert its issuer's common name is
+        what we expect from the encoded crlData string.
         """
         crl = load_crl(FILETYPE_PEM, crlData)
         self.assertTrue(isinstance(crl.get_issuer(), X509Name))
@@ -3419,7 +3420,7 @@ class CRLTests(TestCase):
         Create a CRL.
 
         :param list[X509] certs: A list of certificates to revoke.
-        :return: :py:class:`CRL`
+        :rtype: CRL
         """
         crl = CRL()
         for cert in certs:
@@ -3440,7 +3441,7 @@ class CRLTests(TestCase):
 
     def test_verify_with_revoked(self):
         """
-        :py:obj:`verify_certificate` raises error when an intermediate
+        :func:`verify_certificate` raises error when an intermediate
         certificate is revoked.
         """
         store = X509Store()
@@ -3460,7 +3461,7 @@ class CRLTests(TestCase):
 
     def test_verify_with_missing_crl(self):
         """
-        :py:obj:`verify_certificate` raises error when an intermediate
+        :func:`verify_certificate` raises error when an intermediate
         certificate's CRL is missing.
         """
         store = X509Store()
@@ -3483,13 +3484,9 @@ class X509StoreContextTests(TestCase):
     Tests for :py:obj:`OpenSSL.crypto.X509StoreContext`.
     """
     root_cert = load_certificate(FILETYPE_PEM, root_cert_pem)
-    root_key = load_privatekey(FILETYPE_PEM, root_key_pem)
     intermediate_cert = load_certificate(FILETYPE_PEM, intermediate_cert_pem)
-    intermediate_key = load_privatekey(FILETYPE_PEM, intermediate_key_pem)
     intermediate_server_cert = load_certificate(
         FILETYPE_PEM, intermediate_server_cert_pem)
-    intermediate_server_key = load_privatekey(
-        FILETYPE_PEM, intermediate_server_key_pem)
 
     def test_valid(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3115,7 +3115,8 @@ class CRLTests(TestCase):
     intermediate_key = load_privatekey(FILETYPE_PEM, intermediate_key_pem)
     intermediate_server_cert = load_certificate(
         FILETYPE_PEM, intermediate_server_cert_pem)
-    intermediate_server_key = load_privatekey(FILETYPE_PEM, intermediate_server_key_pem)
+    intermediate_server_key = load_privatekey(
+        FILETYPE_PEM, intermediate_server_key_pem)
 
     def test_construction(self):
         """
@@ -3423,8 +3424,8 @@ class CRLTests(TestCase):
         crl = CRL()
         for cert in certs:
             revoked = Revoked()
-            # FIXME: This string splicing is an unfortunate implementation detail
-            # that has been reported in
+            # FIXME: This string splicing is an unfortunate implementation
+            # detail that has been reported in
             # https://github.com/pyca/pyopenssl/issues/258
             serial = hex(cert.get_serial_number())[2:].encode('utf-8')
             revoked.set_serial(serial)
@@ -3445,13 +3446,16 @@ class CRLTests(TestCase):
         store = X509Store()
         store.add_cert(self.root_cert)
         store.add_cert(self.intermediate_cert)
-        root_crl = self._make_test_crl(self.root_cert, self.root_key, certs=[self.intermediate_cert])
-        intermediate_crl = self._make_test_crl(self.intermediate_cert, self.intermediate_key, certs=[])
+        root_crl = self._make_test_crl(
+            self.root_cert, self.root_key, certs=[self.intermediate_cert])
+        intermediate_crl = self._make_test_crl(
+            self.intermediate_cert, self.intermediate_key, certs=[])
         store.add_crl(root_crl)
         store.add_crl(intermediate_crl)
         store.set_flags(store.CRL_CHECK | store.CRL_CHECK_ALL)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
-        e = self.assertRaises(X509StoreContextError, store_ctx.verify_certificate)
+        e = self.assertRaises(
+            X509StoreContextError, store_ctx.verify_certificate)
         self.assertEqual(e.args[0][2], 'certificate revoked')
 
     def test_verify_with_missing_crl(self):
@@ -3462,13 +3466,16 @@ class CRLTests(TestCase):
         store = X509Store()
         store.add_cert(self.root_cert)
         store.add_cert(self.intermediate_cert)
-        root_crl = self._make_test_crl(self.root_cert, self.root_key, certs=[self.intermediate_cert])
+        root_crl = self._make_test_crl(
+            self.root_cert, self.root_key, certs=[self.intermediate_cert])
         store.add_crl(root_crl)
         store.set_flags(store.CRL_CHECK | store.CRL_CHECK_ALL)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
-        e = self.assertRaises(X509StoreContextError, store_ctx.verify_certificate)
+        e = self.assertRaises(
+            X509StoreContextError, store_ctx.verify_certificate)
         self.assertEqual(e.args[0][2], 'unable to get certificate CRL')
-        self.assertEqual(e.certificate.get_subject().CN, 'intermediate-service')
+        self.assertEqual(
+            e.certificate.get_subject().CN, 'intermediate-service')
 
 
 class X509StoreContextTests(TestCase):
@@ -3481,7 +3488,8 @@ class X509StoreContextTests(TestCase):
     intermediate_key = load_privatekey(FILETYPE_PEM, intermediate_key_pem)
     intermediate_server_cert = load_certificate(
         FILETYPE_PEM, intermediate_server_cert_pem)
-    intermediate_server_key = load_privatekey(FILETYPE_PEM, intermediate_server_key_pem)
+    intermediate_server_key = load_privatekey(
+        FILETYPE_PEM, intermediate_server_key_pem)
 
     def test_valid(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -21,7 +21,11 @@ from six import u, b, binary_type
 from OpenSSL.crypto import TYPE_RSA, TYPE_DSA, Error, PKey, PKeyType
 from OpenSSL.crypto import X509, X509Type, X509Name, X509NameType
 from OpenSSL.crypto import (
-    X509Store, X509StoreType, X509StoreContext, X509StoreContextError
+    X509Store,
+    X509StoreFlags,
+    X509StoreType,
+    X509StoreContext,
+    X509StoreContextError
 )
 from OpenSSL.crypto import X509Req, X509ReqType
 from OpenSSL.crypto import X509Extension, X509ExtensionType
@@ -3453,7 +3457,9 @@ class CRLTests(TestCase):
             self.intermediate_cert, self.intermediate_key, certs=[])
         store.add_crl(root_crl)
         store.add_crl(intermediate_crl)
-        store.set_flags(store.CRL_CHECK | store.CRL_CHECK_ALL)
+        store.set_flags(
+            X509StoreFlags.CRL_CHECK.value |
+            X509StoreFlags.CRL_CHECK_ALL.value)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         e = self.assertRaises(
             X509StoreContextError, store_ctx.verify_certificate)
@@ -3470,7 +3476,9 @@ class CRLTests(TestCase):
         root_crl = self._make_test_crl(
             self.root_cert, self.root_key, certs=[self.intermediate_cert])
         store.add_crl(root_crl)
-        store.set_flags(store.CRL_CHECK | store.CRL_CHECK_ALL)
+        store.set_flags(
+            X509StoreFlags.CRL_CHECK.value |
+            X509StoreFlags.CRL_CHECK_ALL.value)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         e = self.assertRaises(
             X509StoreContextError, store_ctx.verify_certificate)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3109,6 +3109,14 @@ class CRLTests(TestCase):
     cert = load_certificate(FILETYPE_PEM, cleartextCertificatePEM)
     pkey = load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM)
 
+    root_cert = load_certificate(FILETYPE_PEM, root_cert_pem)
+    root_key = load_privatekey(FILETYPE_PEM, root_key_pem)
+    intermediate_cert = load_certificate(FILETYPE_PEM, intermediate_cert_pem)
+    intermediate_key = load_privatekey(FILETYPE_PEM, intermediate_key_pem)
+    intermediate_server_cert = load_certificate(
+        FILETYPE_PEM, intermediate_server_cert_pem)
+    intermediate_server_key = load_privatekey(FILETYPE_PEM, intermediate_server_key_pem)
+
     def test_construction(self):
         """
         Confirm we can create :py:obj:`OpenSSL.crypto.CRL`.  Check
@@ -3389,6 +3397,14 @@ class CRLTests(TestCase):
         """
         self.assertRaises(Error, load_crl, FILETYPE_PEM, b"hello, world")
 
+    def test_get_issuer(self):
+        """
+        Load a known CRL and inspect its issuer's common name.
+        """
+        crl = load_crl(FILETYPE_PEM, crlData)
+        self.assertTrue(isinstance(crl.get_issuer(), X509Name))
+        self.assertEqual(crl.get_issuer().CN, 'Testing Root CA')
+
     def test_dump_crl(self):
         """
         The dumped CRL matches the original input.
@@ -3397,15 +3413,75 @@ class CRLTests(TestCase):
         buf = dump_crl(FILETYPE_PEM, crl)
         assert buf == crlData
 
+    def _make_test_crl(self, issuer_cert, issuer_key, certs=()):
+        """
+        Create a CRL.
+
+        :param list[X509] certs: A list of certificates to revoke.
+        :return: :py:class:`CRL`
+        """
+        crl = CRL()
+        for cert in certs:
+            revoked = Revoked()
+            # FIXME: This string splicing is an unfortunate implementation detail
+            # that has been reported in
+            # https://github.com/pyca/pyopenssl/issues/258
+            serial = hex(cert.get_serial_number())[2:].encode('utf-8')
+            revoked.set_serial(serial)
+            revoked.set_reason(b'unspecified')
+            revoked.set_rev_date(b'20140601000000Z')
+            crl.add_revoked(revoked)
+        crl.set_version(1)
+        crl.set_lastUpdate(b'20140601000000Z')
+        crl.set_nextUpdate(b'20180601000000Z')
+        crl.sign(issuer_cert, issuer_key, digest=b'sha512')
+        return crl
+
+    def test_verify_with_revoked(self):
+        """
+        :py:obj:`verify_certificate` raises error when an intermediate
+        certificate is revoked.
+        """
+        store = X509Store()
+        store.add_cert(self.root_cert)
+        store.add_cert(self.intermediate_cert)
+        root_crl = self._make_test_crl(self.root_cert, self.root_key, certs=[self.intermediate_cert])
+        intermediate_crl = self._make_test_crl(self.intermediate_cert, self.intermediate_key, certs=[])
+        store.add_crl(root_crl)
+        store.add_crl(intermediate_crl)
+        store.set_flags(store.CRL_CHECK | store.CRL_CHECK_ALL)
+        store_ctx = X509StoreContext(store, self.intermediate_server_cert)
+        e = self.assertRaises(X509StoreContextError, store_ctx.verify_certificate)
+        self.assertEqual(e.args[0][2], 'certificate revoked')
+
+    def test_verify_with_missing_crl(self):
+        """
+        :py:obj:`verify_certificate` raises error when an intermediate
+        certificate's CRL is missing.
+        """
+        store = X509Store()
+        store.add_cert(self.root_cert)
+        store.add_cert(self.intermediate_cert)
+        root_crl = self._make_test_crl(self.root_cert, self.root_key, certs=[self.intermediate_cert])
+        store.add_crl(root_crl)
+        store.set_flags(store.CRL_CHECK | store.CRL_CHECK_ALL)
+        store_ctx = X509StoreContext(store, self.intermediate_server_cert)
+        e = self.assertRaises(X509StoreContextError, store_ctx.verify_certificate)
+        self.assertEqual(e.args[0][2], 'unable to get certificate CRL')
+        self.assertEqual(e.certificate.get_subject().CN, 'intermediate-service')
+
 
 class X509StoreContextTests(TestCase):
     """
     Tests for :py:obj:`OpenSSL.crypto.X509StoreContext`.
     """
     root_cert = load_certificate(FILETYPE_PEM, root_cert_pem)
+    root_key = load_privatekey(FILETYPE_PEM, root_key_pem)
     intermediate_cert = load_certificate(FILETYPE_PEM, intermediate_cert_pem)
+    intermediate_key = load_privatekey(FILETYPE_PEM, intermediate_key_pem)
     intermediate_server_cert = load_certificate(
         FILETYPE_PEM, intermediate_server_cert_pem)
+    intermediate_server_key = load_privatekey(FILETYPE_PEM, intermediate_server_key_pem)
 
     def test_valid(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3458,8 +3458,7 @@ class CRLTests(TestCase):
         store.add_crl(root_crl)
         store.add_crl(intermediate_crl)
         store.set_flags(
-            X509StoreFlags.CRL_CHECK.value |
-            X509StoreFlags.CRL_CHECK_ALL.value)
+            X509StoreFlags.CRL_CHECK | X509StoreFlags.CRL_CHECK_ALL)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         e = self.assertRaises(
             X509StoreContextError, store_ctx.verify_certificate)
@@ -3477,8 +3476,7 @@ class CRLTests(TestCase):
             self.root_cert, self.root_key, certs=[self.intermediate_cert])
         store.add_crl(root_crl)
         store.set_flags(
-            X509StoreFlags.CRL_CHECK.value |
-            X509StoreFlags.CRL_CHECK_ALL.value)
+            X509StoreFlags.CRL_CHECK | X509StoreFlags.CRL_CHECK_ALL)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         e = self.assertRaises(
             X509StoreContextError, store_ctx.verify_certificate)


### PR DESCRIPTION
This is a rebased change from #281 by @sholsapp, which changes by me to be _openssl_assert() compatible.

A local py.test --cov looks good, and all tests pass.