### PR TITLE
Migrate a large number of tests from unittest to pytest style

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1165,7 +1165,7 @@ class X509NameTests(TestCase):
         b = self._x509name(CN="foo")
         self.assertEqual(a.hash(), b.hash())
         a.CN = "bar"
-        self.assertNotEqual(a.hash(), b.hash())
+        assert a.hash() != b.hash()
 
     def test_der(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -588,17 +588,15 @@ class X509ExtTests(TestCase):
         :py:class:`X509ExtensionType` instance.
         """
         basic = X509Extension(b'basicConstraints', True, b'CA:true')
-        self.assertTrue(
-            isinstance(basic, X509ExtensionType),
+        assert isinstance(basic, X509ExtensionType), \
             "%r is of type %r, should be %r" % (
-                basic, type(basic), X509ExtensionType))
+                basic, type(basic), X509ExtensionType)
 
         comment = X509Extension(
             b'nsComment', False, b'pyOpenSSL unit test')
-        self.assertTrue(
-            isinstance(comment, X509ExtensionType),
+        assert isinstance(comment, X509ExtensionType), \
             "%r is of type %r, should be %r" % (
-                comment, type(comment), X509ExtensionType))
+                comment, type(comment), X509ExtensionType)
 
     def test_invalid_extension(self):
         """
@@ -624,7 +622,7 @@ class X509ExtTests(TestCase):
         extension's critical flag.
         """
         ext = X509Extension(b'basicConstraints', True, b'CA:true')
-        self.assertTrue(ext.get_critical())
+        assert ext.get_critical()
         ext = X509Extension(b'basicConstraints', False, b'CA:true')
         assert not ext.get_critical()
 
@@ -669,8 +667,8 @@ class X509ExtTests(TestCase):
         self.x509.sign(self.pkey, 'sha1')
         # This is a little lame.  Can we think of a better way?
         text = dump_certificate(FILETYPE_TEXT, self.x509)
-        self.assertTrue(b'X509v3 Basic Constraints:' in text)
-        self.assertTrue(b'CA:TRUE' in text)
+        assert b'X509v3 Basic Constraints:' in text
+        assert b'CA:TRUE' in text
 
     def test_subject(self):
         """
@@ -682,7 +680,7 @@ class X509ExtTests(TestCase):
         self.x509.add_extensions([ext3])
         self.x509.sign(self.pkey, 'sha1')
         text = dump_certificate(FILETYPE_TEXT, self.x509)
-        self.assertTrue(b'X509v3 Subject Key Identifier:' in text)
+        assert b'X509v3 Subject Key Identifier:' in text
 
     def test_missing_subject(self):
         """
@@ -714,8 +712,8 @@ class X509ExtTests(TestCase):
         self.x509.add_extensions([ext1])
         self.x509.sign(self.pkey, 'sha1')
         text = dump_certificate(FILETYPE_TEXT, self.x509)
-        self.assertTrue(b'X509v3 Basic Constraints:' in text)
-        self.assertTrue(b'CA:TRUE' in text)
+        assert b'X509v3 Basic Constraints:' in text
+        assert b'CA:TRUE' in text
 
     def test_issuer(self):
         """
@@ -728,8 +726,8 @@ class X509ExtTests(TestCase):
         self.x509.add_extensions([ext2])
         self.x509.sign(self.pkey, 'sha1')
         text = dump_certificate(FILETYPE_TEXT, self.x509)
-        self.assertTrue(b'X509v3 Authority Key Identifier:' in text)
-        self.assertTrue(b'DirName:/CN=Yoda root CA' in text)
+        assert b'X509v3 Authority Key Identifier:' in text
+        assert b'DirName:/CN=Yoda root CA' in text
 
     def test_missing_issuer(self):
         """
@@ -839,9 +837,8 @@ class PKeyTests(TestCase):
         """
         self.assertRaises(TypeError, PKey, None)
         key = PKey()
-        self.assertTrue(
-            isinstance(key, PKeyType),
-            "%r is of type %r, should be %r" % (key, type(key), PKeyType))
+        assert isinstance(key, PKeyType), \
+            "%r is of type %r, should be %r" % (key, type(key), PKeyType)
 
     def test_pregeneration(self):
         """
@@ -902,7 +899,7 @@ class PKeyTests(TestCase):
         key.generate_key(TYPE_RSA, bits)
         self.assertEqual(key.type(), TYPE_RSA)
         self.assertEqual(key.bits(), bits)
-        self.assertTrue(key.check())
+        assert key.check()
 
     def test_dsaGeneration(self):
         """
@@ -985,13 +982,12 @@ class X509NameTests(TestCase):
         """
         assert X509Name is X509NameType
         self.assertEqual(X509NameType.__name__, 'X509Name')
-        self.assertTrue(isinstance(X509NameType, type))
+        assert isinstance(X509NameType, type)
 
         name = self._x509name()
-        self.assertTrue(
-            isinstance(name, X509NameType),
+        assert isinstance(name, X509NameType), \
             "%r is of type %r, should be %r" % (
-                name, type(name), X509NameType))
+                name, type(name), X509NameType)
 
     def test_onlyStringAttributes(self):
         """
@@ -1276,7 +1272,7 @@ class _PKeyInteractionTestsMixin:
         # If the type has a verify method, cover that too.
         if getattr(request, 'verify', None) is not None:
             pub = request.get_pubkey()
-            self.assertTrue(request.verify(pub))
+            assert request.verify(pub)
             # Make another key that won't verify.
             key = PKey()
             key.generate_key(TYPE_RSA, 512)
@@ -1498,11 +1494,10 @@ WpOdIpB8KksUTCzV591Nr1wd
         :py:obj:`X509Type`.
         """
         certificate = X509()
-        self.assertTrue(
-            isinstance(certificate, X509Type),
+        assert isinstance(certificate, X509Type), \
             "%r is of type %r, should be %r" % (certificate,
                                                 type(certificate),
-                                                X509Type))
+                                                X509Type)
         self.assertEqual(type(X509Type).__name__, 'type')
         self.assertEqual(type(certificate).__name__, 'X509')
         self.assertEqual(type(certificate), X509Type)
@@ -1662,7 +1657,7 @@ WpOdIpB8KksUTCzV591Nr1wd
             cert.get_notBefore().decode(), "%Y%m%d%H%M%SZ"
         )
         not_before_max = datetime.utcnow() + timedelta(seconds=100)
-        self.assertTrue(not_before_min <= not_before <= not_before_max)
+        assert not_before_min <= not_before <= not_before_max
 
     def test_gmtime_adj_notAfter_wrong_args(self):
         """
@@ -1689,7 +1684,7 @@ WpOdIpB8KksUTCzV591Nr1wd
             cert.get_notAfter().decode(), "%Y%m%d%H%M%SZ"
         )
         not_after_max = datetime.utcnow() + timedelta(seconds=100)
-        self.assertTrue(not_after_min <= not_after <= not_after_max)
+        assert not_after_min <= not_after <= not_after_max
 
     def test_has_expired_wrong_args(self):
         """
@@ -1706,7 +1701,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         """
         cert = X509()
         cert.gmtime_adj_notAfter(-1)
-        self.assertTrue(cert.has_expired())
+        assert cert.has_expired()
 
     def test_has_not_expired(self):
         """
@@ -1791,17 +1786,17 @@ WpOdIpB8KksUTCzV591Nr1wd
         cert = self._extcert(pkey, [ca, key, subjectAltName])
 
         ext = cert.get_extension(0)
-        self.assertTrue(isinstance(ext, X509Extension))
-        self.assertTrue(ext.get_critical())
+        assert isinstance(ext, X509Extension)
+        assert ext.get_critical()
         self.assertEqual(ext.get_short_name(), b'basicConstraints')
 
         ext = cert.get_extension(1)
-        self.assertTrue(isinstance(ext, X509Extension))
-        self.assertTrue(ext.get_critical())
+        assert isinstance(ext, X509Extension)
+        assert ext.get_critical()
         self.assertEqual(ext.get_short_name(), b'keyUsage')
 
         ext = cert.get_extension(2)
-        self.assertTrue(isinstance(ext, X509Extension))
+        assert isinstance(ext, X509Extension)
         assert not ext.get_critical()
         self.assertEqual(ext.get_short_name(), b'subjectAltName')
 
@@ -1848,7 +1843,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         """
         cert = load_certificate(FILETYPE_PEM, self.pemData)
         subj = cert.get_subject()
-        self.assertTrue(isinstance(subj, X509Name))
+        assert isinstance(subj, X509Name)
         self.assertEquals(
             subj.get_components(),
             [(b'C', b'US'), (b'ST', b'IL'), (b'L', b'Chicago'),
@@ -1894,7 +1889,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         """
         cert = load_certificate(FILETYPE_PEM, self.pemData)
         subj = cert.get_issuer()
-        self.assertTrue(isinstance(subj, X509Name))
+        assert isinstance(subj, X509Name)
         comp = subj.get_components()
         self.assertEquals(
             comp,
@@ -2121,7 +2116,7 @@ class PKCS12Tests(TestCase):
 
         # OpenSSL fails to bring the key back to us.  So sad.  Perhaps in the
         # future this will be improved.
-        self.assertTrue(isinstance(p12.get_privatekey(), (PKey, type(None))))
+        assert isinstance(p12.get_privatekey(), (PKey, type(None)))
 
     def test_cert_only(self):
         """
@@ -2145,7 +2140,7 @@ class PKCS12Tests(TestCase):
         self.assertEqual(None, p12.get_privatekey())
 
         # OpenSSL fails to bring the cert back to us.  Groany mcgroan.
-        self.assertTrue(isinstance(p12.get_certificate(), (X509, type(None))))
+        assert isinstance(p12.get_certificate(), (X509, type(None)))
 
         # Oh ho.  It puts the certificate into the ca certificates list, in
         # fact.  Totally bogus, I would think.  Nevertheless, let's exploit
@@ -2417,7 +2412,7 @@ class PKCS12Tests(TestCase):
             # whether a PCKS12 had a MAC that was verified.
             # Anyway, libopenssl chooses to allow it, so the
             # pyopenssl binding does as well.
-            self.assertTrue(isinstance(recovered_p12, PKCS12))
+            assert isinstance(recovered_p12, PKCS12)
         except Error:
             # Failing here with an exception is preferred as some openssl
             # versions do.
@@ -2635,7 +2630,7 @@ class FunctionTests(TestCase):
         key = load_privatekey(
             FILETYPE_PEM, encryptedPrivateKeyPEM,
             encryptedPrivateKeyPEMPassphrase)
-        self.assertTrue(isinstance(key, PKeyType))
+        assert isinstance(key, PKeyType)
 
     def test_load_privatekey_passphrase_exception(self):
         """
@@ -2662,7 +2657,7 @@ class FunctionTests(TestCase):
         self.assertRaises(
             Error,
             load_privatekey, FILETYPE_PEM, encryptedPrivateKeyPEM, cb)
-        self.assertTrue(called)
+        assert called
 
     def test_load_privatekey_passphraseCallback(self):
         """
@@ -2676,7 +2671,7 @@ class FunctionTests(TestCase):
             called.append(writing)
             return encryptedPrivateKeyPEMPassphrase
         key = load_privatekey(FILETYPE_PEM, encryptedPrivateKeyPEM, cb)
-        self.assertTrue(isinstance(key, PKeyType))
+        assert isinstance(key, PKeyType)
         self.assertEqual(called, [False])
 
     def test_load_privatekey_passphrase_wrong_return_type(self):
@@ -2750,9 +2745,9 @@ class FunctionTests(TestCase):
         passphrase = b"foo"
         key = load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM)
         pem = dump_privatekey(FILETYPE_PEM, key, GOOD_CIPHER, passphrase)
-        self.assertTrue(isinstance(pem, binary_type))
+        assert isinstance(pem, binary_type)
         loadedKey = load_privatekey(FILETYPE_PEM, pem, passphrase)
-        self.assertTrue(isinstance(loadedKey, PKeyType))
+        assert isinstance(loadedKey, PKeyType)
         self.assertEqual(loadedKey.type(), key.type())
         self.assertEqual(loadedKey.bits(), key.bits())
 
@@ -2799,7 +2794,7 @@ class FunctionTests(TestCase):
         :py:obj:`dump_privatekey` writes a PEM
         """
         key = load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM)
-        self.assertTrue(key.check())
+        assert key.check()
         dumped_pem = dump_privatekey(FILETYPE_PEM, key)
         self.assertEqual(dumped_pem, cleartextPrivateKeyPEM)
 
@@ -2889,10 +2884,10 @@ class FunctionTests(TestCase):
             return passphrase
         key = load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM)
         pem = dump_privatekey(FILETYPE_PEM, key, GOOD_CIPHER, cb)
-        self.assertTrue(isinstance(pem, binary_type))
+        assert isinstance(pem, binary_type)
         self.assertEqual(called, [True])
         loadedKey = load_privatekey(FILETYPE_PEM, pem, passphrase)
-        self.assertTrue(isinstance(loadedKey, PKeyType))
+        assert isinstance(loadedKey, PKeyType)
         self.assertEqual(loadedKey.type(), key.type())
         self.assertEqual(loadedKey.bits(), key.bits())
 
@@ -2927,7 +2922,7 @@ class FunctionTests(TestCase):
         instance of :py:obj:`PKCS7Type`.
         """
         pkcs7 = load_pkcs7_data(FILETYPE_PEM, pkcs7Data)
-        self.assertTrue(isinstance(pkcs7, PKCS7Type))
+        assert isinstance(pkcs7, PKCS7Type)
 
     def test_load_pkcs7_data_asn1(self):
         """
@@ -2935,7 +2930,7 @@ class FunctionTests(TestCase):
         representing PKCS#7 and returns an instance of :py:obj`PKCS7Type`.
         """
         pkcs7 = load_pkcs7_data(FILETYPE_ASN1, pkcs7DataASN1)
-        self.assertTrue(isinstance(pkcs7, PKCS7Type))
+        assert isinstance(pkcs7, PKCS7Type)
 
     def test_load_pkcs7_data_invalid(self):
         """
@@ -2987,7 +2982,7 @@ class PKCS7Tests(TestCase):
         """
         :py:obj:`PKCS7Type` is a type object.
         """
-        self.assertTrue(isinstance(PKCS7Type, type))
+        assert isinstance(PKCS7Type, type)
         self.assertEqual(PKCS7Type.__name__, 'PKCS7')
 
         # XXX This doesn't currently work.
@@ -3009,7 +3004,7 @@ class PKCS7Tests(TestCase):
         object is of the type *signed*.
         """
         pkcs7 = load_pkcs7_data(FILETYPE_PEM, pkcs7Data)
-        self.assertTrue(pkcs7.type_is_signed())
+        assert pkcs7.type_is_signed()
 
     def test_type_is_enveloped_wrong_args(self):
         """
@@ -3110,7 +3105,7 @@ class NetscapeSPKITests(TestCase, _PKeyInteractionTestsMixin):
         :py:obj:`NetscapeSPKIType`.
         """
         nspki = NetscapeSPKI()
-        self.assertTrue(isinstance(nspki, NetscapeSPKIType))
+        assert isinstance(nspki, NetscapeSPKIType)
 
     def test_invalid_attribute(self):
         """
@@ -3127,7 +3122,7 @@ class NetscapeSPKITests(TestCase, _PKeyInteractionTestsMixin):
         """
         nspki = NetscapeSPKI()
         blob = nspki.b64_encode()
-        self.assertTrue(isinstance(blob, binary_type))
+        assert isinstance(blob, binary_type)
 
 
 class TestRevoked(object):
@@ -3166,7 +3161,7 @@ class RevokedTests(TestCase):
         that it is empty.
         """
         revoked = Revoked()
-        self.assertTrue(isinstance(revoked, Revoked))
+        assert isinstance(revoked, Revoked)
         self.assertEquals(type(revoked), Revoked)
         self.assertEquals(revoked.get_serial(), b'00')
         self.assertEquals(revoked.get_rev_date(), None)
@@ -3282,7 +3277,7 @@ class CRLTests(TestCase):
         that it is empty
         """
         crl = CRL()
-        self.assertTrue(isinstance(crl, CRL))
+        assert isinstance(crl, CRL)
         self.assertEqual(crl.get_revoked(), None)
 
     def test_construction_wrong_args(self):
@@ -3420,7 +3415,7 @@ class CRLTests(TestCase):
         revoked.set_serial(b"01")
         revoked.set_rev_date(b"20160310020145Z")
         crl.add_revoked(revoked=revoked)
-        self.assertTrue(isinstance(crl.get_revoked()[0], Revoked))
+        assert isinstance(crl.get_revoked()[0], Revoked)
 
     def test_export_wrong_args(self):
         """
@@ -3562,7 +3557,7 @@ class CRLTests(TestCase):
         what we expect from the encoded crlData string.
         """
         crl = load_crl(FILETYPE_PEM, crlData)
-        self.assertTrue(isinstance(crl.get_issuer(), X509Name))
+        assert isinstance(crl.get_issuer(), X509Name)
         self.assertEqual(crl.get_issuer().CN, 'Testing Root CA')
 
     def test_dump_crl(self):
@@ -3883,7 +3878,7 @@ class EllipticCurveTests(TestCase):
         """
         curves = get_elliptic_curves()
         if lib.Cryptography_HAS_EC:
-            self.assertTrue(curves)
+            assert curves
         else:
             assert not curves
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -626,7 +626,7 @@ class X509ExtTests(TestCase):
         ext = X509Extension(b'basicConstraints', True, b'CA:true')
         self.assertTrue(ext.get_critical())
         ext = X509Extension(b'basicConstraints', False, b'CA:true')
-        self.assertFalse(ext.get_critical())
+        assert not ext.get_critical()
 
     def test_get_short_name(self):
         """
@@ -1090,8 +1090,14 @@ class X509NameTests(TestCase):
             assertTrue(b == a)
             assertFalse(b != a)
 
+        def assertTrue(condition, message="assertTrue failed"):
+            assert condition, message
+
+        def assertFalse(condition, message="assertFalse failed"):
+            assert not condition, message
+
         def assertEqual(a, b):
-            _equality(a, b, self.assertTrue, self.assertFalse)
+            _equality(a, b, assertTrue, assertFalse)
 
         # Instances compare equal to themselves.
         name = self._x509name()
@@ -1115,7 +1121,7 @@ class X509NameTests(TestCase):
                     self._x509name(commonName="foo", OU="bar"))
 
         def assertNotEqual(a, b):
-            _equality(a, b, self.assertFalse, self.assertTrue)
+            _equality(a, b, assertFalse, assertTrue)
 
         # Instances with different values for the same NID should not compare
         # equal to each other.
@@ -1139,7 +1145,7 @@ class X509NameTests(TestCase):
             assertFalse(b <= a)
 
         def assertLessThan(a, b):
-            _inequality(a, b, self.assertTrue, self.assertFalse)
+            _inequality(a, b, assertTrue, assertFalse)
 
         # An X509Name with a NID with a value which sorts less than the value
         # of the same NID on another X509Name compares less than the other
@@ -1148,7 +1154,7 @@ class X509NameTests(TestCase):
                        self._x509name(CN="def"))
 
         def assertGreaterThan(a, b):
-            _inequality(a, b, self.assertFalse, self.assertTrue)
+            _inequality(a, b, assertFalse, assertTrue)
 
         # An X509Name with a NID with a value which sorts greater than the
         # value of the same NID on another X509Name compares greater than the
@@ -1709,7 +1715,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         """
         cert = X509()
         cert.gmtime_adj_notAfter(2)
-        self.assertFalse(cert.has_expired())
+        assert not cert.has_expired()
 
     def test_root_has_not_expired(self):
         """
@@ -1717,7 +1723,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         certificate's not-after time is in the future.
         """
         cert = load_certificate(FILETYPE_PEM, root_cert_pem)
-        self.assertFalse(cert.has_expired())
+        assert not cert.has_expired()
 
     def test_digest(self):
         """
@@ -1796,7 +1802,7 @@ WpOdIpB8KksUTCzV591Nr1wd
 
         ext = cert.get_extension(2)
         self.assertTrue(isinstance(ext, X509Extension))
-        self.assertFalse(ext.get_critical())
+        assert not ext.get_critical()
         self.assertEqual(ext.get_short_name(), b'subjectAltName')
 
         self.assertRaises(IndexError, cert.get_extension, -1)
@@ -3019,7 +3025,7 @@ class PKCS7Tests(TestCase):
         PKCS7 object is not of the type *enveloped*.
         """
         pkcs7 = load_pkcs7_data(FILETYPE_PEM, pkcs7Data)
-        self.assertFalse(pkcs7.type_is_enveloped())
+        assert not pkcs7.type_is_enveloped()
 
     def test_type_is_signedAndEnveloped_wrong_args(self):
         """
@@ -3035,7 +3041,7 @@ class PKCS7Tests(TestCase):
         if the PKCS7 object is not of the type *signed and enveloped*.
         """
         pkcs7 = load_pkcs7_data(FILETYPE_PEM, pkcs7Data)
-        self.assertFalse(pkcs7.type_is_signedAndEnveloped())
+        assert not pkcs7.type_is_signedAndEnveloped()
 
     def test_type_is_data(self):
         """
@@ -3043,7 +3049,7 @@ class PKCS7Tests(TestCase):
         object is not of the type data.
         """
         pkcs7 = load_pkcs7_data(FILETYPE_PEM, pkcs7Data)
-        self.assertFalse(pkcs7.type_is_data())
+        assert not pkcs7.type_is_data()
 
     def test_type_is_data_wrong_args(self):
         """
@@ -3879,7 +3885,7 @@ class EllipticCurveTests(TestCase):
         if lib.Cryptography_HAS_EC:
             self.assertTrue(curves)
         else:
-            self.assertFalse(curves)
+            assert not curves
 
     def test_a_curve(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -631,9 +631,9 @@ class X509ExtTests(TestCase):
         short type name of the extension.
         """
         ext = X509Extension(b'basicConstraints', True, b'CA:true')
-        self.assertEqual(ext.get_short_name(), b'basicConstraints')
+        assert ext.get_short_name() == b'basicConstraints'
         ext = X509Extension(b'nsComment', True, b'foo bar')
-        self.assertEqual(ext.get_short_name(), b'nsComment')
+        assert ext.get_short_name() == b'nsComment'
 
     def test_get_data(self):
         """
@@ -642,7 +642,7 @@ class X509ExtTests(TestCase):
         """
         ext = X509Extension(b'basicConstraints', True, b'CA:true')
         # Expect to get back the DER encoded form of CA:true.
-        self.assertEqual(ext.get_data(), b'0\x03\x01\x01\xff')
+        assert ext.get_data() == b'0\x03\x01\x01\xff'
 
     def test_get_data_wrong_args(self):
         """
@@ -846,8 +846,8 @@ class PKeyTests(TestCase):
         raises :py:exc:`TypeError` before the key is generated.
         """
         key = PKey()
-        self.assertEqual(key.type(), 0)
-        self.assertEqual(key.bits(), 0)
+        assert key.type() == 0
+        assert key.bits() == 0
         self.assertRaises(TypeError, key.check)
 
     def test_failedGeneration(self):
@@ -896,8 +896,8 @@ class PKeyTests(TestCase):
         bits = 128
         key = PKey()
         key.generate_key(TYPE_RSA, bits)
-        self.assertEqual(key.type(), TYPE_RSA)
-        self.assertEqual(key.bits(), bits)
+        assert key.type() == TYPE_RSA
+        assert key.bits() == bits
         assert key.check()
 
     def test_dsaGeneration(self):
@@ -911,8 +911,8 @@ class PKeyTests(TestCase):
         bits = 512
         key = PKey()
         key.generate_key(TYPE_DSA, bits)
-        # self.assertEqual(key.type(), TYPE_DSA)
-        # self.assertEqual(key.bits(), bits)
+        # assert key.type() == TYPE_DSA
+        # assert key.bits() == bits
         # self.assertRaises(TypeError, key.check)
 
     def test_regeneration(self):
@@ -923,8 +923,8 @@ class PKeyTests(TestCase):
         key = PKey()
         for type, bits in [(TYPE_RSA, 512), (TYPE_DSA, 576)]:
             key.generate_key(type, bits)
-            self.assertEqual(key.type(), type)
-            self.assertEqual(key.bits(), bits)
+            assert key.type() == type
+            assert key.bits() == bits
 
     def test_inconsistentKey(self):
         """
@@ -980,7 +980,7 @@ class X509NameTests(TestCase):
         The type of X509Name objects is :py:class:`X509NameType`.
         """
         assert X509Name is X509NameType
-        self.assertEqual(X509NameType.__name__, 'X509Name')
+        assert X509NameType.__name__ == 'X509Name'
         assert isinstance(X509NameType, type)
 
         name = self._x509name()
@@ -1053,16 +1053,16 @@ class X509NameTests(TestCase):
         name = self._x509name(commonName="foo", emailAddress="bar@example.com")
 
         copy = X509Name(name)
-        self.assertEqual(copy.commonName, "foo")
-        self.assertEqual(copy.emailAddress, "bar@example.com")
+        assert copy.commonName == "foo"
+        assert copy.emailAddress == "bar@example.com"
 
         # Mutate the copy and ensure the original is unmodified.
         copy.commonName = "baz"
-        self.assertEqual(name.commonName, "foo")
+        assert name.commonName == "foo"
 
         # Mutate the original and ensure the copy is unmodified.
         name.emailAddress = "quux@example.com"
-        self.assertEqual(copy.emailAddress, "bar@example.com")
+        assert copy.emailAddress == "bar@example.com"
 
     def test_repr(self):
         """
@@ -1071,9 +1071,7 @@ class X509NameTests(TestCase):
         have been set on it.
         """
         name = self._x509name(commonName="foo", emailAddress="bar")
-        self.assertEqual(
-            repr(name),
-            "<X509Name object '/emailAddress=bar/CN=foo'>")
+        assert repr(name) == "<X509Name object '/emailAddress=bar/CN=foo'>"
 
     def test_comparison(self):
         """
@@ -1164,7 +1162,7 @@ class X509NameTests(TestCase):
         """
         a = self._x509name(CN="foo")
         b = self._x509name(CN="foo")
-        self.assertEqual(a.hash(), b.hash())
+        assert a.hash() == b.hash()
         a.CN = "bar"
         assert a.hash() != b.hash()
 
@@ -1173,8 +1171,7 @@ class X509NameTests(TestCase):
         :py:meth:`X509Name.der` returns the DER encoded form of the name.
         """
         a = self._x509name(CN="foo", C="US")
-        self.assertEqual(
-            a.der(),
+        assert a.der() == (
             b'0\x1b1\x0b0\t\x06\x03U\x04\x06\x13\x02US'
             b'1\x0c0\n\x06\x03U\x04\x03\x0c\x03foo')
 
@@ -1185,13 +1182,11 @@ class X509NameTests(TestCase):
         giving the NIDs and associated values which make up the name.
         """
         a = self._x509name()
-        self.assertEqual(a.get_components(), [])
+        assert a.get_components() == []
         a.CN = "foo"
-        self.assertEqual(a.get_components(), [(b"CN", b"foo")])
+        assert a.get_components() == [(b"CN", b"foo")]
         a.organizationalUnitName = "bar"
-        self.assertEqual(
-            a.get_components(),
-            [(b"CN", b"foo"), (b"OU", b"bar")])
+        assert a.get_components() == [(b"CN", b"foo"), (b"OU", b"bar")]
 
     def test_load_nul_byte_attribute(self):
         """
@@ -1201,8 +1196,7 @@ class X509NameTests(TestCase):
         """
         cert = load_certificate(FILETYPE_PEM, nulbyteSubjectAltNamePEM)
         subject = cert.get_subject()
-        self.assertEqual(
-            "null.python.org\x00example.org", subject.commonName)
+        assert "null.python.org\x00example.org" == subject.commonName
 
     def test_setAttributeFailure(self):
         """
@@ -1313,11 +1307,11 @@ class X509ReqTests(TestCase, _PKeyInteractionTestsMixin):
         version is 0.
         """
         request = X509Req()
-        self.assertEqual(request.get_version(), 0)
+        assert request.get_version() == 0
         request.set_version(1)
-        self.assertEqual(request.get_version(), 1)
+        assert request.get_version() == 1
         request.set_version(3)
-        self.assertEqual(request.get_version(), 3)
+        assert request.get_version() == 3
 
     def test_version_wrong_args(self):
         """
@@ -1342,10 +1336,10 @@ class X509ReqTests(TestCase, _PKeyInteractionTestsMixin):
         subject = request.get_subject()
         assert isinstance(subject, X509NameType)
         subject.commonName = "foo"
-        self.assertEqual(request.get_subject().commonName, "foo")
+        assert request.get_subject().commonName == "foo"
         del request
         subject.commonName = "bar"
-        self.assertEqual(subject.commonName, "bar")
+        assert subject.commonName == "bar"
 
     def test_get_subject_wrong_args(self):
         """
@@ -1364,10 +1358,10 @@ class X509ReqTests(TestCase, _PKeyInteractionTestsMixin):
         request.add_extensions([
             X509Extension(b'basicConstraints', True, b'CA:false')])
         exts = request.get_extensions()
-        self.assertEqual(len(exts), 1)
-        self.assertEqual(exts[0].get_short_name(), b'basicConstraints')
-        self.assertEqual(exts[0].get_critical(), 1)
-        self.assertEqual(exts[0].get_data(), b'0\x00')
+        assert len(exts) == 1
+        assert exts[0].get_short_name() == b'basicConstraints'
+        assert exts[0].get_critical() == 1
+        assert exts[0].get_data() == b'0\x00'
 
     def test_get_extensions(self):
         """
@@ -1376,18 +1370,18 @@ class X509ReqTests(TestCase, _PKeyInteractionTestsMixin):
         """
         request = X509Req()
         exts = request.get_extensions()
-        self.assertEqual(exts, [])
+        assert exts == []
         request.add_extensions([
             X509Extension(b'basicConstraints', True, b'CA:true'),
             X509Extension(b'keyUsage', False, b'digitalSignature')])
         exts = request.get_extensions()
-        self.assertEqual(len(exts), 2)
-        self.assertEqual(exts[0].get_short_name(), b'basicConstraints')
-        self.assertEqual(exts[0].get_critical(), 1)
-        self.assertEqual(exts[0].get_data(), b'0\x03\x01\x01\xff')
-        self.assertEqual(exts[1].get_short_name(), b'keyUsage')
-        self.assertEqual(exts[1].get_critical(), 0)
-        self.assertEqual(exts[1].get_data(), b'\x03\x02\x07\x80')
+        assert len(exts) == 2
+        assert exts[0].get_short_name() == b'basicConstraints'
+        assert exts[0].get_critical() == 1
+        assert exts[0].get_data() == b'0\x03\x01\x01\xff'
+        assert exts[1].get_short_name() == b'keyUsage'
+        assert exts[1].get_critical() == 0
+        assert exts[1].get_data() == b'\x03\x02\x07\x80'
 
     def test_add_extensions_wrong_args(self):
         """
@@ -1443,7 +1437,7 @@ class X509ReqTests(TestCase, _PKeyInteractionTestsMixin):
         request = X509Req()
         pkey = load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM)
         request.sign(pkey, GOOD_DIGEST)
-        self.assertEqual(True, request.verify(pkey))
+        assert request.verify(pkey)
 
 
 class X509Tests(TestCase, _PKeyInteractionTestsMixin):
@@ -1497,10 +1491,10 @@ WpOdIpB8KksUTCzV591Nr1wd
             "%r is of type %r, should be %r" % (certificate,
                                                 type(certificate),
                                                 X509Type)
-        self.assertEqual(type(X509Type).__name__, 'type')
-        self.assertEqual(type(certificate).__name__, 'X509')
-        self.assertEqual(type(certificate), X509Type)
-        self.assertEqual(type(certificate), X509)
+        assert type(X509Type).__name__ == 'type'
+        assert type(certificate).__name__ == 'X509'
+        assert type(certificate) == X509Type
+        assert type(certificate) == X509
 
     def test_get_version_wrong_args(self):
         """
@@ -1548,15 +1542,15 @@ WpOdIpB8KksUTCzV591Nr1wd
         self.assertRaises(TypeError, certificate.set_serial_number, 1, 2)
         self.assertRaises(TypeError, certificate.set_serial_number, "1")
         self.assertRaises(TypeError, certificate.set_serial_number, 5.5)
-        self.assertEqual(certificate.get_serial_number(), 0)
+        assert certificate.get_serial_number() == 0
         certificate.set_serial_number(1)
-        self.assertEqual(certificate.get_serial_number(), 1)
+        assert certificate.get_serial_number() == 1
         certificate.set_serial_number(2 ** 32 + 1)
-        self.assertEqual(certificate.get_serial_number(), 2 ** 32 + 1)
+        assert certificate.get_serial_number() == 2 ** 32 + 1
         certificate.set_serial_number(2 ** 64 + 1)
-        self.assertEqual(certificate.get_serial_number(), 2 ** 64 + 1)
+        assert certificate.get_serial_number() == 2 ** 64 + 1
         certificate.set_serial_number(2 ** 128 + 1)
-        self.assertEqual(certificate.get_serial_number(), 2 ** 128 + 1)
+        assert certificate.get_serial_number() == 2 ** 128 + 1
 
     def _setBoundTest(self, which):
         """
@@ -1569,22 +1563,22 @@ WpOdIpB8KksUTCzV591Nr1wd
         get = getattr(certificate, 'get_not' + which)
 
         # Starts with no value.
-        self.assertEqual(get(), None)
+        assert get() is None
 
         # GMT (Or is it UTC?) -exarkun
         when = b"20040203040506Z"
         set(when)
-        self.assertEqual(get(), when)
+        assert get() == when
 
         # A plus two hours and thirty minutes offset
         when = b"20040203040506+0530"
         set(when)
-        self.assertEqual(get(), when)
+        assert get() == when
 
         # A minus one hour fifteen minutes offset
         when = b"20040203040506-0115"
         set(when)
-        self.assertEqual(get(), when)
+        assert get() == when
 
         # An invalid string results in a ValueError
         self.assertRaises(ValueError, set, b"foo bar")
@@ -1620,7 +1614,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         internally.
         """
         cert = load_certificate(FILETYPE_PEM, self.pemData)
-        self.assertEqual(cert.get_notBefore(), b"20090325123658Z")
+        assert cert.get_notBefore() == b"20090325123658Z"
 
     def test_get_notAfter(self):
         """
@@ -1629,7 +1623,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         internally.
         """
         cert = load_certificate(FILETYPE_PEM, self.pemData)
-        self.assertEqual(cert.get_notAfter(), b"20170611123658Z")
+        assert cert.get_notAfter() == b"20170611123658Z"
 
     def test_gmtime_adj_notBefore_wrong_args(self):
         """
@@ -1725,14 +1719,13 @@ WpOdIpB8KksUTCzV591Nr1wd
         words of the digest of the certificate.
         """
         cert = load_certificate(FILETYPE_PEM, root_cert_pem)
-        self.assertEqual(
-            # This is MD5 instead of GOOD_DIGEST because the digest algorithm
-            # actually matters to the assertion (ie, another arbitrary, good
-            # digest will not product the same digest).
-            # Digest verified with the command:
-            # openssl x509 -in root_cert.pem -noout -fingerprint -md5
-            cert.digest("MD5"),
-            b"19:B3:05:26:2B:F8:F2:FF:0B:8F:21:07:A8:28:B8:75")
+        # This is MD5 instead of GOOD_DIGEST because the digest algorithm
+        # actually matters to the assertion (ie == another arbitrary, good
+        # digest will not product the same digest.
+        # Digest verified with the command:
+        # openssl x509 -in root_cert.pem -noout -fingerprint -md5
+        assert cert.digest("MD5") == \
+            b"19:B3:05:26:2B:F8:F2:FF:0B:8F:21:07:A8:28:B8:75"
 
     def _extcert(self, pkey, extensions):
         cert = X509()
@@ -1761,15 +1754,15 @@ WpOdIpB8KksUTCzV591Nr1wd
 
         # Try a certificate with no extensions at all.
         c = self._extcert(pkey, [])
-        self.assertEqual(c.get_extension_count(), 0)
+        assert c.get_extension_count() == 0
 
         # And a certificate with one
         c = self._extcert(pkey, [ca])
-        self.assertEqual(c.get_extension_count(), 1)
+        assert c.get_extension_count() == 1
 
         # And a certificate with several
         c = self._extcert(pkey, [ca, key, subjectAltName])
-        self.assertEqual(c.get_extension_count(), 3)
+        assert c.get_extension_count() == 3
 
     def test_get_extension(self):
         """
@@ -1787,17 +1780,17 @@ WpOdIpB8KksUTCzV591Nr1wd
         ext = cert.get_extension(0)
         assert isinstance(ext, X509Extension)
         assert ext.get_critical()
-        self.assertEqual(ext.get_short_name(), b'basicConstraints')
+        assert ext.get_short_name() == b'basicConstraints'
 
         ext = cert.get_extension(1)
         assert isinstance(ext, X509Extension)
         assert ext.get_critical()
-        self.assertEqual(ext.get_short_name(), b'keyUsage')
+        assert ext.get_short_name() == b'keyUsage'
 
         ext = cert.get_extension(2)
         assert isinstance(ext, X509Extension)
         assert not ext.get_critical()
-        self.assertEqual(ext.get_short_name(), b'subjectAltName')
+        assert ext.get_short_name() == b'subjectAltName'
 
         self.assertRaises(IndexError, cert.get_extension, -1)
         self.assertRaises(IndexError, cert.get_extension, 4)
@@ -1812,13 +1805,13 @@ WpOdIpB8KksUTCzV591Nr1wd
         cert = load_certificate(FILETYPE_PEM, nulbyteSubjectAltNamePEM)
 
         ext = cert.get_extension(3)
-        self.assertEqual(ext.get_short_name(), b'subjectAltName')
-        self.assertEqual(
+        assert ext.get_short_name() == b'subjectAltName'
+        assert str(ext).encode("ascii") == (
             b"DNS:altnull.python.org\x00example.com, "
             b"email:null@python.org\x00user@example.org, "
             b"URI:http://null.python.org\x00http://example.org, "
-            b"IP Address:192.0.2.1, IP Address:2001:DB8:0:0:0:0:0:1\n",
-            str(ext).encode("ascii"))
+            b"IP Address:192.0.2.1, IP Address:2001:DB8:0:0:0:0:0:1\n"
+        )
 
     def test_invalid_digest_algorithm(self):
         """
@@ -1958,8 +1951,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         the algorithm used to sign the certificate.
         """
         cert = load_certificate(FILETYPE_PEM, self.pemData)
-        self.assertEqual(
-            b"sha1WithRSAEncryption", cert.get_signature_algorithm())
+        assert b"sha1WithRSAEncryption" == cert.get_signature_algorithm()
 
     def test_get_undefined_signature_algorithm(self):
         """
@@ -2061,10 +2053,10 @@ class PKCS12Tests(TestCase):
         certificate, private key, CA certificates, or friendly name.
         """
         p12 = PKCS12()
-        self.assertEqual(None, p12.get_certificate())
-        self.assertEqual(None, p12.get_privatekey())
-        self.assertEqual(None, p12.get_ca_certificates())
-        self.assertEqual(None, p12.get_friendlyname())
+        assert p12.get_certificate() is None
+        assert p12.get_privatekey() is None
+        assert p12.get_ca_certificates() is None
+        assert p12.get_friendlyname() is None
 
     def test_type_errors(self):
         """
@@ -2096,8 +2088,8 @@ class PKCS12Tests(TestCase):
         p12 = PKCS12()
         pkey = load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM)
         p12.set_privatekey(pkey)
-        self.assertEqual(None, p12.get_certificate())
-        self.assertEqual(pkey, p12.get_privatekey())
+        assert p12.get_certificate() is None
+        assert pkey == p12.get_privatekey()
         try:
             dumped_p12 = p12.export(passphrase=passwd, iter=2, maciter=3)
         except Error:
@@ -2106,8 +2098,8 @@ class PKCS12Tests(TestCase):
             # [('PKCS12 routines', 'PKCS12_create', 'invalid null argument')]
             return
         p12 = load_pkcs12(dumped_p12, passwd)
-        self.assertEqual(None, p12.get_ca_certificates())
-        self.assertEqual(None, p12.get_certificate())
+        assert p12.get_ca_certificates() is None
+        assert p12.get_certificate() is None
 
         # OpenSSL fails to bring the key back to us.  So sad.  Perhaps in the
         # future this will be improved.
@@ -2122,8 +2114,8 @@ class PKCS12Tests(TestCase):
         p12 = PKCS12()
         cert = load_certificate(FILETYPE_PEM, cleartextCertificatePEM)
         p12.set_certificate(cert)
-        self.assertEqual(cert, p12.get_certificate())
-        self.assertEqual(None, p12.get_privatekey())
+        assert cert == p12.get_certificate()
+        assert p12.get_privatekey() is None
         try:
             dumped_p12 = p12.export(passphrase=passwd, iter=2, maciter=3)
         except Error:
@@ -2132,7 +2124,7 @@ class PKCS12Tests(TestCase):
             # [('PKCS12 routines', 'PKCS12_create', 'invalid null argument')]
             return
         p12 = load_pkcs12(dumped_p12, passwd)
-        self.assertEqual(None, p12.get_privatekey())
+        assert p12.get_privatekey() is None
 
         # OpenSSL fails to bring the cert back to us.  Groany mcgroan.
         assert isinstance(p12.get_certificate(), (X509, type(None)))
@@ -2143,9 +2135,8 @@ class PKCS12Tests(TestCase):
         # it to.  At some point, hopefully this will change so that
         # p12.get_certificate() is actually what returns the loaded
         # certificate.
-        self.assertEqual(
-            cleartextCertificatePEM,
-            dump_certificate(FILETYPE_PEM, p12.get_ca_certificates()[0]))
+        assert cleartextCertificatePEM == \
+            dump_certificate(FILETYPE_PEM, p12.get_ca_certificates()[0])
 
     def gen_pkcs12(self, cert_pem=None, key_pem=None, ca_pem=None,
                    friendly_name=None):
@@ -2156,18 +2147,18 @@ class PKCS12Tests(TestCase):
         p12 = PKCS12()
         if cert_pem:
             ret = p12.set_certificate(load_certificate(FILETYPE_PEM, cert_pem))
-            self.assertEqual(ret, None)
+            assert ret is None
         if key_pem:
             ret = p12.set_privatekey(load_privatekey(FILETYPE_PEM, key_pem))
-            self.assertEqual(ret, None)
+            assert ret is None
         if ca_pem:
             ret = p12.set_ca_certificates(
                 (load_certificate(FILETYPE_PEM, ca_pem),)
             )
-            self.assertEqual(ret, None)
+            assert ret is None
         if friendly_name:
             ret = p12.set_friendlyname(friendly_name)
-            self.assertEqual(ret, None)
+            assert ret is None
         return p12
 
     def check_recovery(self, p12_str, key=None, cert=None, ca=None, passwd=b"",
@@ -2180,17 +2171,17 @@ class PKCS12Tests(TestCase):
             recovered_key = _runopenssl(
                 p12_str, b"pkcs12", b"-nocerts", b"-nodes", b"-passin",
                 b"pass:" + passwd, *extra)
-            self.assertEqual(recovered_key[-len(key):], key)
+            assert recovered_key[-len(key):] == key
         if cert:
             recovered_cert = _runopenssl(
                 p12_str, b"pkcs12", b"-clcerts", b"-nodes", b"-passin",
                 b"pass:" + passwd, b"-nokeys", *extra)
-            self.assertEqual(recovered_cert[-len(cert):], cert)
+            assert recovered_cert[-len(cert):] == cert
         if ca:
             recovered_cert = _runopenssl(
                 p12_str, b"pkcs12", b"-cacerts", b"-nodes", b"-passin",
                 b"pass:" + passwd, b"-nokeys", *extra)
-            self.assertEqual(recovered_cert[-len(ca):], ca)
+            assert recovered_cert[-len(ca):] == ca
 
     def verify_pkcs12_container(self, p12):
         """
@@ -2202,9 +2193,8 @@ class PKCS12Tests(TestCase):
         """
         cert_pem = dump_certificate(FILETYPE_PEM, p12.get_certificate())
         key_pem = dump_privatekey(FILETYPE_PEM, p12.get_privatekey())
-        self.assertEqual(
-            (client_cert_pem, client_key_pem, None),
-            (cert_pem, key_pem, p12.get_ca_certificates()))
+        assert (client_cert_pem, client_key_pem, None) == \
+            (cert_pem, key_pem, p12.get_ca_certificates())
 
     def test_load_pkcs12(self):
         """
@@ -2238,12 +2228,9 @@ class PKCS12Tests(TestCase):
             simplefilter("always")
             p12 = load_pkcs12(p12_str, passphrase=b"whatever".decode("ascii"))
 
-            self.assertEqual(
+            assert str(w[-1].message) == (
                 "{0} for passphrase is no longer accepted, use bytes".format(
-                    WARNING_TYPE_EXPECTED
-                ),
-                str(w[-1].message)
-            )
+                    WARNING_TYPE_EXPECTED))
             assert w[-1].category is DeprecationWarning
 
         self.verify_pkcs12_container(p12)
@@ -2311,8 +2298,8 @@ class PKCS12Tests(TestCase):
         """
         passwd = 'whatever'
         e = self.assertRaises(Error, load_pkcs12, b'fruit loops', passwd)
-        self.assertEqual(e.args[0][0][0], 'asn1 encoding routines')
-        self.assertEqual(len(e.args[0][0]), 3)
+        assert e.args[0][0][0] == 'asn1 encoding routines'
+        assert len(e.args[0][0]) == 3
 
     def test_replace(self):
         """
@@ -2326,12 +2313,12 @@ class PKCS12Tests(TestCase):
         root_cert = load_certificate(FILETYPE_PEM, root_cert_pem)
         client_cert = load_certificate(FILETYPE_PEM, client_cert_pem)
         p12.set_ca_certificates([root_cert])  # not a tuple
-        self.assertEqual(1, len(p12.get_ca_certificates()))
-        self.assertEqual(root_cert, p12.get_ca_certificates()[0])
+        assert 1 == len(p12.get_ca_certificates())
+        assert root_cert == p12.get_ca_certificates()[0]
         p12.set_ca_certificates([client_cert, root_cert])
-        self.assertEqual(2, len(p12.get_ca_certificates()))
-        self.assertEqual(client_cert, p12.get_ca_certificates()[0])
-        self.assertEqual(root_cert, p12.get_ca_certificates()[1])
+        assert 2 == len(p12.get_ca_certificates())
+        assert client_cert == p12.get_ca_certificates()[0]
+        assert root_cert == p12.get_ca_certificates()[1]
 
     def test_friendly_name(self):
         """
@@ -2344,11 +2331,10 @@ class PKCS12Tests(TestCase):
         p12 = self.gen_pkcs12(server_cert_pem, server_key_pem, root_cert_pem)
         for friendly_name in [b'Serverlicious', None, b'###']:
             p12.set_friendlyname(friendly_name)
-            self.assertEqual(p12.get_friendlyname(), friendly_name)
+            assert p12.get_friendlyname() == friendly_name
             dumped_p12 = p12.export(passphrase=passwd, iter=2, maciter=3)
             reloaded_p12 = load_pkcs12(dumped_p12, passwd)
-            self.assertEqual(
-                p12.get_friendlyname(), reloaded_p12.get_friendlyname())
+            assert p12.get_friendlyname() == reloaded_p12.get_friendlyname()
             # We would use the openssl program to confirm the friendly
             # name, but it is not possible.  The pkcs12 command
             # does not store the friendly name in the cert's
@@ -2379,7 +2365,7 @@ class PKCS12Tests(TestCase):
         """
         p12 = self.gen_pkcs12(server_cert_pem, server_key_pem, root_cert_pem)
         p12.set_ca_certificates(None)
-        self.assertEqual(None, p12.get_ca_certificates())
+        assert p12.get_ca_certificates() is None
 
     def test_export_without_mac(self):
         """
@@ -2420,7 +2406,7 @@ class PKCS12Tests(TestCase):
         passwd = b'Hobie 18'
         p12 = self.gen_pkcs12(server_cert_pem, server_key_pem)
         p12.set_ca_certificates([])
-        self.assertEqual((), p12.get_ca_certificates())
+        assert () == p12.get_ca_certificates()
         dumped_p12 = p12.export(passphrase=passwd, iter=3)
         self.check_recovery(
             dumped_p12, key=server_key_pem, cert=server_cert_pem,
@@ -2444,12 +2430,9 @@ class PKCS12Tests(TestCase):
         with catch_warnings(record=True) as w:
             simplefilter("always")
             dumped_p12 = p12.export(passphrase=b"randomtext".decode("ascii"))
-            self.assertEqual(
+            assert str(w[-1].message) == (
                 "{0} for passphrase is no longer accepted, use bytes".format(
-                    WARNING_TYPE_EXPECTED
-                ),
-                str(w[-1].message)
-            )
+                    WARNING_TYPE_EXPECTED))
             assert w[-1].category is DeprecationWarning
         self.check_recovery(
             dumped_p12,
@@ -2667,7 +2650,7 @@ class FunctionTests(TestCase):
             return encryptedPrivateKeyPEMPassphrase
         key = load_privatekey(FILETYPE_PEM, encryptedPrivateKeyPEM, cb)
         assert isinstance(key, PKeyType)
-        self.assertEqual(called, [False])
+        assert called == [False]
 
     def test_load_privatekey_passphrase_wrong_return_type(self):
         """
@@ -2743,8 +2726,8 @@ class FunctionTests(TestCase):
         assert isinstance(pem, binary_type)
         loadedKey = load_privatekey(FILETYPE_PEM, pem, passphrase)
         assert isinstance(loadedKey, PKeyType)
-        self.assertEqual(loadedKey.type(), key.type())
-        self.assertEqual(loadedKey.bits(), key.bits())
+        assert loadedKey.type() == key.type()
+        assert loadedKey.bits() == key.bits()
 
     def test_dump_privatekey_passphraseWrongType(self):
         """
@@ -2763,17 +2746,17 @@ class FunctionTests(TestCase):
         pemData = cleartextCertificatePEM + cleartextPrivateKeyPEM
         cert = load_certificate(FILETYPE_PEM, pemData)
         dumped_pem = dump_certificate(FILETYPE_PEM, cert)
-        self.assertEqual(dumped_pem, cleartextCertificatePEM)
+        assert dumped_pem == cleartextCertificatePEM
         dumped_der = dump_certificate(FILETYPE_ASN1, cert)
         good_der = _runopenssl(dumped_pem, b"x509", b"-outform", b"DER")
-        self.assertEqual(dumped_der, good_der)
+        assert dumped_der == good_der
         cert2 = load_certificate(FILETYPE_ASN1, dumped_der)
         dumped_pem2 = dump_certificate(FILETYPE_PEM, cert2)
-        self.assertEqual(dumped_pem2, cleartextCertificatePEM)
+        assert dumped_pem2 == cleartextCertificatePEM
         dumped_text = dump_certificate(FILETYPE_TEXT, cert)
         good_text = _runopenssl(
             dumped_pem, b"x509", b"-noout", b"-text", b"-nameopt", b"")
-        self.assertEqual(dumped_text, good_text)
+        assert dumped_text == good_text
 
     def test_dump_certificate_bad_type(self):
         """
@@ -2791,7 +2774,7 @@ class FunctionTests(TestCase):
         key = load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM)
         assert key.check()
         dumped_pem = dump_privatekey(FILETYPE_PEM, key)
-        self.assertEqual(dumped_pem, cleartextPrivateKeyPEM)
+        assert dumped_pem == cleartextPrivateKeyPEM
 
     def test_dump_privatekey_asn1(self):
         """
@@ -2803,10 +2786,10 @@ class FunctionTests(TestCase):
         dumped_der = dump_privatekey(FILETYPE_ASN1, key)
         # XXX This OpenSSL call writes "writing RSA key" to standard out.  Sad.
         good_der = _runopenssl(dumped_pem, b"rsa", b"-outform", b"DER")
-        self.assertEqual(dumped_der, good_der)
+        assert dumped_der == good_der
         key2 = load_privatekey(FILETYPE_ASN1, dumped_der)
         dumped_pem2 = dump_privatekey(FILETYPE_PEM, key2)
-        self.assertEqual(dumped_pem2, cleartextPrivateKeyPEM)
+        assert dumped_pem2 == cleartextPrivateKeyPEM
 
     def test_dump_privatekey_text(self):
         """
@@ -2817,7 +2800,7 @@ class FunctionTests(TestCase):
 
         dumped_text = dump_privatekey(FILETYPE_TEXT, key)
         good_text = _runopenssl(dumped_pem, b"rsa", b"-noout", b"-text")
-        self.assertEqual(dumped_text, good_text)
+        assert dumped_text == good_text
 
     def test_dump_publickey_pem(self):
         """
@@ -2853,17 +2836,17 @@ class FunctionTests(TestCase):
         req = load_certificate_request(
             FILETYPE_PEM, cleartextCertificateRequestPEM)
         dumped_pem = dump_certificate_request(FILETYPE_PEM, req)
-        self.assertEqual(dumped_pem, cleartextCertificateRequestPEM)
+        assert dumped_pem == cleartextCertificateRequestPEM
         dumped_der = dump_certificate_request(FILETYPE_ASN1, req)
         good_der = _runopenssl(dumped_pem, b"req", b"-outform", b"DER")
-        self.assertEqual(dumped_der, good_der)
+        assert dumped_der == good_der
         req2 = load_certificate_request(FILETYPE_ASN1, dumped_der)
         dumped_pem2 = dump_certificate_request(FILETYPE_PEM, req2)
-        self.assertEqual(dumped_pem2, cleartextCertificateRequestPEM)
+        assert dumped_pem2 == cleartextCertificateRequestPEM
         dumped_text = dump_certificate_request(FILETYPE_TEXT, req)
         good_text = _runopenssl(
             dumped_pem, b"req", b"-noout", b"-text", b"-nameopt", b"")
-        self.assertEqual(dumped_text, good_text)
+        assert dumped_text == good_text
         self.assertRaises(ValueError, dump_certificate_request, 100, req)
 
     def test_dump_privatekey_passphraseCallback(self):
@@ -2880,11 +2863,11 @@ class FunctionTests(TestCase):
         key = load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM)
         pem = dump_privatekey(FILETYPE_PEM, key, GOOD_CIPHER, cb)
         assert isinstance(pem, binary_type)
-        self.assertEqual(called, [True])
+        assert called == [True]
         loadedKey = load_privatekey(FILETYPE_PEM, pem, passphrase)
         assert isinstance(loadedKey, PKeyType)
-        self.assertEqual(loadedKey.type(), key.type())
-        self.assertEqual(loadedKey.bits(), key.bits())
+        assert loadedKey.type() == key.type()
+        assert loadedKey.bits() == key.bits()
 
     def test_dump_privatekey_passphrase_exception(self):
         """
@@ -2978,7 +2961,7 @@ class PKCS7Tests(TestCase):
         :py:obj:`PKCS7Type` is a type object.
         """
         assert isinstance(PKCS7Type, type)
-        self.assertEqual(PKCS7Type.__name__, 'PKCS7')
+        assert PKCS7Type.__name__ == 'PKCS7'
 
         # XXX This doesn't currently work.
         # assert PKCS7 is PKCS7Type
@@ -3205,9 +3188,9 @@ class RevokedTests(TestCase):
 
         now = datetime.now().strftime("%Y%m%d%H%M%SZ").encode("ascii")
         ret = revoked.set_rev_date(now)
-        self.assertEqual(ret, None)
+        assert ret is None
         date = revoked.get_rev_date()
-        self.assertEqual(date, now)
+        assert date == now
 
     def test_reason(self):
         """
@@ -3226,7 +3209,7 @@ class RevokedTests(TestCase):
                 r = reason  # again with the resp of get
 
         revoked.set_reason(None)
-        self.assertEqual(revoked.get_reason(), None)
+        assert revoked.get_reason() is None
 
     def test_set_reason_wrong_arguments(self):
         """
@@ -3272,7 +3255,7 @@ class CRLTests(TestCase):
         """
         crl = CRL()
         assert isinstance(crl, CRL)
-        self.assertEqual(crl.get_revoked(), None)
+        assert crl.get_revoked() is None
 
     def test_construction_wrong_args(self):
         """
@@ -3349,7 +3332,7 @@ class CRLTests(TestCase):
 
         # text format
         dumped_text = crl.export(self.cert, self.pkey, type=FILETYPE_TEXT)
-        self.assertEqual(text, dumped_text)
+        assert text == dumped_text
 
     def test_export_custom_digest(self):
         """
@@ -3369,7 +3352,7 @@ class CRLTests(TestCase):
         crl = self._get_crl()
         with catch_warnings(record=True) as catcher:
             simplefilter("always")
-            self.assertEqual(0, len(catcher))
+            assert 0 == len(catcher)
         dumped_crl = crl.export(self.cert, self.pkey, digest=b"md5")
         text = _runopenssl(dumped_crl, b"crl", b"-noout", b"-text")
         text.index(b'Signature Algorithm: md5')
@@ -3383,10 +3366,9 @@ class CRLTests(TestCase):
         with catch_warnings(record=True) as catcher:
             simplefilter("always")
             dumped_crl = crl.export(self.cert, self.pkey)
-            self.assertEqual(
+            assert str(catcher[0].message) == (
                 "The default message digest (md5) is deprecated.  "
-                "Pass the name of a message digest explicitly.",
-                str(catcher[0].message),
+                "Pass the name of a message digest explicitly."
             )
         text = _runopenssl(dumped_crl, b"crl", b"-noout", b"-text")
         text.index(b'Signature Algorithm: md5')
@@ -3471,13 +3453,13 @@ class CRLTests(TestCase):
         crl.add_revoked(revoked)
 
         revs = crl.get_revoked()
-        self.assertEqual(len(revs), 2)
-        self.assertEqual(type(revs[0]), Revoked)
-        self.assertEqual(type(revs[1]), Revoked)
-        self.assertEqual(revs[0].get_serial(), b'03AB')
-        self.assertEqual(revs[1].get_serial(), b'0100')
-        self.assertEqual(revs[0].get_rev_date(), now)
-        self.assertEqual(revs[1].get_rev_date(), now)
+        assert len(revs) == 2
+        assert type(revs[0]) == Revoked
+        assert type(revs[1]) == Revoked
+        assert revs[0].get_serial() == b'03AB'
+        assert revs[1].get_serial() == b'0100'
+        assert revs[0].get_rev_date() == now
+        assert revs[1].get_rev_date() == now
 
     def test_get_revoked_wrong_args(self):
         """
@@ -3507,20 +3489,20 @@ class CRLTests(TestCase):
         """
         crl = load_crl(FILETYPE_PEM, crlData)
         revs = crl.get_revoked()
-        self.assertEqual(len(revs), 2)
-        self.assertEqual(revs[0].get_serial(), b'03AB')
-        self.assertEqual(revs[0].get_reason(), None)
-        self.assertEqual(revs[1].get_serial(), b'0100')
-        self.assertEqual(revs[1].get_reason(), b'Superseded')
+        assert len(revs) == 2
+        assert revs[0].get_serial() == b'03AB'
+        assert revs[0].get_reason() is None
+        assert revs[1].get_serial() == b'0100'
+        assert revs[1].get_reason() == b'Superseded'
 
         der = _runopenssl(crlData, b"crl", b"-outform", b"DER")
         crl = load_crl(FILETYPE_ASN1, der)
         revs = crl.get_revoked()
-        self.assertEqual(len(revs), 2)
-        self.assertEqual(revs[0].get_serial(), b'03AB')
-        self.assertEqual(revs[0].get_reason(), None)
-        self.assertEqual(revs[1].get_serial(), b'0100')
-        self.assertEqual(revs[1].get_reason(), b'Superseded')
+        assert len(revs) == 2
+        assert revs[0].get_serial() == b'03AB'
+        assert revs[0].get_reason() is None
+        assert revs[1].get_serial() == b'0100'
+        assert revs[1].get_reason() == b'Superseded'
 
     def test_load_crl_wrong_args(self):
         """
@@ -3552,7 +3534,7 @@ class CRLTests(TestCase):
         """
         crl = load_crl(FILETYPE_PEM, crlData)
         assert isinstance(crl.get_issuer(), X509Name)
-        self.assertEqual(crl.get_issuer().CN, 'Testing Root CA')
+        assert crl.get_issuer().CN == 'Testing Root CA'
 
     def test_dump_crl(self):
         """
@@ -3605,7 +3587,7 @@ class CRLTests(TestCase):
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         e = self.assertRaises(
             X509StoreContextError, store_ctx.verify_certificate)
-        self.assertEqual(e.args[0][2], 'certificate revoked')
+        assert e.args[0][2] == 'certificate revoked'
 
     def test_verify_with_missing_crl(self):
         """
@@ -3623,9 +3605,8 @@ class CRLTests(TestCase):
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         e = self.assertRaises(
             X509StoreContextError, store_ctx.verify_certificate)
-        self.assertEqual(e.args[0][2], 'unable to get certificate CRL')
-        self.assertEqual(
-            e.certificate.get_subject().CN, 'intermediate-service')
+        assert e.args[0][2] == 'unable to get certificate CRL'
+        assert e.certificate.get_subject().CN == 'intermediate-service'
 
 
 class X509StoreContextTests(TestCase):
@@ -3646,7 +3627,7 @@ class X509StoreContextTests(TestCase):
         store.add_cert(self.root_cert)
         store.add_cert(self.intermediate_cert)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
-        self.assertEqual(store_ctx.verify_certificate(), None)
+        assert store_ctx.verify_certificate() is None
 
     def test_reuse(self):
         """
@@ -3657,8 +3638,8 @@ class X509StoreContextTests(TestCase):
         store.add_cert(self.root_cert)
         store.add_cert(self.intermediate_cert)
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
-        self.assertEqual(store_ctx.verify_certificate(), None)
-        self.assertEqual(store_ctx.verify_certificate(), None)
+        assert store_ctx.verify_certificate() is None
+        assert store_ctx.verify_certificate() is None
 
     def test_trusted_self_signed(self):
         """
@@ -3668,7 +3649,7 @@ class X509StoreContextTests(TestCase):
         store = X509Store()
         store.add_cert(self.root_cert)
         store_ctx = X509StoreContext(store, self.root_cert)
-        self.assertEqual(store_ctx.verify_certificate(), None)
+        assert store_ctx.verify_certificate() is None
 
     def test_untrusted_self_signed(self):
         """
@@ -3732,7 +3713,7 @@ class X509StoreContextTests(TestCase):
         assert exc.value.certificate.get_subject().CN == 'intermediate'
 
         store_ctx.set_store(store_good)
-        self.assertEqual(store_ctx.verify_certificate(), None)
+        assert store_ctx.verify_certificate() is None
 
 
 class SignVerifyTests(TestCase):
@@ -3804,24 +3785,18 @@ class SignVerifyTests(TestCase):
                 simplefilter("always")
                 sig = sign(priv_key, content, digest)
 
-                self.assertEqual(
+                assert str(w[-1].message) == (
                     "{0} for data is no longer accepted, use bytes".format(
-                        WARNING_TYPE_EXPECTED
-                    ),
-                    str(w[-1].message)
-                )
+                        WARNING_TYPE_EXPECTED))
                 assert w[-1].category is DeprecationWarning
 
             with catch_warnings(record=True) as w:
                 simplefilter("always")
                 verify(cert, sig, content, digest)
 
-                self.assertEqual(
+                assert str(w[-1].message) == (
                     "{0} for data is no longer accepted, use bytes".format(
-                        WARNING_TYPE_EXPECTED
-                    ),
-                    str(w[-1].message)
-                )
+                        WARNING_TYPE_EXPECTED))
                 assert w[-1].category is DeprecationWarning
 
     def test_sign_nulls(self):
@@ -3884,7 +3859,7 @@ class EllipticCurveTests(TestCase):
         curves = get_elliptic_curves()
         if curves:
             curve = next(iter(curves))
-            self.assertEqual(curve.name, get_elliptic_curve(curve.name).name)
+            assert curve.name == get_elliptic_curve(curve.name).name
         else:
             self.assertRaises(ValueError, get_elliptic_curve, u"prime256v1")
 
@@ -3904,7 +3879,7 @@ class EllipticCurveTests(TestCase):
         curves = get_elliptic_curves()
         if curves:
             curve = next(iter(curves))
-            self.assertEqual("<Curve %r>" % (curve.name,), repr(curve))
+            assert repr(curve) == ("<Curve %r>" % curve.name)
 
     def test_to_EC_KEY(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -567,9 +567,8 @@ class X509ExtTests(TestCase):
         """
         # This isn't necessarily the best string representation.  Perhaps it
         # will be changed/improved in the future.
-        self.assertEquals(
-            str(X509Extension(b'basicConstraints', True, b'CA:false')),
-            'CA:FALSE')
+        assert str(X509Extension(b'basicConstraints', True, b'CA:false')) == \
+            'CA:FALSE'
 
     def test_type(self):
         """
@@ -1528,7 +1527,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         """
         cert = X509()
         cert.set_version(1234)
-        self.assertEquals(cert.get_version(), 1234)
+        assert cert.get_version() == 1234
 
     def test_get_serial_number_wrong_args(self):
         """
@@ -1844,10 +1843,9 @@ WpOdIpB8KksUTCzV591Nr1wd
         cert = load_certificate(FILETYPE_PEM, self.pemData)
         subj = cert.get_subject()
         assert isinstance(subj, X509Name)
-        self.assertEquals(
-            subj.get_components(),
+        assert subj.get_components() == \
             [(b'C', b'US'), (b'ST', b'IL'), (b'L', b'Chicago'),
-             (b'O', b'Testing'), (b'CN', b'Testing Root CA')])
+             (b'O', b'Testing'), (b'CN', b'Testing Root CA')]
 
     def test_set_subject_wrong_args(self):
         """
@@ -1871,9 +1869,8 @@ WpOdIpB8KksUTCzV591Nr1wd
         name.C = 'AU'
         name.O = 'Unit Tests'
         cert.set_subject(name)
-        self.assertEquals(
-            cert.get_subject().get_components(),
-            [(b'C', b'AU'), (b'O', b'Unit Tests')])
+        assert cert.get_subject().get_components() == \
+            [(b'C', b'AU'), (b'O', b'Unit Tests')]
 
     def test_get_issuer_wrong_args(self):
         """
@@ -1891,10 +1888,9 @@ WpOdIpB8KksUTCzV591Nr1wd
         subj = cert.get_issuer()
         assert isinstance(subj, X509Name)
         comp = subj.get_components()
-        self.assertEquals(
-            comp,
+        assert comp == \
             [(b'C', b'US'), (b'ST', b'IL'), (b'L', b'Chicago'),
-             (b'O', b'Testing'), (b'CN', b'Testing Root CA')])
+             (b'O', b'Testing'), (b'CN', b'Testing Root CA')]
 
     def test_set_issuer_wrong_args(self):
         """
@@ -1917,9 +1913,8 @@ WpOdIpB8KksUTCzV591Nr1wd
         name.C = 'AU'
         name.O = 'Unit Tests'
         cert.set_issuer(name)
-        self.assertEquals(
-            cert.get_issuer().get_components(),
-            [(b'C', b'AU'), (b'O', b'Unit Tests')])
+        assert cert.get_issuer().get_components() == \
+            [(b'C', b'AU'), (b'O', b'Unit Tests')]
 
     def test_get_pubkey_uninitialized(self):
         """
@@ -3068,7 +3063,7 @@ class PKCS7Tests(TestCase):
         type name.
         """
         pkcs7 = load_pkcs7_data(FILETYPE_PEM, pkcs7Data)
-        self.assertEquals(pkcs7.get_type_name(), b'pkcs7-signedData')
+        assert pkcs7.get_type_name() == b'pkcs7-signedData'
 
     def test_attribute(self):
         """
@@ -3162,10 +3157,10 @@ class RevokedTests(TestCase):
         """
         revoked = Revoked()
         assert isinstance(revoked, Revoked)
-        self.assertEquals(type(revoked), Revoked)
-        self.assertEquals(revoked.get_serial(), b'00')
-        self.assertEquals(revoked.get_rev_date(), None)
-        self.assertEquals(revoked.get_reason(), None)
+        assert type(revoked) == Revoked
+        assert revoked.get_serial() == b'00'
+        assert revoked.get_rev_date() is None
+        assert revoked.get_reason() is None
 
     def test_construction_wrong_args(self):
         """
@@ -3184,13 +3179,13 @@ class RevokedTests(TestCase):
         """
         revoked = Revoked()
         ret = revoked.set_serial(b'10b')
-        self.assertEquals(ret, None)
+        assert ret is None
         ser = revoked.get_serial()
-        self.assertEquals(ser, b'010B')
+        assert ser == b'010B'
 
         revoked.set_serial(b'31ppp')  # a type error would be nice
         ser = revoked.get_serial()
-        self.assertEquals(ser, b'31')
+        assert ser == b'31'
 
         self.assertRaises(ValueError, revoked.set_serial, b'pqrst')
         self.assertRaises(TypeError, revoked.set_serial, 100)
@@ -3206,7 +3201,7 @@ class RevokedTests(TestCase):
         """
         revoked = Revoked()
         date = revoked.get_rev_date()
-        self.assertEquals(date, None)
+        assert date is None
 
         now = datetime.now().strftime("%Y%m%d%H%M%SZ").encode("ascii")
         ret = revoked.set_rev_date(now)
@@ -3224,11 +3219,10 @@ class RevokedTests(TestCase):
         for r in revoked.all_reasons():
             for x in range(2):
                 ret = revoked.set_reason(r)
-                self.assertEquals(ret, None)
+                assert ret is None
                 reason = revoked.get_reason()
-                self.assertEquals(
-                    reason.lower().replace(b' ', b''),
-                    r.lower().replace(b' ', b''))
+                assert reason.lower().replace(b' ', b'') == \
+                    r.lower().replace(b' ', b'')
                 r = reason  # again with the resp of get
 
         revoked.set_reason(None)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3864,7 +3864,7 @@ class EllipticCurveTests(TestCase):
         """
         :py:obj:`get_elliptic_curves` returns a :py:obj:`set`.
         """
-        self.assertIsInstance(get_elliptic_curves(), set)
+        assert isinstance(get_elliptic_curves(), set)
 
     def test_some_curves(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -46,7 +46,7 @@ from OpenSSL.crypto import (
 from OpenSSL._util import native, lib
 
 from .util import (
-    EqualityTestsMixin, TestCase, WARNING_TYPE_EXPECTED
+    EqualityTestsMixin, TestCase, WARNING_TYPE_EXPECTED, is_consistent_type
 )
 
 
@@ -577,7 +577,7 @@ class X509ExtTests(TestCase):
         the same type object and can be used to create instances of that type.
         """
         assert X509Extension is X509ExtensionType
-        self.assertConsistentType(
+        assert is_consistent_type(
             X509Extension,
             'X509Extension', b'basicConstraints', True, b'CA:true')
 
@@ -830,7 +830,7 @@ class PKeyTests(TestCase):
         and can be used to create instances of that type.
         """
         assert PKey is PKeyType
-        self.assertConsistentType(PKey, 'PKey')
+        assert is_consistent_type(PKey, 'PKey')
 
     def test_construction(self):
         """
@@ -1294,7 +1294,7 @@ class X509ReqTests(TestCase, _PKeyInteractionTestsMixin):
         object and can be used to create instances of that type.
         """
         assert X509Req is X509ReqType
-        self.assertConsistentType(X509Req, 'X509Req')
+        assert is_consistent_type(X509Req, 'X509Req')
 
     def test_construction(self):
         """
@@ -1484,7 +1484,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         can be used to create instances of that type.
         """
         assert X509 is X509Type
-        self.assertConsistentType(X509, 'X509')
+        assert is_consistent_type(X509, 'X509')
 
     def test_construction(self):
         """
@@ -2016,7 +2016,7 @@ class X509StoreTests(TestCase):
         :py:obj:`X509StoreType` is a type object.
         """
         assert X509Store is X509StoreType
-        self.assertConsistentType(X509Store, 'X509Store')
+        assert is_consistent_type(X509Store, 'X509Store')
 
     def test_add_cert_wrong_args(self):
         store = X509Store()
@@ -2057,7 +2057,7 @@ class PKCS12Tests(TestCase):
         :py:obj:`PKCS12Type` is a type object.
         """
         assert PKCS12 is PKCS12Type
-        self.assertConsistentType(PKCS12, 'PKCS12')
+        assert is_consistent_type(PKCS12, 'PKCS12')
 
     def test_empty_construction(self):
         """
@@ -3096,7 +3096,7 @@ class NetscapeSPKITests(TestCase, _PKeyInteractionTestsMixin):
         type object and can be used to create instances of that type.
         """
         assert NetscapeSPKI is NetscapeSPKIType
-        self.assertConsistentType(NetscapeSPKI, 'NetscapeSPKI')
+        assert is_consistent_type(NetscapeSPKI, 'NetscapeSPKI')
 
     def test_construction(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1951,11 +1951,10 @@ WpOdIpB8KksUTCzV591Nr1wd
         subject name.
         """
         cert = load_certificate(FILETYPE_PEM, self.pemData)
-        self.assertIn(
-            cert.subject_name_hash(),
-            [3350047874,  # OpenSSL 0.9.8, MD5
-             3278919224,  # OpenSSL 1.0.0, SHA1
-             ])
+        assert cert.subject_name_hash() in [
+            3350047874,  # OpenSSL 0.9.8, MD5
+            3278919224,  # OpenSSL 1.0.0, SHA1
+        ]
 
     def test_get_signature_algorithm(self):
         """
@@ -3980,7 +3979,7 @@ class EllipticCurveHashTests(TestCase):
         """
         curve = get_elliptic_curve(self.curve_factory.curve_name)
         curves = set([curve])
-        self.assertIn(curve, curves)
+        assert curve in curves
 
     def test_does_not_contain(self):
         """
@@ -3991,4 +3990,4 @@ class EllipticCurveHashTests(TestCase):
         curves = set([
             get_elliptic_curve(self.curve_factory.another_curve_name)
         ])
-        self.assertNotIn(curve, curves)
+        assert curve not in curves

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -576,7 +576,7 @@ class X509ExtTests(TestCase):
         :py:class:`X509Extension` and :py:class:`X509ExtensionType` refer to
         the same type object and can be used to create instances of that type.
         """
-        self.assertIdentical(X509Extension, X509ExtensionType)
+        assert X509Extension is X509ExtensionType
         self.assertConsistentType(
             X509Extension,
             'X509Extension', b'basicConstraints', True, b'CA:true')
@@ -829,7 +829,7 @@ class PKeyTests(TestCase):
         :py:class:`PKey` and :py:class:`PKeyType` refer to the same type object
         and can be used to create instances of that type.
         """
-        self.assertIdentical(PKey, PKeyType)
+        assert PKey is PKeyType
         self.assertConsistentType(PKey, 'PKey')
 
     def test_construction(self):
@@ -983,7 +983,7 @@ class X509NameTests(TestCase):
         """
         The type of X509Name objects is :py:class:`X509NameType`.
         """
-        self.assertIdentical(X509Name, X509NameType)
+        assert X509Name is X509NameType
         self.assertEqual(X509NameType.__name__, 'X509Name')
         self.assertTrue(isinstance(X509NameType, type))
 
@@ -1293,7 +1293,7 @@ class X509ReqTests(TestCase, _PKeyInteractionTestsMixin):
         :py:obj:`X509Req` and :py:obj:`X509ReqType` refer to the same type
         object and can be used to create instances of that type.
         """
-        self.assertIdentical(X509Req, X509ReqType)
+        assert X509Req is X509ReqType
         self.assertConsistentType(X509Req, 'X509Req')
 
     def test_construction(self):
@@ -1483,7 +1483,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         :py:obj:`X509` and :py:obj:`X509Type` refer to the same type object and
         can be used to create instances of that type.
         """
-        self.assertIdentical(X509, X509Type)
+        assert X509 is X509Type
         self.assertConsistentType(X509, 'X509')
 
     def test_construction(self):
@@ -2016,7 +2016,7 @@ class X509StoreTests(TestCase):
         """
         :py:obj:`X509StoreType` is a type object.
         """
-        self.assertIdentical(X509Store, X509StoreType)
+        assert X509Store is X509StoreType
         self.assertConsistentType(X509Store, 'X509Store')
 
     def test_add_cert_wrong_args(self):
@@ -2057,7 +2057,7 @@ class PKCS12Tests(TestCase):
         """
         :py:obj:`PKCS12Type` is a type object.
         """
-        self.assertIdentical(PKCS12, PKCS12Type)
+        assert PKCS12 is PKCS12Type
         self.assertConsistentType(PKCS12, 'PKCS12')
 
     def test_empty_construction(self):
@@ -2249,7 +2249,7 @@ class PKCS12Tests(TestCase):
                 ),
                 str(w[-1].message)
             )
-            self.assertIs(w[-1].category, DeprecationWarning)
+            assert w[-1].category is DeprecationWarning
 
         self.verify_pkcs12_container(p12)
 
@@ -2455,7 +2455,7 @@ class PKCS12Tests(TestCase):
                 ),
                 str(w[-1].message)
             )
-            self.assertIs(w[-1].category, DeprecationWarning)
+            assert w[-1].category is DeprecationWarning
         self.check_recovery(
             dumped_p12,
             key=server_key_pem,
@@ -2986,7 +2986,7 @@ class PKCS7Tests(TestCase):
         self.assertEqual(PKCS7Type.__name__, 'PKCS7')
 
         # XXX This doesn't currently work.
-        # self.assertIdentical(PKCS7, PKCS7Type)
+        # assert PKCS7 is PKCS7Type
 
     # XXX Opposite results for all these following methods
 
@@ -3096,7 +3096,7 @@ class NetscapeSPKITests(TestCase, _PKeyInteractionTestsMixin):
         :py:obj:`NetscapeSPKI` and :py:obj:`NetscapeSPKIType` refer to the same
         type object and can be used to create instances of that type.
         """
-        self.assertIdentical(NetscapeSPKI, NetscapeSPKIType)
+        assert NetscapeSPKI is NetscapeSPKIType
         self.assertConsistentType(NetscapeSPKI, 'NetscapeSPKI')
 
     def test_construction(self):
@@ -3816,7 +3816,7 @@ class SignVerifyTests(TestCase):
                     ),
                     str(w[-1].message)
                 )
-                self.assertIs(w[-1].category, DeprecationWarning)
+                assert w[-1].category is DeprecationWarning
 
             with catch_warnings(record=True) as w:
                 simplefilter("always")
@@ -3828,7 +3828,7 @@ class SignVerifyTests(TestCase):
                     ),
                     str(w[-1].message)
                 )
-                self.assertIs(w[-1].category, DeprecationWarning)
+                assert w[-1].category is DeprecationWarning
 
     def test_sign_nulls(self):
         """

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -40,13 +40,13 @@ class RandTests(TestCase):
         of rand_bytes() for bad values.
         """
         b1 = rand.bytes(50)
-        self.assertEqual(len(b1), 50)
+        assert len(b1) == 50
         b2 = rand.bytes(num_bytes=50)  # parameter by name
         assert b1 != b2  # Hip, Hip, Horay! FIPS complaince
         b3 = rand.bytes(num_bytes=0)
-        self.assertEqual(len(b3), 0)
+        assert len(b3) == 0
         exc = self.assertRaises(ValueError, rand.bytes, -1)
-        self.assertEqual(str(exc), "num_bytes must not be negative")
+        assert str(exc) == "num_bytes must not be negative"
 
     def test_add_wrong_args(self):
         """
@@ -168,7 +168,7 @@ class RandTests(TestCase):
 
             # Verify length of written file
             size = os.stat(path)[stat.ST_SIZE]
-            self.assertEqual(1024, size)
+            assert size == 1024
 
             # Read random bytes from file
             rand.load_file(path)

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -96,7 +96,7 @@ class RandTests(TestCase):
         # It's hard to know what it is actually going to return.  Different
         # OpenSSL random engines decide differently whether they have enough
         # entropy or not.
-        self.assertTrue(rand.status() in (1, 2))
+        assert rand.status() in (1, 2)
 
     def test_egd_warning(self):
         """

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -42,7 +42,7 @@ class RandTests(TestCase):
         b1 = rand.bytes(50)
         self.assertEqual(len(b1), 50)
         b2 = rand.bytes(num_bytes=50)  # parameter by name
-        self.assertNotEqual(b1, b2)  # Hip, Hip, Horay! FIPS complaince
+        assert b1 != b2  # Hip, Hip, Horay! FIPS complaince
         b3 = rand.bytes(num_bytes=0)
         self.assertEqual(len(b3), 0)
         exc = self.assertRaises(ValueError, rand.bytes, -1)

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -131,7 +131,7 @@ class RandTests(TestCase):
         :py:obj:`OpenSSL.rand.cleanup` releases the memory used by the PRNG and
         returns :py:obj:`None`.
         """
-        self.assertIdentical(rand.cleanup(), None)
+        assert rand.cleanup() is None
 
     def test_load_file_wrong_args(self):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -332,7 +332,7 @@ class VersionTests(TestCase):
         byte and the patch, fix, minor, and major versions in the
         nibbles above that.
         """
-        self.assertTrue(isinstance(OPENSSL_VERSION_NUMBER, int))
+        assert isinstance(OPENSSL_VERSION_NUMBER, int)
 
     def test_SSLeay_version(self):
         """
@@ -344,7 +344,7 @@ class VersionTests(TestCase):
                   SSLEAY_PLATFORM, SSLEAY_DIR]:
             version = SSLeay_version(t)
             versions[version] = t
-            self.assertTrue(isinstance(version, bytes))
+            assert isinstance(version, bytes)
         self.assertEqual(len(versions), 5)
 
 
@@ -811,8 +811,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         newly set mode.
         """
         context = Context(TLSv1_METHOD)
-        self.assertTrue(
-            MODE_RELEASE_BUFFERS & context.set_mode(MODE_RELEASE_BUFFERS))
+        assert MODE_RELEASE_BUFFERS & context.set_mode(MODE_RELEASE_BUFFERS)
 
     @skip_if_py3
     def test_set_mode_long(self):
@@ -822,7 +821,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         """
         context = Context(TLSv1_METHOD)
         mode = context.set_mode(long(MODE_RELEASE_BUFFERS))
-        self.assertTrue(MODE_RELEASE_BUFFERS & mode)
+        assert MODE_RELEASE_BUFFERS & mode
 
     def test_set_timeout_wrong_args(self):
         """
@@ -941,9 +940,10 @@ class ContextTests(TestCase, _LoopbackMixin):
         context = Context(TLSv1_METHOD)
         context.set_passwd_cb(passphraseCallback)
         context.use_privatekey_file(pemFile)
-        self.assertTrue(len(calledWith), 1)
-        self.assertTrue(isinstance(calledWith[0][0], int))
-        self.assertTrue(isinstance(calledWith[0][1], int))
+        # @@AWLC: The original check here looked a bit odd, so I'm guessing
+        assert len(calledWith) == 1
+        assert isinstance(calledWith[0][0], int)
+        assert isinstance(calledWith[0][1], int)
         self.assertEqual(calledWith[0][2], None)
 
     def test_passwd_callback_exception(self):
@@ -1211,7 +1211,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         clientSSL.set_connect_state()
         clientSSL.do_handshake()
         clientSSL.send(b"GET / HTTP/1.0\r\n\r\n")
-        self.assertTrue(clientSSL.recv(1024))
+        assert clientSSL.recv(1024)
 
     def test_set_default_verify_paths_signature(self):
         """
@@ -2100,7 +2100,7 @@ class SessionTests(TestCase):
         a new instance of that type.
         """
         new_session = Session()
-        self.assertTrue(isinstance(new_session, Session))
+        assert isinstance(new_session, Session)
 
     def test_construction_wrong_args(self):
         """
@@ -2315,8 +2315,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         clientSSL.setblocking(False)
         result = clientSSL.connect_ex(port.getsockname())
         expected = (EINPROGRESS, EWOULDBLOCK)
-        self.assertTrue(
-            result in expected, "%r not in %r" % (result, expected))
+        assert result in expected, "%r not in %r" % (result, expected)
 
     def test_accept_wrong_args(self):
         """
@@ -2348,7 +2347,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
 
         serverSSL, address = portSSL.accept()
 
-        self.assertTrue(isinstance(serverSSL, Connection))
+        assert isinstance(serverSSL, Connection)
         assert serverSSL.get_context() is ctx
         self.assertEquals(address, clientSSL.getsockname())
 
@@ -2742,11 +2741,10 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         message send from client, or server. Finished messages are send during
         TLS handshake.
         """
-
         server, client = self._loopback()
 
         assert server.get_finished() is not None
-        self.assertTrue(len(server.get_finished()) > 0)
+        assert len(server.get_finished()) > 0
 
     def test_get_peer_finished(self):
         """
@@ -2757,7 +2755,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         server, client = self._loopback()
 
         assert server.get_peer_finished() is not None
-        self.assertTrue(len(server.get_peer_finished()) > 0)
+        assert len(server.get_peer_finished()) > 0
 
     def test_tls_finished_message_symmetry(self):
         """
@@ -2891,9 +2889,9 @@ class ConnectionGetCipherListTests(TestCase):
         """
         connection = Connection(Context(TLSv1_METHOD), None)
         ciphers = connection.get_cipher_list()
-        self.assertTrue(isinstance(ciphers, list))
+        assert isinstance(ciphers, list)
         for cipher in ciphers:
-            self.assertTrue(isinstance(cipher, str))
+            assert isinstance(cipher, str)
 
 
 class ConnectionSendTests(TestCase, _LoopbackMixin):
@@ -3264,7 +3262,7 @@ class ErrorTests(TestCase):
         """
         :py:obj:`Error` is an exception type.
         """
-        self.assertTrue(issubclass(Error, Exception))
+        assert issubclass(Error, Exception)
         self.assertEqual(Error.__name__, 'Error')
 
 
@@ -3535,7 +3533,7 @@ class MemoryBIOTests(TestCase, _LoopbackMixin):
         # Sanity check.  We're trying to test what happens when the entire
         # input can't be sent.  If the entire input was sent, this test is
         # meaningless.
-        self.assertTrue(sent < size)
+        assert sent < size
 
         receiver, received = self._interactInMemory(client, server)
         assert receiver is server

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -345,7 +345,7 @@ class VersionTests(TestCase):
             version = SSLeay_version(t)
             versions[version] = t
             assert isinstance(version, bytes)
-        self.assertEqual(len(versions), 5)
+        assert len(versions) == 5
 
 
 @pytest.fixture
@@ -944,7 +944,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         assert len(calledWith) == 1
         assert isinstance(calledWith[0][0], int)
         assert isinstance(calledWith[0][1], int)
-        self.assertEqual(calledWith[0][2], None)
+        assert calledWith[0][2] is None
 
     def test_passwd_callback_exception(self):
         """
@@ -1043,9 +1043,8 @@ class ContextTests(TestCase, _LoopbackMixin):
         notConnections = [
             conn for (conn, where, ret) in called
             if not isinstance(conn, Connection)]
-        self.assertEqual(
-            [], notConnections,
-            "Some info callback arguments were not Connection instaces.")
+        assert notConnections == [], \
+            "Some info callback arguments were not Connection instaces."
 
     def _load_verify_locations_test(self, *args):
         """
@@ -1082,7 +1081,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         handshake(clientSSL, serverSSL)
 
         cert = clientSSL.get_peer_certificate()
-        self.assertEqual(cert.get_subject().CN, 'Testing Root CA')
+        assert cert.get_subject().CN == 'Testing Root CA'
 
     def _load_verify_cafile(self, cafile):
         """
@@ -1306,7 +1305,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         with pytest.raises(Exception) as exc:
             self._handshake_test(serverContext, clientContext)
 
-        self.assertEqual("silly verify failure", str(exc.value))
+        assert "silly verify failure" == str(exc.value)
 
     def test_add_extra_chain_cert(self):
         """
@@ -1554,8 +1553,8 @@ class ContextTests(TestCase, _LoopbackMixin):
         context = Context(TLSv1_METHOD)
         context.set_session_cache_mode(SESS_CACHE_OFF)
         off = context.set_session_cache_mode(SESS_CACHE_BOTH)
-        self.assertEqual(SESS_CACHE_OFF, off)
-        self.assertEqual(SESS_CACHE_BOTH, context.get_session_cache_mode())
+        assert SESS_CACHE_OFF == off
+        assert SESS_CACHE_BOTH == context.get_session_cache_mode()
 
     @skip_if_py3
     def test_session_cache_mode_long(self):
@@ -1565,8 +1564,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         """
         context = Context(TLSv1_METHOD)
         context.set_session_cache_mode(long(SESS_CACHE_BOTH))
-        self.assertEqual(
-            SESS_CACHE_BOTH, context.get_session_cache_mode())
+        assert SESS_CACHE_BOTH == context.get_session_cache_mode()
 
     def test_get_cert_store(self):
         """
@@ -1657,7 +1655,7 @@ class ServerNameCallbackTests(TestCase, _LoopbackMixin):
 
         self._interactInMemory(server, client)
 
-        self.assertEqual([(server, None)], args)
+        assert args == [(server, None)]
 
     def test_servername(self):
         """
@@ -1688,7 +1686,7 @@ class ServerNameCallbackTests(TestCase, _LoopbackMixin):
 
         self._interactInMemory(server, client)
 
-        self.assertEqual([(server, b"foo1.example.com")], args)
+        assert args == [(server, b"foo1.example.com")]
 
 
 class NextProtoNegotiationTests(TestCase, _LoopbackMixin):
@@ -1734,11 +1732,11 @@ class NextProtoNegotiationTests(TestCase, _LoopbackMixin):
 
             self._interactInMemory(server, client)
 
-            self.assertEqual([(server,)], advertise_args)
-            self.assertEqual([(client, [b'http/1.1', b'spdy/2'])], select_args)
+            assert advertise_args == [(server,)]
+            assert select_args == [(client, [b'http/1.1', b'spdy/2'])]
 
-            self.assertEqual(server.get_next_proto_negotiated(), b'spdy/2')
-            self.assertEqual(client.get_next_proto_negotiated(), b'spdy/2')
+            assert server.get_next_proto_negotiated() == b'spdy/2'
+            assert client.get_next_proto_negotiated() == b'spdy/2'
 
         def test_npn_client_fail(self):
             """
@@ -1778,8 +1776,8 @@ class NextProtoNegotiationTests(TestCase, _LoopbackMixin):
             # If the client doesn't return anything, the connection will fail.
             self.assertRaises(Error, self._interactInMemory, server, client)
 
-            self.assertEqual([(server,)], advertise_args)
-            self.assertEqual([(client, [b'http/1.1', b'spdy/2'])], select_args)
+            assert advertise_args == [(server,)]
+            assert select_args == [(client, [b'http/1.1', b'spdy/2'])]
 
         def test_npn_select_error(self):
             """
@@ -1818,7 +1816,7 @@ class NextProtoNegotiationTests(TestCase, _LoopbackMixin):
             self.assertRaises(
                 TypeError, self._interactInMemory, server, client
             )
-            self.assertEqual([(server,)], advertise_args)
+            assert advertise_args == [(server,)]
 
         def test_npn_advertise_error(self):
             """
@@ -1860,7 +1858,7 @@ class NextProtoNegotiationTests(TestCase, _LoopbackMixin):
             self.assertRaises(
                 TypeError, self._interactInMemory, server, client
             )
-            self.assertEqual([], select_args)
+            assert select_args == []
 
     else:
         # No NPN.
@@ -1925,10 +1923,10 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
 
             self._interactInMemory(server, client)
 
-            self.assertEqual([(server, [b'http/1.1', b'spdy/2'])], select_args)
+            assert select_args == [(server, [b'http/1.1', b'spdy/2'])]
 
-            self.assertEqual(server.get_alpn_proto_negotiated(), b'spdy/2')
-            self.assertEqual(client.get_alpn_proto_negotiated(), b'spdy/2')
+            assert server.get_alpn_proto_negotiated() == b'spdy/2'
+            assert client.get_alpn_proto_negotiated() == b'spdy/2'
 
         def test_alpn_set_on_connection(self):
             """
@@ -1964,10 +1962,10 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
 
             self._interactInMemory(server, client)
 
-            self.assertEqual([(server, [b'http/1.1', b'spdy/2'])], select_args)
+            assert select_args == [(server, [b'http/1.1', b'spdy/2'])]
 
-            self.assertEqual(server.get_alpn_proto_negotiated(), b'spdy/2')
-            self.assertEqual(client.get_alpn_proto_negotiated(), b'spdy/2')
+            assert server.get_alpn_proto_negotiated() == b'spdy/2'
+            assert client.get_alpn_proto_negotiated() == b'spdy/2'
 
         def test_alpn_server_fail(self):
             """
@@ -2002,7 +2000,7 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             # If the client doesn't return anything, the connection will fail.
             self.assertRaises(Error, self._interactInMemory, server, client)
 
-            self.assertEqual([(server, [b'http/1.1', b'spdy/2'])], select_args)
+            assert select_args == [(server, [b'http/1.1', b'spdy/2'])]
 
         def test_alpn_no_server(self):
             """
@@ -2030,7 +2028,7 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             # Do the dance.
             self._interactInMemory(server, client)
 
-            self.assertEqual(client.get_alpn_proto_negotiated(), b'')
+            assert client.get_alpn_proto_negotiated() == b''
 
         def test_alpn_callback_exception(self):
             """
@@ -2064,7 +2062,7 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             self.assertRaises(
                 TypeError, self._interactInMemory, server, client
             )
-            self.assertEqual([(server, [b'http/1.1', b'spdy/2'])], select_args)
+            assert select_args == [(server, [b'http/1.1', b'spdy/2'])]
 
     else:
         # No ALPN.
@@ -2239,9 +2237,9 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
         server.send(b'xy')
-        self.assertEqual(client.recv(2, MSG_PEEK), b'xy')
-        self.assertEqual(client.recv(2, MSG_PEEK), b'xy')
-        self.assertEqual(client.recv(2), b'xy')
+        assert client.recv(2, MSG_PEEK) == b'xy'
+        assert client.recv(2, MSG_PEEK) == b'xy'
+        assert client.recv(2) == b'xy'
 
     def test_connect_wrong_args(self):
         """
@@ -2386,9 +2384,9 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         server.sock_shutdown(2)
         exc = self.assertRaises(SysCallError, server.shutdown)
         if platform == "win32":
-            self.assertEqual(exc.args[0], ESHUTDOWN)
+            assert exc.args[0] == ESHUTDOWN
         else:
-            self.assertEqual(exc.args[0], EPIPE)
+            assert exc.args[0] == EPIPE
 
     def test_shutdown_truncated(self):
         """
@@ -2404,7 +2402,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         server = Connection(server_ctx, None)
         client = Connection(client_ctx, None)
         self._handshakeInMemory(client, server)
-        self.assertEqual(server.shutdown(), False)
+        assert not server.shutdown()
         self.assertRaises(WantReadError, server.shutdown)
         server.bio_shutdown()
         self.assertRaises(Error, server.shutdown)
@@ -2511,13 +2509,10 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         self._interactInMemory(client, server)
 
         chain = client.get_peer_cert_chain()
-        self.assertEqual(len(chain), 3)
-        self.assertEqual(
-            "Server Certificate", chain[0].get_subject().CN)
-        self.assertEqual(
-            "Intermediate Certificate", chain[1].get_subject().CN)
-        self.assertEqual(
-            "Authority Certificate", chain[2].get_subject().CN)
+        assert len(chain) == 3
+        assert chain[0].get_subject().CN == "Server Certificate"
+        assert chain[1].get_subject().CN == "Intermediate Certificate"
+        assert chain[2].get_subject().CN == "Authority Certificate"
 
     def test_get_peer_cert_chain_none(self):
         """
@@ -2627,8 +2622,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         # Instead, exploit the fact that the master key is re-used if the
         # session is re-used.  As long as the master key for the two
         # connections is the same, the session was re-used!
-        self.assertEqual(
-            originalServer.master_key(), resumedServer.master_key())
+        assert originalServer.master_key() == resumedServer.master_key()
 
     def test_set_session_wrong_method(self):
         """
@@ -2719,7 +2713,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         ctx = Context(TLSv1_METHOD)
         connection = Connection(ctx, None)
-        self.assertEqual(connection.get_finished(), None)
+        assert connection.get_finished() is None
 
     def test_get_peer_finished_before_connect(self):
         """
@@ -2728,7 +2722,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         ctx = Context(TLSv1_METHOD)
         connection = Connection(ctx, None)
-        self.assertEqual(connection.get_peer_finished(), None)
+        assert connection.get_peer_finished() is None
 
     def test_get_finished(self):
         """
@@ -2762,8 +2756,8 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
 
-        self.assertEqual(server.get_finished(), client.get_peer_finished())
-        self.assertEqual(client.get_finished(), server.get_peer_finished())
+        assert server.get_finished() == client.get_peer_finished()
+        assert client.get_finished() == server.get_peer_finished()
 
     def test_get_cipher_name_before_connect(self):
         """
@@ -2786,7 +2780,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         assert isinstance(server_cipher_name, text_type)
         assert isinstance(client_cipher_name, text_type)
 
-        self.assertEqual(server_cipher_name, client_cipher_name)
+        assert server_cipher_name == client_cipher_name
 
     def test_get_cipher_version_before_connect(self):
         """
@@ -2809,7 +2803,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         assert isinstance(server_cipher_version, text_type)
         assert isinstance(client_cipher_version, text_type)
 
-        self.assertEqual(server_cipher_version, client_cipher_version)
+        assert server_cipher_version == client_cipher_version
 
     def test_get_cipher_bits_before_connect(self):
         """
@@ -2832,7 +2826,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         assert isinstance(server_cipher_bits, int)
         assert isinstance(client_cipher_bits, int)
 
-        self.assertEqual(server_cipher_bits, client_cipher_bits)
+        assert server_cipher_bits == client_cipher_bits
 
     def test_get_protocol_version_name(self):
         """
@@ -2846,9 +2840,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         assert isinstance(server_protocol_version_name, text_type)
         assert isinstance(client_protocol_version_name, text_type)
 
-        self.assertEqual(
-            server_protocol_version_name, client_protocol_version_name
-        )
+        assert server_protocol_version_name == client_protocol_version_name
 
     def test_get_protocol_version(self):
         """
@@ -2862,7 +2854,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         assert isinstance(server_protocol_version, int)
         assert isinstance(client_protocol_version, int)
 
-        self.assertEqual(server_protocol_version, client_protocol_version)
+        assert server_protocol_version == client_protocol_version
 
 
 class ConnectionGetCipherListTests(TestCase):
@@ -2923,12 +2915,9 @@ class ConnectionSendTests(TestCase, _LoopbackMixin):
         with catch_warnings(record=True) as w:
             simplefilter("always")
             count = server.send(b"xy".decode("ascii"))
-            self.assertEqual(
+            assert str(w[-1].message) == (
                 "{0} for buf is no longer accepted, use bytes".format(
-                    WARNING_TYPE_EXPECTED
-                ),
-                str(w[-1].message)
-            )
+                    WARNING_TYPE_EXPECTED))
             assert w[-1].category is DeprecationWarning
         assert count == 2
         assert client.recv(2) == b"xy"
@@ -2981,8 +2970,8 @@ class ConnectionRecvIntoTests(TestCase, _LoopbackMixin):
         server, client = self._loopback()
         server.send(b'xy')
 
-        self.assertEqual(client.recv_into(output_buffer), 2)
-        self.assertEqual(output_buffer, bytearray(b'xy\x00\x00\x00'))
+        assert client.recv_into(output_buffer) == 2
+        assert output_buffer == bytearray(b'xy\x00\x00\x00')
 
     def test_bytearray_no_length(self):
         """
@@ -3002,10 +2991,8 @@ class ConnectionRecvIntoTests(TestCase, _LoopbackMixin):
         server, client = self._loopback()
         server.send(b'abcdefghij')
 
-        self.assertEqual(client.recv_into(output_buffer, 5), 5)
-        self.assertEqual(
-            output_buffer, bytearray(b'abcde\x00\x00\x00\x00\x00')
-        )
+        assert client.recv_into(output_buffer, 5) == 5
+        assert output_buffer == bytearray(b'abcde\x00\x00\x00\x00\x00')
 
     def test_bytearray_respects_length(self):
         """
@@ -3027,10 +3014,10 @@ class ConnectionRecvIntoTests(TestCase, _LoopbackMixin):
         server, client = self._loopback()
         server.send(b'abcdefghij')
 
-        self.assertEqual(client.recv_into(output_buffer), 5)
-        self.assertEqual(output_buffer, bytearray(b'abcde'))
+        assert client.recv_into(output_buffer) == 5
+        assert output_buffer == bytearray(b'abcde')
         rest = client.recv(5)
-        self.assertEqual(b'fghij', rest)
+        assert b'fghij' == rest
 
     def test_bytearray_doesnt_overfill(self):
         """
@@ -3055,9 +3042,8 @@ class ConnectionRecvIntoTests(TestCase, _LoopbackMixin):
 
         for _ in range(2):
             output_buffer = bytearray(5)
-            self.assertEqual(
-                client.recv_into(output_buffer, flags=MSG_PEEK), 2)
-            self.assertEqual(output_buffer, bytearray(b'xy\x00\x00\x00'))
+            assert client.recv_into(output_buffer, flags=MSG_PEEK) == 2
+            assert output_buffer == bytearray(b'xy\x00\x00\x00')
 
     @skip_if_py26
     def test_memoryview_no_length(self):
@@ -3130,12 +3116,9 @@ class ConnectionSendallTests(TestCase, _LoopbackMixin):
         with catch_warnings(record=True) as w:
             simplefilter("always")
             server.sendall(b"x".decode("ascii"))
-            self.assertEqual(
+            assert str(w[-1].message) == (
                 "{0} for buf is no longer accepted, use bytes".format(
-                    WARNING_TYPE_EXPECTED
-                ),
-                str(w[-1].message)
-            )
+                    WARNING_TYPE_EXPECTED))
             assert w[-1].category is DeprecationWarning
         assert client.recv(1) == b"x"
 
@@ -3188,9 +3171,9 @@ class ConnectionSendallTests(TestCase, _LoopbackMixin):
         server.sock_shutdown(2)
         exc = self.assertRaises(SysCallError, server.sendall, b"hello, world")
         if platform == "win32":
-            self.assertEqual(exc.args[0], ESHUTDOWN)
+            assert exc.args[0] == ESHUTDOWN
         else:
-            self.assertEqual(exc.args[0], EPIPE)
+            assert exc.args[0] == EPIPE
 
 
 class ConnectionRenegotiateTests(TestCase, _LoopbackMixin):
@@ -3258,7 +3241,7 @@ class ErrorTests(TestCase):
         :py:obj:`Error` is an exception type.
         """
         assert issubclass(Error, Exception)
-        self.assertEqual(Error.__name__, 'Error')
+        assert Error.__name__ == 'Error'
 
 
 class ConstantsTests(TestCase):
@@ -3278,7 +3261,7 @@ class ConstantsTests(TestCase):
         The value of :py:obj:`OpenSSL.SSL.OP_NO_QUERY_MTU` is 0x1000, the value
         of :py:const:`SSL_OP_NO_QUERY_MTU` defined by :file:`openssl/ssl.h`.
         """
-        self.assertEqual(OP_NO_QUERY_MTU, 0x1000)
+        assert OP_NO_QUERY_MTU == 0x1000
 
     @pytest.mark.skipif(
         OP_COOKIE_EXCHANGE is None,
@@ -3291,7 +3274,7 @@ class ConstantsTests(TestCase):
         value of :py:const:`SSL_OP_COOKIE_EXCHANGE` defined by
         :file:`openssl/ssl.h`.
         """
-        self.assertEqual(OP_COOKIE_EXCHANGE, 0x2000)
+        assert OP_COOKIE_EXCHANGE == 0x2000
 
     @pytest.mark.skipif(
         OP_NO_TICKET is None,
@@ -3302,7 +3285,7 @@ class ConstantsTests(TestCase):
         The value of :py:obj:`OpenSSL.SSL.OP_NO_TICKET` is 0x4000, the value of
         :py:const:`SSL_OP_NO_TICKET` defined by :file:`openssl/ssl.h`.
         """
-        self.assertEqual(OP_NO_TICKET, 0x4000)
+        assert OP_NO_TICKET == 0x4000
 
     @pytest.mark.skipif(
         OP_NO_COMPRESSION is None,
@@ -3314,35 +3297,35 @@ class ConstantsTests(TestCase):
         value of :py:const:`SSL_OP_NO_COMPRESSION` defined by
         :file:`openssl/ssl.h`.
         """
-        self.assertEqual(OP_NO_COMPRESSION, 0x20000)
+        assert OP_NO_COMPRESSION == 0x20000
 
     def test_sess_cache_off(self):
         """
         The value of :py:obj:`OpenSSL.SSL.SESS_CACHE_OFF` 0x0, the value of
         :py:obj:`SSL_SESS_CACHE_OFF` defined by ``openssl/ssl.h``.
         """
-        self.assertEqual(0x0, SESS_CACHE_OFF)
+        assert 0x0 == SESS_CACHE_OFF
 
     def test_sess_cache_client(self):
         """
         The value of :py:obj:`OpenSSL.SSL.SESS_CACHE_CLIENT` 0x1, the value of
         :py:obj:`SSL_SESS_CACHE_CLIENT` defined by ``openssl/ssl.h``.
         """
-        self.assertEqual(0x1, SESS_CACHE_CLIENT)
+        assert 0x1 == SESS_CACHE_CLIENT
 
     def test_sess_cache_server(self):
         """
         The value of :py:obj:`OpenSSL.SSL.SESS_CACHE_SERVER` 0x2, the value of
         :py:obj:`SSL_SESS_CACHE_SERVER` defined by ``openssl/ssl.h``.
         """
-        self.assertEqual(0x2, SESS_CACHE_SERVER)
+        assert 0x2 == SESS_CACHE_SERVER
 
     def test_sess_cache_both(self):
         """
         The value of :py:obj:`OpenSSL.SSL.SESS_CACHE_BOTH` 0x3, the value of
         :py:obj:`SSL_SESS_CACHE_BOTH` defined by ``openssl/ssl.h``.
         """
-        self.assertEqual(0x3, SESS_CACHE_BOTH)
+        assert 0x3 == SESS_CACHE_BOTH
 
     def test_sess_cache_no_auto_clear(self):
         """
@@ -3350,7 +3333,7 @@ class ConstantsTests(TestCase):
         value of :py:obj:`SSL_SESS_CACHE_NO_AUTO_CLEAR` defined by
         ``openssl/ssl.h``.
         """
-        self.assertEqual(0x80, SESS_CACHE_NO_AUTO_CLEAR)
+        assert 0x80 == SESS_CACHE_NO_AUTO_CLEAR
 
     def test_sess_cache_no_internal_lookup(self):
         """
@@ -3358,7 +3341,7 @@ class ConstantsTests(TestCase):
         the value of :py:obj:`SSL_SESS_CACHE_NO_INTERNAL_LOOKUP` defined by
         ``openssl/ssl.h``.
         """
-        self.assertEqual(0x100, SESS_CACHE_NO_INTERNAL_LOOKUP)
+        assert 0x100 == SESS_CACHE_NO_INTERNAL_LOOKUP
 
     def test_sess_cache_no_internal_store(self):
         """
@@ -3366,7 +3349,7 @@ class ConstantsTests(TestCase):
         the value of :py:obj:`SSL_SESS_CACHE_NO_INTERNAL_STORE` defined by
         ``openssl/ssl.h``.
         """
-        self.assertEqual(0x200, SESS_CACHE_NO_INTERNAL_STORE)
+        assert 0x200 == SESS_CACHE_NO_INTERNAL_STORE
 
     def test_sess_cache_no_internal(self):
         """
@@ -3374,7 +3357,7 @@ class ConstantsTests(TestCase):
         value of :py:obj:`SSL_SESS_CACHE_NO_INTERNAL` defined by
         ``openssl/ssl.h``.
         """
-        self.assertEqual(0x300, SESS_CACHE_NO_INTERNAL)
+        assert 0x300 == SESS_CACHE_NO_INTERNAL
 
 
 class MemoryBIOTests(TestCase, _LoopbackMixin):
@@ -3486,13 +3469,13 @@ class MemoryBIOTests(TestCase, _LoopbackMixin):
         important_message = b"Help me Obi Wan Kenobi, you're my only hope."
         client_conn.send(important_message)
         msg = server_conn.recv(1024)
-        self.assertEqual(msg, important_message)
+        assert msg == important_message
 
         # Again in the other direction, just for fun.
         important_message = important_message[::-1]
         server_conn.send(important_message)
         msg = client_conn.recv(1024)
-        self.assertEqual(msg, important_message)
+        assert msg == important_message
 
     def test_socketOverridesMemory(self):
         """
@@ -3554,7 +3537,7 @@ class MemoryBIOTests(TestCase, _LoopbackMixin):
         server_conn, client_conn = self._loopback()
         client_conn.sock_shutdown(SHUT_RDWR)
         exc = self.assertRaises(SysCallError, server_conn.recv, 1024)
-        self.assertEqual(exc.args, (-1, "Unexpected EOF"))
+        assert exc.args == (-1, "Unexpected EOF")
 
     def _check_client_ca_list(self, func):
         """
@@ -3570,15 +3553,15 @@ class MemoryBIOTests(TestCase, _LoopbackMixin):
         """
         server = self._server(None)
         client = self._client(None)
-        self.assertEqual(client.get_client_ca_list(), [])
-        self.assertEqual(server.get_client_ca_list(), [])
+        assert client.get_client_ca_list() == []
+        assert server.get_client_ca_list() == []
         ctx = server.get_context()
         expected = func(ctx)
-        self.assertEqual(client.get_client_ca_list(), [])
-        self.assertEqual(server.get_client_ca_list(), expected)
+        assert client.get_client_ca_list() == []
+        assert server.get_client_ca_list() == expected
         self._interactInMemory(client, server)
-        self.assertEqual(client.get_client_ca_list(), expected)
-        self.assertEqual(server.get_client_ca_list(), expected)
+        assert client.get_client_ca_list() == expected
+        assert server.get_client_ca_list() == expected
 
     def test_set_client_ca_list_errors(self):
         """
@@ -3787,7 +3770,7 @@ class ConnectionBIOTests(TestCase):
         except WantReadError:
             pass
         data = conn.bio_read(2)
-        self.assertEqual(2, len(data))
+        assert len(data) == 2
 
     @skip_if_py3
     def test_buffer_size_long(self):
@@ -3803,7 +3786,7 @@ class ConnectionBIOTests(TestCase):
         except WantReadError:
             pass
         data = conn.bio_read(long(2))
-        self.assertEqual(2, len(data))
+        assert len(data) == 2
 
 
 class InfoConstantTests(TestCase):

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1576,7 +1576,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         """
         context = Context(TLSv1_METHOD)
         store = context.get_cert_store()
-        self.assertIsInstance(store, X509Store)
+        assert isinstance(store, X509Store)
 
 
 class ServerNameCallbackTests(TestCase, _LoopbackMixin):
@@ -2568,7 +2568,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
         session = server.get_session()
-        self.assertIsInstance(session, Session)
+        assert isinstance(session, Session)
 
     def test_client_get_session(self):
         """
@@ -2578,7 +2578,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
         session = client.get_session()
-        self.assertIsInstance(session, Session)
+        assert isinstance(session, Session)
 
     def test_set_session_wrong_args(self):
         """
@@ -2789,8 +2789,8 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         server_cipher_name, client_cipher_name = \
             server.get_cipher_name(), client.get_cipher_name()
 
-        self.assertIsInstance(server_cipher_name, text_type)
-        self.assertIsInstance(client_cipher_name, text_type)
+        assert isinstance(server_cipher_name, text_type)
+        assert isinstance(client_cipher_name, text_type)
 
         self.assertEqual(server_cipher_name, client_cipher_name)
 
@@ -2812,8 +2812,8 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         server_cipher_version, client_cipher_version = \
             server.get_cipher_version(), client.get_cipher_version()
 
-        self.assertIsInstance(server_cipher_version, text_type)
-        self.assertIsInstance(client_cipher_version, text_type)
+        assert isinstance(server_cipher_version, text_type)
+        assert isinstance(client_cipher_version, text_type)
 
         self.assertEqual(server_cipher_version, client_cipher_version)
 
@@ -2835,8 +2835,8 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         server_cipher_bits, client_cipher_bits = \
             server.get_cipher_bits(), client.get_cipher_bits()
 
-        self.assertIsInstance(server_cipher_bits, int)
-        self.assertIsInstance(client_cipher_bits, int)
+        assert isinstance(server_cipher_bits, int)
+        assert isinstance(client_cipher_bits, int)
 
         self.assertEqual(server_cipher_bits, client_cipher_bits)
 
@@ -2849,8 +2849,8 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         client_protocol_version_name = client.get_protocol_version_name()
         server_protocol_version_name = server.get_protocol_version_name()
 
-        self.assertIsInstance(server_protocol_version_name, text_type)
-        self.assertIsInstance(client_protocol_version_name, text_type)
+        assert isinstance(server_protocol_version_name, text_type)
+        assert isinstance(client_protocol_version_name, text_type)
 
         self.assertEqual(
             server_protocol_version_name, client_protocol_version_name
@@ -2865,8 +2865,8 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         client_protocol_version = client.get_protocol_version()
         server_protocol_version = server.get_protocol_version()
 
-        self.assertIsInstance(server_protocol_version, int)
-        self.assertIsInstance(client_protocol_version, int)
+        assert isinstance(server_protocol_version, int)
+        assert isinstance(client_protocol_version, int)
 
         self.assertEqual(server_protocol_version, client_protocol_version)
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2745,7 +2745,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
 
         server, client = self._loopback()
 
-        self.assertNotEqual(server.get_finished(), None)
+        assert server.get_finished() is not None
         self.assertTrue(len(server.get_finished()) > 0)
 
     def test_get_peer_finished(self):
@@ -2756,7 +2756,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
 
-        self.assertNotEqual(server.get_peer_finished(), None)
+        assert server.get_peer_finished() is not None
         self.assertTrue(len(server.get_peer_finished()) > 0)
 
     def test_tls_finished_message_symmetry(self):
@@ -3466,10 +3466,8 @@ class MemoryBIOTests(TestCase, _LoopbackMixin):
             server_conn.client_random(), client_conn.client_random())
         self.assertEquals(
             server_conn.server_random(), client_conn.server_random())
-        self.assertNotEquals(
-            server_conn.client_random(), server_conn.server_random())
-        self.assertNotEquals(
-            client_conn.client_random(), client_conn.server_random())
+        assert server_conn.client_random() != server_conn.server_random()
+        assert client_conn.client_random() != client_conn.server_random()
 
         # Here are the bytes we'll try to send.
         important_message = b'One if by land, two if by sea.'

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -528,7 +528,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         :py:obj:`Context` and :py:obj:`ContextType` refer to the same type
         object and can be used to create instances of that type.
         """
-        self.assertIdentical(Context, ContextType)
+        assert Context is ContextType
         self.assertConsistentType(Context, 'Context', TLSv1_METHOD)
 
     def test_use_privatekey(self):
@@ -716,7 +716,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         context = Context(TLSv1_METHOD)
         context.use_privatekey(key)
         context.use_certificate(cert)
-        self.assertIs(None, context.check_privatekey())
+        assert None is context.check_privatekey()
 
     def test_check_privatekey_invalid(self):
         """
@@ -764,7 +764,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         app_data = object()
         context = Context(TLSv1_METHOD)
         context.set_app_data(app_data)
-        self.assertIdentical(context.get_app_data(), app_data)
+        assert context.get_app_data() is app_data
 
     def test_set_options_wrong_args(self):
         """
@@ -1282,7 +1282,7 @@ class ContextTests(TestCase, _LoopbackMixin):
 
         self._handshakeInMemory(clientConnection, serverConnection)
 
-        self.assertIdentical(verify.connection, clientConnection)
+        assert verify.connection is clientConnection
 
     def test_set_verify_callback_exception(self):
         """
@@ -2134,7 +2134,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         :py:obj:`Connection` and :py:obj:`ConnectionType` refer to the same
         type object and can be used to create instances of that type.
         """
-        self.assertIdentical(Connection, ConnectionType)
+        assert Connection is ConnectionType
         ctx = Context(TLSv1_METHOD)
         self.assertConsistentType(Connection, 'Connection', ctx, None)
 
@@ -2145,7 +2145,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         context = Context(TLSv1_METHOD)
         connection = Connection(context, None)
-        self.assertIdentical(connection.get_context(), context)
+        assert connection.get_context() is context
 
     def test_get_context_wrong_args(self):
         """
@@ -2170,7 +2170,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         self.assertRaises(TypeError, connection.set_context, 1, 2)
         self.assertRaises(
             TypeError, connection.set_context, Context(TLSv1_METHOD), 2)
-        self.assertIdentical(ctx, connection.get_context())
+        assert ctx is connection.get_context()
 
     def test_set_context(self):
         """
@@ -2181,7 +2181,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         replacement = Context(TLSv1_METHOD)
         connection = Connection(original, None)
         connection.set_context(replacement)
-        self.assertIdentical(replacement, connection.get_context())
+        assert replacement is connection.get_context()
         # Lose our references to the contexts, just in case the Connection
         # isn't properly managing its own contributions to their reference
         # counts.
@@ -2348,7 +2348,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         serverSSL, address = portSSL.accept()
 
         self.assertTrue(isinstance(serverSSL, Connection))
-        self.assertIdentical(serverSSL.get_context(), ctx)
+        assert serverSSL.get_context() is ctx
         self.assertEquals(address, clientSSL.getsockname())
 
     def test_shutdown_wrong_args(self):
@@ -2537,7 +2537,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         client = Connection(Context(TLSv1_METHOD), None)
         client.set_connect_state()
         self._interactInMemory(client, server)
-        self.assertIdentical(None, server.get_peer_cert_chain())
+        assert None is server.get_peer_cert_chain()
 
     def test_get_session_wrong_args(self):
         """
@@ -2558,7 +2558,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         ctx = Context(TLSv1_METHOD)
         server = Connection(ctx, None)
         session = server.get_session()
-        self.assertIdentical(None, session)
+        assert None is session
 
     def test_server_get_session(self):
         """
@@ -2778,7 +2778,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         ctx = Context(TLSv1_METHOD)
         conn = Connection(ctx, None)
-        self.assertIdentical(conn.get_cipher_name(), None)
+        assert conn.get_cipher_name() is None
 
     def test_get_cipher_name(self):
         """
@@ -2801,7 +2801,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         ctx = Context(TLSv1_METHOD)
         conn = Connection(ctx, None)
-        self.assertIdentical(conn.get_cipher_version(), None)
+        assert conn.get_cipher_version() is None
 
     def test_get_cipher_version(self):
         """
@@ -2824,7 +2824,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         ctx = Context(TLSv1_METHOD)
         conn = Connection(ctx, None)
-        self.assertIdentical(conn.get_cipher_bits(), None)
+        assert conn.get_cipher_bits() is None
 
     def test_get_cipher_bits(self):
         """
@@ -2935,7 +2935,7 @@ class ConnectionSendTests(TestCase, _LoopbackMixin):
                 ),
                 str(w[-1].message)
             )
-            self.assertIs(w[-1].category, DeprecationWarning)
+            assert w[-1].category is DeprecationWarning
         self.assertEquals(count, 2)
         self.assertEquals(client.recv(2), b"xy")
 
@@ -3142,7 +3142,7 @@ class ConnectionSendallTests(TestCase, _LoopbackMixin):
                 ),
                 str(w[-1].message)
             )
-            self.assertIs(w[-1].category, DeprecationWarning)
+            assert w[-1].category is DeprecationWarning
         self.assertEquals(client.recv(1), b"x")
 
     @skip_if_py26
@@ -3448,20 +3448,19 @@ class MemoryBIOTests(TestCase, _LoopbackMixin):
         client_conn = self._client(None)
 
         # There should be no key or nonces yet.
-        self.assertIdentical(server_conn.master_key(), None)
-        self.assertIdentical(server_conn.client_random(), None)
-        self.assertIdentical(server_conn.server_random(), None)
+        assert server_conn.master_key() is None
+        assert server_conn.client_random() is None
+        assert server_conn.server_random() is None
 
         # First, the handshake needs to happen.  We'll deliver bytes back and
         # forth between the client and server until neither of them feels like
         # speaking any more.
-        self.assertIdentical(
-            self._interactInMemory(client_conn, server_conn), None)
+        assert self._interactInMemory(client_conn, server_conn) is None
 
         # Now that the handshake is done, there should be a key and nonces.
-        self.assertNotIdentical(server_conn.master_key(), None)
-        self.assertNotIdentical(server_conn.client_random(), None)
-        self.assertNotIdentical(server_conn.server_random(), None)
+        assert server_conn.master_key() is not None
+        assert server_conn.client_random() is not None
+        assert server_conn.server_random() is not None
         self.assertEquals(
             server_conn.client_random(), client_conn.client_random())
         self.assertEquals(
@@ -3540,7 +3539,7 @@ class MemoryBIOTests(TestCase, _LoopbackMixin):
         self.assertTrue(sent < size)
 
         receiver, received = self._interactInMemory(client, server)
-        self.assertIdentical(receiver, server)
+        assert receiver is server
 
         # We can rely on all of these bytes being received at once because
         # _loopback passes 2 ** 16 to recv - more than 2 ** 15.
@@ -3602,7 +3601,7 @@ class MemoryBIOTests(TestCase, _LoopbackMixin):
         ctx = Context(TLSv1_METHOD)
         self.assertRaises(TypeError, ctx.set_client_ca_list, "spam")
         self.assertRaises(TypeError, ctx.set_client_ca_list, ["spam"])
-        self.assertIdentical(ctx.set_client_ca_list([]), None)
+        assert ctx.set_client_ca_list([]) is None
 
     def test_set_empty_ca_list(self):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2370,7 +2370,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         shutdown.
         """
         server, client = self._loopback()
-        self.assertFalse(server.shutdown())
+        assert not server.shutdown()
         self.assertEquals(server.get_shutdown(), SENT_SHUTDOWN)
         self.assertRaises(ZeroReturnError, client.recv, 1024)
         self.assertEquals(client.get_shutdown(), RECEIVED_SHUTDOWN)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -849,7 +849,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         """
         context = Context(TLSv1_METHOD)
         context.set_timeout(1234)
-        self.assertEquals(context.get_timeout(), 1234)
+        assert context.get_timeout() == 1234
 
     @skip_if_py3
     def test_timeout_long(self):
@@ -859,7 +859,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         """
         context = Context(TLSv1_METHOD)
         context.set_timeout(long(1234))
-        self.assertEquals(context.get_timeout(), 1234)
+        assert context.get_timeout() == 1234
 
     def test_set_verify_depth_wrong_args(self):
         """
@@ -887,7 +887,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         """
         context = Context(TLSv1_METHOD)
         context.set_verify_depth(11)
-        self.assertEquals(context.get_verify_depth(), 11)
+        assert context.get_verify_depth() == 11
 
     @skip_if_py3
     def test_verify_depth_long(self):
@@ -897,7 +897,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         """
         context = Context(TLSv1_METHOD)
         context.set_verify_depth(long(11))
-        self.assertEquals(context.get_verify_depth(), 11)
+        assert context.get_verify_depth() == 11
 
     def _write_encrypted_pem(self, passphrase):
         """
@@ -1446,11 +1446,10 @@ class ContextTests(TestCase, _LoopbackMixin):
         previously passed to :py:obj:`Context.set_verify`.
         """
         context = Context(TLSv1_METHOD)
-        self.assertEquals(context.get_verify_mode(), 0)
+        assert context.get_verify_mode() == 0
         context.set_verify(
             VERIFY_PEER | VERIFY_CLIENT_ONCE, lambda *args: None)
-        self.assertEquals(
-            context.get_verify_mode(), VERIFY_PEER | VERIFY_CLIENT_ONCE)
+        assert context.get_verify_mode() == VERIFY_PEER | VERIFY_CLIENT_ONCE
 
     @skip_if_py3
     def test_set_verify_mode_long(self):
@@ -1459,12 +1458,11 @@ class ContextTests(TestCase, _LoopbackMixin):
         type :py:obj:`long` as well as :py:obj:`int`.
         """
         context = Context(TLSv1_METHOD)
-        self.assertEquals(context.get_verify_mode(), 0)
+        assert context.get_verify_mode() == 0
         context.set_verify(
             long(VERIFY_PEER | VERIFY_CLIENT_ONCE), lambda *args: None
         )  # pragma: nocover
-        self.assertEquals(
-            context.get_verify_mode(), VERIFY_PEER | VERIFY_CLIENT_ONCE)
+        assert context.get_verify_mode() == VERIFY_PEER | VERIFY_CLIENT_ONCE
 
     def test_load_tmp_dh_wrong_args(self):
         """
@@ -2224,7 +2222,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         immediate read.
         """
         connection = Connection(Context(TLSv1_METHOD), None)
-        self.assertEquals(connection.pending(), 0)
+        assert connection.pending() == 0
 
     def test_pending_wrong_args(self):
         """
@@ -2349,7 +2347,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
 
         assert isinstance(serverSSL, Connection)
         assert serverSSL.get_context() is ctx
-        self.assertEquals(address, clientSSL.getsockname())
+        assert address == clientSSL.getsockname()
 
     def test_shutdown_wrong_args(self):
         """
@@ -2370,17 +2368,14 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
         assert not server.shutdown()
-        self.assertEquals(server.get_shutdown(), SENT_SHUTDOWN)
+        assert server.get_shutdown() == SENT_SHUTDOWN
         self.assertRaises(ZeroReturnError, client.recv, 1024)
-        self.assertEquals(client.get_shutdown(), RECEIVED_SHUTDOWN)
+        assert client.get_shutdown() == RECEIVED_SHUTDOWN
         client.shutdown()
-        self.assertEquals(
-            client.get_shutdown(), SENT_SHUTDOWN | RECEIVED_SHUTDOWN
-        )
+        assert client.get_shutdown() == SENT_SHUTDOWN | RECEIVED_SHUTDOWN
+
         self.assertRaises(ZeroReturnError, server.recv, 1024)
-        self.assertEquals(
-            server.get_shutdown(), SENT_SHUTDOWN | RECEIVED_SHUTDOWN
-        )
+        assert server.get_shutdown() == SENT_SHUTDOWN | RECEIVED_SHUTDOWN
 
     def test_shutdown_closed(self):
         """
@@ -2421,7 +2416,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         connection = Connection(Context(TLSv1_METHOD), socket())
         connection.set_shutdown(RECEIVED_SHUTDOWN)
-        self.assertEquals(connection.get_shutdown(), RECEIVED_SHUTDOWN)
+        assert connection.get_shutdown() == RECEIVED_SHUTDOWN
 
     @skip_if_py3
     def test_set_shutdown_long(self):
@@ -2431,7 +2426,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         connection = Connection(Context(TLSv1_METHOD), socket())
         connection.set_shutdown(long(RECEIVED_SHUTDOWN))
-        self.assertEquals(connection.get_shutdown(), RECEIVED_SHUTDOWN)
+        assert connection.get_shutdown() == RECEIVED_SHUTDOWN
 
     def test_state_string(self):
         """
@@ -2916,8 +2911,8 @@ class ConnectionSendTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
         count = server.send(b'xy')
-        self.assertEquals(count, 2)
-        self.assertEquals(client.recv(2), b'xy')
+        assert count == 2
+        assert client.recv(2) == b'xy'
 
     def test_text(self):
         """
@@ -2935,8 +2930,8 @@ class ConnectionSendTests(TestCase, _LoopbackMixin):
                 str(w[-1].message)
             )
             assert w[-1].category is DeprecationWarning
-        self.assertEquals(count, 2)
-        self.assertEquals(client.recv(2), b"xy")
+        assert count == 2
+        assert client.recv(2) == b"xy"
 
     @skip_if_py26
     def test_short_memoryview(self):
@@ -2947,8 +2942,8 @@ class ConnectionSendTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
         count = server.send(memoryview(b'xy'))
-        self.assertEquals(count, 2)
-        self.assertEquals(client.recv(2), b'xy')
+        assert count == 2
+        assert client.recv(2) == b'xy'
 
     @skip_if_py3
     def test_short_buffer(self):
@@ -2959,8 +2954,8 @@ class ConnectionSendTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
         count = server.send(buffer(b'xy'))
-        self.assertEquals(count, 2)
-        self.assertEquals(client.recv(2), b'xy')
+        assert count == 2
+        assert client.recv(2) == b'xy'
 
 
 def _make_memoryview(size):
@@ -3124,7 +3119,7 @@ class ConnectionSendallTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
         server.sendall(b'x')
-        self.assertEquals(client.recv(1), b'x')
+        assert client.recv(1) == b'x'
 
     def test_text(self):
         """
@@ -3142,7 +3137,7 @@ class ConnectionSendallTests(TestCase, _LoopbackMixin):
                 str(w[-1].message)
             )
             assert w[-1].category is DeprecationWarning
-        self.assertEquals(client.recv(1), b"x")
+        assert client.recv(1) == b"x"
 
     @skip_if_py26
     def test_short_memoryview(self):
@@ -3152,7 +3147,7 @@ class ConnectionSendallTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
         server.sendall(memoryview(b'x'))
-        self.assertEquals(client.recv(1), b'x')
+        assert client.recv(1) == b'x'
 
     @skip_if_py3
     def test_short_buffers(self):
@@ -3162,7 +3157,7 @@ class ConnectionSendallTests(TestCase, _LoopbackMixin):
         """
         server, client = self._loopback()
         server.sendall(buffer(b'x'))
-        self.assertEquals(client.recv(1), b'x')
+        assert client.recv(1) == b'x'
 
     def test_long(self):
         """
@@ -3182,7 +3177,7 @@ class ConnectionSendallTests(TestCase, _LoopbackMixin):
             data = client.recv(1024)
             accum.append(data)
             received += len(data)
-        self.assertEquals(message, b''.join(accum))
+        assert message == b''.join(accum)
 
     def test_closed(self):
         """
@@ -3224,7 +3219,7 @@ class ConnectionRenegotiateTests(TestCase, _LoopbackMixin):
         any renegotiations have happened.
         """
         connection = Connection(Context(TLSv1_METHOD), None)
-        self.assertEquals(connection.total_renegotiations(), 0)
+        assert connection.total_renegotiations() == 0
 
     def test_renegotiate(self):
         """
@@ -3460,10 +3455,8 @@ class MemoryBIOTests(TestCase, _LoopbackMixin):
         assert server_conn.master_key() is not None
         assert server_conn.client_random() is not None
         assert server_conn.server_random() is not None
-        self.assertEquals(
-            server_conn.client_random(), client_conn.client_random())
-        self.assertEquals(
-            server_conn.server_random(), client_conn.server_random())
+        assert server_conn.client_random() == client_conn.client_random()
+        assert server_conn.server_random() == client_conn.server_random()
         assert server_conn.client_random() != server_conn.server_random()
         assert client_conn.client_random() != client_conn.server_random()
 
@@ -3471,14 +3464,12 @@ class MemoryBIOTests(TestCase, _LoopbackMixin):
         important_message = b'One if by land, two if by sea.'
 
         server_conn.write(important_message)
-        self.assertEquals(
-            self._interactInMemory(client_conn, server_conn),
-            (client_conn, important_message))
+        assert self._interactInMemory(client_conn, server_conn) == \
+            (client_conn, important_message)
 
         client_conn.write(important_message[::-1])
-        self.assertEquals(
-            self._interactInMemory(client_conn, server_conn),
-            (server_conn, important_message[::-1]))
+        assert self._interactInMemory(client_conn, server_conn) == \
+            (server_conn, important_message[::-1])
 
     def test_socketConnect(self):
         """
@@ -3540,7 +3531,7 @@ class MemoryBIOTests(TestCase, _LoopbackMixin):
 
         # We can rely on all of these bytes being received at once because
         # _loopback passes 2 ** 16 to recv - more than 2 ** 15.
-        self.assertEquals(len(received), sent)
+        assert len(received) == sent
 
     def test_shutdown(self):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -81,7 +81,8 @@ try:
 except ImportError:
     SSL_ST_INIT = SSL_ST_BEFORE = SSL_ST_OK = SSL_ST_RENEGOTIATE = None
 
-from .util import WARNING_TYPE_EXPECTED, NON_ASCII, TestCase
+from .util import (
+    WARNING_TYPE_EXPECTED, NON_ASCII, TestCase, is_consistent_type)
 from .test_crypto import (
     cleartextCertificatePEM, cleartextPrivateKeyPEM,
     client_cert_pem, client_key_pem, server_cert_pem, server_key_pem,
@@ -529,7 +530,7 @@ class ContextTests(TestCase, _LoopbackMixin):
         object and can be used to create instances of that type.
         """
         assert Context is ContextType
-        self.assertConsistentType(Context, 'Context', TLSv1_METHOD)
+        assert is_consistent_type(Context, 'Context', TLSv1_METHOD)
 
     def test_use_privatekey(self):
         """
@@ -2136,7 +2137,7 @@ class ConnectionTests(TestCase, _LoopbackMixin):
         """
         assert Connection is ConnectionType
         ctx = Context(TLSv1_METHOD)
-        self.assertConsistentType(Connection, 'Connection', ctx, None)
+        assert is_consistent_type(Connection, 'Connection', ctx, None)
 
     def test_get_context(self):
         """

--- a/tests/util.py
+++ b/tests/util.py
@@ -196,23 +196,6 @@ class TestCase(TestCase):
                     "Left over errors in OpenSSL error queue: " + repr(e)
                 )
 
-    def assertIsInstance(self, instance, classOrTuple, message=None):
-        """
-        Fail if C{instance} is not an instance of the given class or of
-        one of the given classes.
-
-        @param instance: the object to test the type (first argument of the
-            C{isinstance} call).
-        @type instance: any.
-        @param classOrTuple: the class or classes to test against (second
-            argument of the C{isinstance} call).
-        @type classOrTuple: class, type, or tuple.
-
-        @param message: Custom text to include in the exception text if the
-            assertion fails.
-        """
-        assert isinstance(instance, classOrTuple)
-
     def failUnlessRaises(self, exception, f, *args, **kwargs):
         """
         Fail the test unless calling the function :py:data:`f` with the given

--- a/tests/util.py
+++ b/tests/util.py
@@ -240,30 +240,6 @@ class TestCase(TestCase):
         assert containee not in container
     failIfIn = assertNotIn
 
-    def assertIs(self, first, second, msg=None):
-        """
-        Fail the test if :py:data:`first` is not :py:data:`second`.  This is an
-        obect-identity-equality test, not an object equality
-        (i.e. :py:func:`__eq__`) test.
-
-        :param msg: if msg is None, then the failure message will be
-        '%r is not %r' % (first, second)
-        """
-        assert first is second
-    assertIdentical = failUnlessIdentical = assertIs
-
-    def assertIsNot(self, first, second, msg=None):
-        """
-        Fail the test if :py:data:`first` is :py:data:`second`.  This is an
-        obect-identity-equality test, not an object equality
-        (i.e. :py:func:`__eq__`) test.
-
-        :param msg: if msg is None, then the failure message will be
-        '%r is %r' % (first, second)
-        """
-        assert first is not second
-    assertNotIdentical = failIfIdentical = assertIsNot
-
     def failUnlessRaises(self, exception, f, *args, **kwargs):
         """
         Fail the test unless calling the function :py:data:`f` with the given
@@ -308,7 +284,7 @@ class TestCase(TestCase):
         self.assertEqual(theType.__name__, name)
         self.assertTrue(isinstance(theType, type))
         instance = theType(*constructionArgs)
-        self.assertIdentical(type(instance), theType)
+        assert type(instance) is theType
 
 
 class EqualityTestsMixin(object):

--- a/tests/util.py
+++ b/tests/util.py
@@ -213,33 +213,6 @@ class TestCase(TestCase):
         """
         assert isinstance(instance, classOrTuple)
 
-    def failUnlessIn(self, containee, container, msg=None):
-        """
-        Fail the test if :py:data:`containee` is not found in
-        :py:data:`container`.
-
-        :param containee: the value that should be in :py:class:`container`
-        :param container: a sequence type, or in the case of a mapping type,
-                          will follow semantics of 'if key in dict.keys()'
-        :param msg: if msg is None, then the failure message will be
-                    '%r not in %r' % (first, second)
-        """
-        assert containee in container
-    assertIn = failUnlessIn
-
-    def assertNotIn(self, containee, container, msg=None):
-        """
-        Fail the test if C{containee} is found in C{container}.
-
-        @param containee: the value that should not be in C{container}
-        @param container: a sequence type, or in the case of a mapping type,
-                          will follow semantics of 'if key in dict.keys()'
-        @param msg: if msg is None, then the failure message will be
-                    '%r in %r' % (first, second)
-        """
-        assert containee not in container
-    failIfIn = assertNotIn
-
     def failUnlessRaises(self, exception, f, *args, **kwargs):
         """
         Fail the test unless calling the function :py:data:`f` with the given

--- a/tests/util.py
+++ b/tests/util.py
@@ -224,23 +224,24 @@ class TestCase(TestCase):
         """
         return mktemp(dir=self.tmpdir).encode("utf-8")
 
-    # Other stuff
-    def assertConsistentType(self, theType, name, *constructionArgs):
-        """
-        Perform various assertions about :py:data:`theType` to ensure that it
-        is a well-defined type.  This is useful for extension types, where it's
-        pretty easy to do something wacky.  If something about the type is
-        unusual, an exception will be raised.
 
-        :param theType: The type object about which to make assertions.
-        :param name: A string giving the name of the type.
-        :param constructionArgs: Positional arguments to use with
-            :py:data:`theType` to create an instance of it.
-        """
-        self.assertEqual(theType.__name__, name)
-        self.assertTrue(isinstance(theType, type))
-        instance = theType(*constructionArgs)
-        assert type(instance) is theType
+def is_consistent_type(theType, name, *constructionArgs):
+    """
+    Perform various assertions about :py:data:`theType` to ensure that it
+    is a well-defined type.  This is useful for extension types, where it's
+    pretty easy to do something wacky.  If something about the type is
+    unusual, an exception will be raised.
+
+    :param theType: The type object about which to make assertions.
+    :param name: A string giving the name of the type.
+    :param constructionArgs: Positional arguments to use with
+        :py:data:`theType` to create an instance of it.
+    """
+    assert theType.__name__ == name
+    assert isinstance(theType, type)
+    instance = theType(*constructionArgs)
+    assert type(instance) is theType
+    return True
 
 
 class EqualityTestsMixin(object):

--- a/tests/util.py
+++ b/tests/util.py
@@ -270,14 +270,14 @@ class EqualityTestsMixin(object):
         An object compares equal to itself using the C{==} operator.
         """
         o = self.anInstance()
-        self.assertTrue(o == o)
+        assert o == o
 
     def test_identicalNe(self):
         """
         An object doesn't compare not equal to itself using the C{!=} operator.
         """
         o = self.anInstance()
-        self.assertFalse(o != o)
+        assert not (o != o)
 
     def test_sameEq(self):
         """
@@ -286,7 +286,7 @@ class EqualityTestsMixin(object):
         """
         a = self.anInstance()
         b = self.anInstance()
-        self.assertTrue(a == b)
+        assert a == b
 
     def test_sameNe(self):
         """
@@ -295,7 +295,7 @@ class EqualityTestsMixin(object):
         """
         a = self.anInstance()
         b = self.anInstance()
-        self.assertFalse(a != b)
+        assert not (a != b)
 
     def test_differentEq(self):
         """
@@ -304,7 +304,7 @@ class EqualityTestsMixin(object):
         """
         a = self.anInstance()
         b = self.anotherInstance()
-        self.assertFalse(a == b)
+        assert not (a == b)
 
     def test_differentNe(self):
         """
@@ -313,7 +313,7 @@ class EqualityTestsMixin(object):
         """
         a = self.anInstance()
         b = self.anotherInstance()
-        self.assertTrue(a != b)
+        assert a != b
 
     def test_anotherTypeEq(self):
         """
@@ -322,7 +322,7 @@ class EqualityTestsMixin(object):
         """
         a = self.anInstance()
         b = object()
-        self.assertFalse(a == b)
+        assert not (a == b)
 
     def test_anotherTypeNe(self):
         """
@@ -331,7 +331,7 @@ class EqualityTestsMixin(object):
         """
         a = self.anInstance()
         b = object()
-        self.assertTrue(a != b)
+        assert a != b
 
     def test_delegatedEq(self):
         """
@@ -345,7 +345,7 @@ class EqualityTestsMixin(object):
 
         a = self.anInstance()
         b = Delegate()
-        self.assertEqual(a == b, [b])
+        assert (a == b) == [b]
 
     def test_delegateNe(self):
         """
@@ -359,7 +359,7 @@ class EqualityTestsMixin(object):
 
         a = self.anInstance()
         b = Delegate()
-        self.assertEqual(a != b, [b])
+        assert (a != b) == [b]
 
 
 # The type name expected in warnings about using the wrong string type.


### PR DESCRIPTION
This mega-patch converts all the tests (as best I can) to be pytest-style, not unittest style.

The magic of regexes, eh? 😄 

Nowhere near ready for review and/or merging, I just want to start getting CI running against it. I suspect it probably needs breaking up into smaller, individual patches, before being actually reviewed.

Addresses #340.