### PR TITLE
Avoid pytest 3 warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
-[pytest]
-minversion = 2.8.5
+[tool:pytest]
+minversion = 3.0.1
 strict = true
 testpaths = tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ whitelist_externals =
 passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
 deps =
     coverage>=4.2
-    pytest>=2.8.5
+    pytest>=3.0.1
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
     cryptographyMinimum: cryptography<1.4
 setenv =


### PR DESCRIPTION
Also kind of a way to force a fresh Travis run before starting the release process.