### PR TITLE
fix cffi warnings for proper buffer types

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1613,7 +1613,7 @@ class Connection(object):
             return None
         length = _lib.SSL_get_server_random(self._ssl, _ffi.NULL, 0)
         assert length > 0
-        outp = _ffi.new("char[]", length)
+        outp = _ffi.new("unsigned char[]", length)
         _lib.SSL_get_server_random(self._ssl, outp, length)
         return _ffi.buffer(outp, length)[:]
 
@@ -1629,7 +1629,7 @@ class Connection(object):
 
         length = _lib.SSL_get_client_random(self._ssl, _ffi.NULL, 0)
         assert length > 0
-        outp = _ffi.new("char[]", length)
+        outp = _ffi.new("unsigned char[]", length)
         _lib.SSL_get_client_random(self._ssl, outp, length)
         return _ffi.buffer(outp, length)[:]
 
@@ -1645,7 +1645,7 @@ class Connection(object):
 
         length = _lib.SSL_SESSION_get_master_key(session, _ffi.NULL, 0)
         assert length > 0
-        outp = _ffi.new("char[]", length)
+        outp = _ffi.new("unsigned char[]", length)
         _lib.SSL_SESSION_get_master_key(session, outp, length)
         return _ffi.buffer(outp, length)[:]
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1100,7 +1100,7 @@ class X509(object):
         if digest == _ffi.NULL:
             raise ValueError("No such digest method")
 
-        result_buffer = _ffi.new("char[]", _lib.EVP_MAX_MD_SIZE)
+        result_buffer = _ffi.new("unsigned char[]", _lib.EVP_MAX_MD_SIZE)
         result_length = _ffi.new("unsigned int[]", 1)
         result_length[0] = len(result_buffer)
 

--- a/src/OpenSSL/rand.py
+++ b/src/OpenSSL/rand.py
@@ -54,7 +54,7 @@ def bytes(num_bytes):
     if num_bytes < 0:
         raise ValueError("num_bytes must not be negative")
 
-    result_buffer = _ffi.new("char[]", num_bytes)
+    result_buffer = _ffi.new("unsigned char[]", num_bytes)
     result_code = _lib.RAND_bytes(result_buffer, num_bytes)
     if result_code == -1:
         # TODO: No tests for this code path.  Triggering a RAND_bytes failure


### PR DESCRIPTION
fixes #544 

This is all the wrong buffers I found when running `py.test tests -s`