### PR TITLE
Convert test_util to use pytest-style tests

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,9 +1,9 @@
 from OpenSSL._util import exception_from_error_queue, lib
 
-from .util import TestCase
+import pytest
 
 
-class ErrorTests(TestCase):
+class TestErrors(object):
     """
     Tests for handling of certain OpenSSL error cases.
     """
@@ -13,7 +13,6 @@ class ErrorTests(TestCase):
         encounters an OpenSSL error code which does not have a reason string.
         """
         lib.ERR_put_error(lib.ERR_LIB_EVP, 0, 1112, b"", 10)
-        exc = self.assertRaises(
-            ValueError, exception_from_error_queue, ValueError
-        )
-        self.assertEqual(exc.args[0][0][2], "")
+        with pytest.raises(ValueError) as exc:
+            exception_from_error_queue(ValueError)
+        assert exc.value.args[0][0][2] == ""


### PR DESCRIPTION
Fix up the assert helpers, subclass from `object` rather than
`TestCase`, and then I had to rename the class -- pytest doesn't
pick it up with the original name.

Addresses #340.

---

Part of breaking up #561.