### PR TITLE
Add dump_pkcs7_data function to crypto module.

### DIFF
--- a/doc/api/crypto.rst
+++ b/doc/api/crypto.rst
@@ -103,6 +103,12 @@ Certificate revocation lists
     :py:const:`FILETYPE_PEM` or :py:const:`FILETYPE_ASN1`).
 
 
+.. py:function:: dump_pkcs7_data(type, pkcs7)
+    Return a string containing data from the PKCS7 object *pkcs7*
+    decoded from the type *type*. The type *type* must be either
+    :py:const:`FILETYPE_PEM` or :py:const:`FILETYPE_ASN1`.
+
+
 .. py:function:: load_pkcs7_data(type, buffer)
 
     Load pkcs7 data from the string *buffer* encoded with the type

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -2748,6 +2748,31 @@ def load_crl(type, buffer):
     return result
 
 
+def dump_pkcs7_data(type, pkcs7):
+    """
+    Dump PKCS7 data to a buffer.
+
+    :param type: The file type (one of ``FILETYPE_PEM`` or ``FILETYPE_ASN1``).
+    :param pkcs7: The PKCS7 object to dump.
+
+    :return: The buffer with the PKCS7 object.
+    :rtype: bytes
+    """
+    bio = _new_mem_buf()
+
+    if type == FILETYPE_PEM:
+        ret = _lib.PEM_write_bio_PKCS7(bio, pkcs7._pkcs7)
+    elif type == FILETYPE_ASN1:
+        ret = _lib.i2d_PKCS7_bio(bio, pkcs7._pkcs7)
+    else:
+        raise ValueError("type argument must be FILETYPE_PEM or FILETYPE_ASN1")
+
+    if ret != 1:
+        _raise_current_error()
+
+    return _bio_to_string(bio)
+
+
 def load_pkcs7_data(type, buffer):
     """
     Load pkcs7 data from a buffer

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -43,7 +43,7 @@ from OpenSSL.crypto import CRL, Revoked, dump_crl, load_crl
 from OpenSSL.crypto import NetscapeSPKI, NetscapeSPKIType
 from OpenSSL.crypto import (
     sign, verify, get_elliptic_curve, get_elliptic_curves)
-from OpenSSL._util import native, lib
+from OpenSSL._util import native, lib, ffi
 
 from .util import (
     EqualityTestsMixin, TestCase, WARNING_TYPE_EXPECTED
@@ -2940,7 +2940,7 @@ class FunctionTests(TestCase):
         :return:
         """
         pkcs7 = load_pkcs7_data(FILETYPE_PEM, pkcs7Data)
-        pkcs7._pkcs7 = object()
+        pkcs7._pkcs7 = ffi.NULL
         self.assertRaises(Error, dump_pkcs7_data, FILETYPE_PEM, pkcs7)
 
     def test_dump_pkcs7_type_invalid(self):

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -37,7 +37,7 @@ from OpenSSL.crypto import load_publickey, dump_publickey
 from OpenSSL.crypto import FILETYPE_PEM, FILETYPE_ASN1, FILETYPE_TEXT
 from OpenSSL.crypto import dump_certificate, load_certificate_request
 from OpenSSL.crypto import dump_certificate_request, dump_privatekey
-from OpenSSL.crypto import PKCS7Type, load_pkcs7_data
+from OpenSSL.crypto import PKCS7Type, dump_pkcs7_data, load_pkcs7_data
 from OpenSSL.crypto import PKCS12, PKCS12Type, load_pkcs12
 from OpenSSL.crypto import CRL, Revoked, dump_crl, load_crl
 from OpenSSL.crypto import NetscapeSPKI, NetscapeSPKIType
@@ -2913,6 +2913,43 @@ class FunctionTests(TestCase):
         key = load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM)
         with pytest.raises(ValueError):
             dump_privatekey(FILETYPE_PEM, key, GOOD_CIPHER, cb)
+
+    def test_dump_pkcs7_data_pem(self):
+        """
+        :py:obj:`dump_pkcs7_data` accepts an instance of :py:obj:`PKCS7Type`
+        and returns a PKCS#7 string.
+        """
+        pkcs7 = load_pkcs7_data(FILETYPE_PEM, pkcs7Data)
+        buf = dump_pkcs7_data(FILETYPE_PEM, pkcs7)
+        self.assertEqual(buf, pkcs7Data)
+
+    def test_dump_pkcs7_data_asn1(self):
+        """
+        :py:obj:`dump_pkcs7_data` accepts an instance of :py:obj:`PKCS7Type`
+        and returns a bytes containing ASN1 data representing PKCS#7.
+        """
+        pkcs7 = load_pkcs7_data(FILETYPE_ASN1, pkcs7DataASN1)
+        buf = dump_pkcs7_data(FILETYPE_ASN1, pkcs7)
+        self.assertEqual(buf, pkcs7DataASN1)
+
+    def test_dump_pkcs7_object_invalid(self):
+        """
+        If the PKCS7 object passed to :py:obj:`dump_pkcs7_data` is invalid,
+        :py:obj:`Error` is raised.
+        :param self:
+        :return:
+        """
+        pkcs7 = object()
+        pkcs7._pkcs7 = object()
+        self.assertRaises(Error, dump_pkcs7_data, FILETYPE_PEM, pkcs7)
+
+    def test_dump_pkcs7_type_invalid(self):
+        """
+        If the type passed to :py:obj:`dump_pkcs7_data` is invalid,
+        :py:obj:`ValueError` is raised.
+        """
+        pkcs7 = load_pkcs7_data(FILETYPE_PEM, pkcs7Data)
+        self.assertRaises(ValueError, dump_pkcs7_data, object(), pkcs7)
 
     def test_load_pkcs7_data_pem(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2939,7 +2939,7 @@ class FunctionTests(TestCase):
         :param self:
         :return:
         """
-        pkcs7 = object()
+        pkcs7 = load_pkcs7_data(FILETYPE_PEM, pkcs7Data)
         pkcs7._pkcs7 = object()
         self.assertRaises(Error, dump_pkcs7_data, FILETYPE_PEM, pkcs7)
 


### PR DESCRIPTION
Right now there's a function to load PKCS#7 data from a buffer, but no function to dump PKCS#7 data to a buffer. This PR adds one.
