### PR TITLE
Convert test_rand to use pytest-style tests

### DIFF
--- a/src/OpenSSL/rand.py
+++ b/src/OpenSSL/rand.py
@@ -107,7 +107,7 @@ def status():
     """
     Check whether the PRNG has been seeded with enough data.
 
-    :return: :obj:`1` if the PRNG is seeded enough, :obj:`0` otherwise.
+    :return: 1 if the PRNG is seeded enough, 0 otherwise.
     """
     return _lib.RAND_status()
 

--- a/src/OpenSSL/rand.py
+++ b/src/OpenSSL/rand.py
@@ -107,7 +107,7 @@ def status():
     """
     Check whether the PRNG has been seeded with enough data.
 
-    :return: :obj:`True` if the PRNG is seeded enough, :obj:`False` otherwise.
+    :return: :obj:`1` if the PRNG is seeded enough, :obj:`0` otherwise.
     """
     return _lib.RAND_status()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 # Copyright (c) The pyOpenSSL developers
 # See LICENSE for details.
 
+from tempfile import mktemp
+
+import pytest
+
 
 def pytest_report_header(config):
     import OpenSSL.SSL
@@ -10,3 +14,13 @@ def pytest_report_header(config):
         openssl=OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION),
         cryptography=cryptography.__version__
     )
+
+
+@pytest.fixture
+def tmpfile(tmpdir):
+    """
+    Return UTF-8-encoded bytes of a path to a tmp file.
+
+    The file will be cleaned up after the test run.
+    """
+    return mktemp(dir=tmpdir.dirname).encode("utf-8")

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -106,13 +106,13 @@ class TestRand(object):
 
     def test_status(self):
         """
-        `OpenSSL.rand.status` returns `True` if the PRNG has
-        sufficient entropy, `False` otherwise.
+        `OpenSSL.rand.status` returns `1` if the PRNG has
+        sufficient entropy, `0` otherwise.
         """
         # It's hard to know what it is actually going to return.  Different
         # OpenSSL random engines decide differently whether they have enough
         # entropy or not.
-        assert rand.status() in (True, False)
+        assert rand.status() in (0, 1)
 
     @pytest.mark.parametrize('args', [
         (b"foo", 255),

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -19,14 +19,13 @@ from .util import NON_ASCII
 class TestRand(object):
 
     @pytest.mark.parametrize('args', [
-        (),
         (None),
-        (3, None)
+        (b"foo"),
     ])
     def test_bytes_wrong_args(self, args):
         """
         `OpenSSL.rand.bytes` raises `TypeError` if called with
-        the wrong number of arguments or with a non-`int` argument.
+        a non-`int` argument.
         """
         with pytest.raises(TypeError):
             rand.bytes(*args)
@@ -56,16 +55,13 @@ class TestRand(object):
         assert str(exc.value) == "num_bytes must not be negative"
 
     @pytest.mark.parametrize('args', [
-        (),
         (b"foo", None),
         (None, 3),
-        (b"foo", 3, None),
     ])
     def test_add_wrong_args(self, args):
         """
-        When called with the wrong number of arguments, or with arguments not
-        of type `str` and `int`, `OpenSSL.rand.add`
-        raises `TypeError`.
+        `OpenSSL.rand.add` raises `TypeError` if called with arguments
+        not of type `str` and `int`.
         """
         with pytest.raises(TypeError):
             rand.add(*args)
@@ -77,15 +73,13 @@ class TestRand(object):
         rand.add(b'hamburger', 3)
 
     @pytest.mark.parametrize('args', [
-        (),
         (None),
-        (b"foo", None),
+        (42),
     ])
     def test_seed_wrong_args(self, args):
         """
-        When called with the wrong number of arguments, or with
-        a non-`str` argument, `OpenSSL.rand.seed` raises
-        `TypeError`.
+        `OpenSSL.rand.seed` raises `TypeError` if called with
+        a non-`str` argument.
         """
         with pytest.raises(TypeError):
             rand.seed(*args)
@@ -95,14 +89,6 @@ class TestRand(object):
         `OpenSSL.rand.seed` adds entropy to the PRNG.
         """
         rand.seed(b'milk shake')
-
-    def test_status_wrong_args(self):
-        """
-        `OpenSSL.rand.status` raises `TypeError` when called
-        with any arguments.
-        """
-        with pytest.raises(TypeError):
-            rand.status(None)
 
     def test_status(self):
         """
@@ -124,30 +110,6 @@ class TestRand(object):
         """
         pytest.deprecated_call(rand.egd, *args)
 
-    @pytest.mark.parametrize('args', [
-        (),
-        (None,),
-        ("foo", None),
-        (None, 3),
-        ("foo", 3, None),
-    ])
-    def test_egd_wrong_args(self, args):
-        """
-        :meth:`OpenSSL.rand.egd` raises :exc:`TypeError` when called with the
-        wrong number of arguments or with arguments not of type :obj:`str` and
-        :obj:`int`.
-        """
-        with pytest.raises(TypeError):
-            rand.egd(*args)
-
-    def test_cleanup_wrong_args(self):
-        """
-        `OpenSSL.rand.cleanup` raises `TypeError` when called
-        with any arguments.
-        """
-        with pytest.raises(TypeError):
-            rand.cleanup(None)
-
     def test_cleanup(self):
         """
         `OpenSSL.rand.cleanup` releases the memory used by the PRNG and
@@ -156,30 +118,25 @@ class TestRand(object):
         assert rand.cleanup() is None
 
     @pytest.mark.parametrize('args', [
-        (),
         ("foo", None),
         (None, 1),
-        ("foo", 1, None),
     ])
     def test_load_file_wrong_args(self, args):
         """
-        `OpenSSL.rand.load_file` raises `TypeError` when called
-        the wrong number of arguments or arguments not of type `str`
-        and `int`.
+        `OpenSSL.rand.load_file` raises `TypeError` when with arguments
+        not of type `str` and `int`.
         """
         with pytest.raises(TypeError):
             rand.load_file(*args)
 
     @pytest.mark.parametrize('args', [
-        (),
-        (None),
-        ("foo", None),
+        None,
+        1,
     ])
     def test_write_file_wrong_args(self, args):
         """
-        `OpenSSL.rand.write_file` raises `TypeError` when
-        called with the wrong number of arguments or a non-`str`
-        argument.
+        `OpenSSL.rand.write_file` raises `TypeError` when called with
+        a non-`str` argument.
         """
         with pytest.raises(TypeError):
             rand.write_file(*args)

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -13,7 +13,7 @@ import pytest
 
 from OpenSSL import rand
 
-from .util import NON_ASCII
+from .util import NON_ASCII, tmpfile
 
 
 class TestRand(object):

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -13,7 +13,7 @@ import pytest
 
 from OpenSSL import rand
 
-from .util import NON_ASCII, tmpfile
+from .util import NON_ASCII
 
 
 class TestRand(object):

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -2,7 +2,7 @@
 # See LICENSE for details.
 
 """
-Unit tests for :py:obj:`OpenSSL.rand`.
+Unit tests for `OpenSSL.rand`.
 """
 
 import os
@@ -25,15 +25,15 @@ class TestRand(object):
     ])
     def test_bytes_wrong_args(self, args):
         """
-        :py:obj:`OpenSSL.rand.bytes` raises :py:obj:`TypeError` if called with
-        the wrong number of arguments or with a non-:py:obj:`int` argument.
+        `OpenSSL.rand.bytes` raises `TypeError` if called with
+        the wrong number of arguments or with a non-`int` argument.
         """
         with pytest.raises(TypeError):
             rand.bytes(*args)
 
     def test_insufficient_memory(self):
         """
-        :py:obj:`OpenSSL.rand.bytes` raises :py:obj:`MemoryError` if more bytes
+        `OpenSSL.rand.bytes` raises `MemoryError` if more bytes
         are requested than will fit in memory.
         """
         with pytest.raises(MemoryError):
@@ -64,15 +64,15 @@ class TestRand(object):
     def test_add_wrong_args(self, args):
         """
         When called with the wrong number of arguments, or with arguments not
-        of type :py:obj:`str` and :py:obj:`int`, :py:obj:`OpenSSL.rand.add`
-        raises :py:obj:`TypeError`.
+        of type `str` and `int`, `OpenSSL.rand.add`
+        raises `TypeError`.
         """
         with pytest.raises(TypeError):
             rand.add(*args)
 
     def test_add(self):
         """
-        :py:obj:`OpenSSL.rand.add` adds entropy to the PRNG.
+        `OpenSSL.rand.add` adds entropy to the PRNG.
         """
         rand.add(b'hamburger', 3)
 
@@ -84,21 +84,21 @@ class TestRand(object):
     def test_seed_wrong_args(self, args):
         """
         When called with the wrong number of arguments, or with
-        a non-:py:obj:`str` argument, :py:obj:`OpenSSL.rand.seed` raises
-        :py:obj:`TypeError`.
+        a non-`str` argument, `OpenSSL.rand.seed` raises
+        `TypeError`.
         """
         with pytest.raises(TypeError):
             rand.seed(*args)
 
     def test_seed(self):
         """
-        :py:obj:`OpenSSL.rand.seed` adds entropy to the PRNG.
+        `OpenSSL.rand.seed` adds entropy to the PRNG.
         """
         rand.seed(b'milk shake')
 
     def test_status_wrong_args(self):
         """
-        :py:obj:`OpenSSL.rand.status` raises :py:obj:`TypeError` when called
+        `OpenSSL.rand.status` raises `TypeError` when called
         with any arguments.
         """
         with pytest.raises(TypeError):
@@ -106,8 +106,8 @@ class TestRand(object):
 
     def test_status(self):
         """
-        :py:obj:`OpenSSL.rand.status` returns :py:obj:`True` if the PRNG has
-        sufficient entropy, :py:obj:`False` otherwise.
+        `OpenSSL.rand.status` returns `True` if the PRNG has
+        sufficient entropy, `False` otherwise.
         """
         # It's hard to know what it is actually going to return.  Different
         # OpenSSL random engines decide differently whether they have enough
@@ -142,7 +142,7 @@ class TestRand(object):
 
     def test_cleanup_wrong_args(self):
         """
-        :py:obj:`OpenSSL.rand.cleanup` raises :py:obj:`TypeError` when called
+        `OpenSSL.rand.cleanup` raises `TypeError` when called
         with any arguments.
         """
         with pytest.raises(TypeError):
@@ -150,8 +150,8 @@ class TestRand(object):
 
     def test_cleanup(self):
         """
-        :py:obj:`OpenSSL.rand.cleanup` releases the memory used by the PRNG and
-        returns :py:obj:`None`.
+        `OpenSSL.rand.cleanup` releases the memory used by the PRNG and
+        returns `None`.
         """
         assert rand.cleanup() is None
 
@@ -163,9 +163,9 @@ class TestRand(object):
     ])
     def test_load_file_wrong_args(self, args):
         """
-        :py:obj:`OpenSSL.rand.load_file` raises :py:obj:`TypeError` when called
-        the wrong number of arguments or arguments not of type :py:obj:`str`
-        and :py:obj:`int`.
+        `OpenSSL.rand.load_file` raises `TypeError` when called
+        the wrong number of arguments or arguments not of type `str`
+        and `int`.
         """
         with pytest.raises(TypeError):
             rand.load_file(*args)
@@ -177,8 +177,8 @@ class TestRand(object):
     ])
     def test_write_file_wrong_args(self, args):
         """
-        :py:obj:`OpenSSL.rand.write_file` raises :py:obj:`TypeError` when
-        called with the wrong number of arguments or a non-:py:obj:`str`
+        `OpenSSL.rand.write_file` raises `TypeError` when
+        called with the wrong number of arguments or a non-`str`
         argument.
         """
         with pytest.raises(TypeError):

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -24,25 +24,25 @@ class TestRand(object):
     ])
     def test_bytes_wrong_args(self, args):
         """
-        `OpenSSL.rand.bytes` raises `TypeError` if called with
-        a non-`int` argument.
+        `OpenSSL.rand.bytes` raises `TypeError` if called with a non-`int`
+        argument.
         """
         with pytest.raises(TypeError):
             rand.bytes(*args)
 
     def test_insufficient_memory(self):
         """
-        `OpenSSL.rand.bytes` raises `MemoryError` if more bytes
-        are requested than will fit in memory.
+        `OpenSSL.rand.bytes` raises `MemoryError` if more bytes are requested
+        than will fit in memory.
         """
         with pytest.raises(MemoryError):
             rand.bytes(sys.maxsize)
 
     def test_bytes(self):
         """
-        Verify that we can obtain bytes from rand_bytes() and
-        that they are different each time.  Test the parameter
-        of rand_bytes() for bad values.
+        Verify that we can obtain bytes from rand_bytes() and that they are
+        different each time.  Test the parameter of rand_bytes() for
+        bad values.
         """
         b1 = rand.bytes(50)
         assert len(b1) == 50
@@ -60,8 +60,8 @@ class TestRand(object):
     ])
     def test_add_wrong_args(self, args):
         """
-        `OpenSSL.rand.add` raises `TypeError` if called with arguments
-        not of type `str` and `int`.
+        `OpenSSL.rand.add` raises `TypeError` if called with arguments not of
+        type `str` and `int`.
         """
         with pytest.raises(TypeError):
             rand.add(*args)
@@ -92,8 +92,8 @@ class TestRand(object):
 
     def test_status(self):
         """
-        `OpenSSL.rand.status` returns `1` if the PRNG has
-        sufficient entropy, `0` otherwise.
+        `OpenSSL.rand.status` returns `1` if the PRNG has sufficient entropy,
+        `0` otherwise.
         """
         # It's hard to know what it is actually going to return.  Different
         # OpenSSL random engines decide differently whether they have enough

--- a/tests/util.py
+++ b/tests/util.py
@@ -31,6 +31,16 @@ from OpenSSL._util import ffi, lib
 NON_ASCII = b"\xe2\x98\x83".decode("utf-8")
 
 
+@pytest.fixture
+def tmpfile(tmpdir):
+    """
+    Return UTF-8-encoded bytes of a path to a tmp file.
+
+    The file will be cleaned up after the test run.
+    """
+    return mktemp(dir=tmpdir.dirname).encode("utf-8")
+
+
 class TestCase(TestCase):
     """
     :py:class:`TestCase` adds useful testing functionality beyond what is

--- a/tests/util.py
+++ b/tests/util.py
@@ -31,16 +31,6 @@ from OpenSSL._util import ffi, lib
 NON_ASCII = b"\xe2\x98\x83".decode("utf-8")
 
 
-@pytest.fixture
-def tmpfile(tmpdir):
-    """
-    Return UTF-8-encoded bytes of a path to a tmp file.
-
-    The file will be cleaned up after the test run.
-    """
-    return mktemp(dir=tmpdir.dirname).encode("utf-8")
-
-
 class TestCase(TestCase):
     """
     :py:class:`TestCase` adds useful testing functionality beyond what is

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ setenv =
     PIP_NO_BINARY=cryptography
 commands =
     openssl version
-    coverage run --parallel -m pytest {posargs}
+    coverage run --parallel -m pytest -v {posargs}
 
 [testenv:py27-twistedMaster]
 deps =


### PR DESCRIPTION
Fix up the assert helpers, subclass form `object` rather than test case,
and use parametrization where appropriate.

One helper method on the original `TestCase` was the ability to create
temporary directories that were cleaned up at the end of the test --
now we use a pytest fixture instead: http://doc.pytest.org/en/latest/tmpdir.html

Addresses #340.

---

Part of breaking up #561.