### PR TITLE
Add the ability to set a custom verification time on X509Store

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Changes:
 ^^^^^^^^
 
 - Added ``OpenSSL.X509Store.set_time()`` to set a custom verification time.
-  `#XXX <https://github.com/pyca/pyopenssl/pull/XXX>`_
+  `#567 <https://github.com/pyca/pyopenssl/pull/567>`_
 
 
 ----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-- Added ``OpenSSL.X509Store.set_time()`` to set a custom verification time.
+- Added ``OpenSSL.X509Store.set_time()`` to set a custom verification time when verifying certificate chains.
   `#567 <https://github.com/pyca/pyopenssl/pull/567>`_
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Added ``OpenSSL.X509Store.set_time()`` to set a custom verification time.
+  `#XXX <https://github.com/pyca/pyopenssl/pull/XXX>`_
 
 
 ----

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             # Fix cryptographyMinimum in tox.ini when changing this!
-            "cryptography>=1.3.4",
+            "cryptography>=1.6",
             "six>=1.5.2"
         ],
     )

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1524,7 +1524,7 @@ class X509Store(object):
         .. versionadded: 16.3.0
 
         :param datetime vfy_time: The verification time to set on this store.
-        :return: ``None`` if the verification time were successfully set.
+        :return: ``None`` if the verification time was successfully set.
         """
         param = _lib.X509_VERIFY_PARAM_new()
         param = _ffi.gc(param, _lib.X509_VERIFY_PARAM_free)

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1514,12 +1514,12 @@ class X509Store(object):
 
         :param int flags: The verification flags to set on this store.
             See :class:`X509StoreFlags` for available constants.
-        :return: ``None`` if the verification flags were successfully set.
         """
         _openssl_assert(_lib.X509_STORE_set_flags(self._store, flags) != 0)
 
     def set_time(self, vfy_time):
-        """Set verification time to this store.
+        """
+        Set verification time to this store.
 
         .. versionadded: 16.3.0
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1520,9 +1520,15 @@ class X509Store(object):
 
     def set_time(self, vfy_time):
         """
-        Set verification time to this store.
+        Set the time against which the certificates are verified.
 
-        .. versionadded: 16.3.0
+        Normally the current time is used.
+
+        .. note::
+
+          For example, you can determine if a certificate was valid at a given time.
+
+        .. versionadded:: 16.3.0
 
         :param datetime vfy_time: The verification time to set on this store.
         :return: ``None`` if the verification time was successfully set.

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1514,6 +1514,7 @@ class X509Store(object):
 
         :param int flags: The verification flags to set on this store.
             See :class:`X509StoreFlags` for available constants.
+        :return: ``None`` if the verification flags were successfully set.
         """
         _openssl_assert(_lib.X509_STORE_set_flags(self._store, flags) != 0)
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1518,6 +1518,18 @@ class X509Store(object):
         """
         _openssl_assert(_lib.X509_STORE_set_flags(self._store, flags) != 0)
 
+    def set_time(self, vfy_time):
+        """Set verification time to this store.
+
+        .. versionadded: 16.3.0
+
+        :param datetime vfy_time: The verification time to set on this store.
+        :return: ``None`` if the verification time were successfully set.
+        """
+        vfy_param = _lib.X509_VERIFY_PARAM_new()
+        _lib.X509_VERIFY_PARAM_set_time(vfy_param, int(vfy_time.strftime('%s')))
+        _openssl_assert(_lib.X509_STORE_set1_param(self._store, vfy_param) != 0)
+
 
 X509StoreType = X509Store
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1526,9 +1526,9 @@ class X509Store(object):
         :param datetime vfy_time: The verification time to set on this store.
         :return: ``None`` if the verification time were successfully set.
         """
-        vfy_param = _lib.X509_VERIFY_PARAM_new()
-        _lib.X509_VERIFY_PARAM_set_time(vfy_param, int(vfy_time.strftime('%s')))
-        _openssl_assert(_lib.X509_STORE_set1_param(self._store, vfy_param) != 0)
+        param = _lib.X509_VERIFY_PARAM_new()
+        _lib.X509_VERIFY_PARAM_set_time(param, int(vfy_time.strftime('%s')))
+        _openssl_assert(_lib.X509_STORE_set1_param(self._store, param) != 0)
 
 
 X509StoreType = X509Store

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1527,6 +1527,8 @@ class X509Store(object):
         :return: ``None`` if the verification time were successfully set.
         """
         param = _lib.X509_VERIFY_PARAM_new()
+        param = _ffi.gc(param, _lib.X509_VERIFY_PARAM_free)
+
         _lib.X509_VERIFY_PARAM_set_time(param, int(vfy_time.strftime('%s')))
         _openssl_assert(_lib.X509_STORE_set1_param(self._store, param) != 0)
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1526,7 +1526,8 @@ class X509Store(object):
 
         .. note::
 
-          For example, you can determine if a certificate was valid at a given time.
+          For example, you can determine if a certificate was valid at a given
+          time.
 
         .. versionadded:: 16.3.0
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3756,9 +3756,10 @@ class X509StoreContextTests(TestCase):
         store.set_time(expire_datetime)
 
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
-        with pytest.raises(X509StoreContextError) as e:
+        with pytest.raises(X509StoreContextError) as exc:
             store_ctx.verify_certificate()
-            assert e.args[0][2] == 'certificate has expired'
+
+        assert exc.args[0][2] == 'certificate has expired'
 
 
 class SignVerifyTests(TestCase):

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3759,7 +3759,7 @@ class X509StoreContextTests(TestCase):
         with pytest.raises(X509StoreContextError) as exc:
             store_ctx.verify_certificate()
 
-        assert exc.args[0][2] == 'certificate has expired'
+        assert exc.value.args[0][2] == 'certificate has expired'
 
 
 class SignVerifyTests(TestCase):

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3742,14 +3742,17 @@ class X509StoreContextTests(TestCase):
 
     def test_verify_with_time(self):
         """
-        :func:`verify_certificate` raises error when the verification time is set at notAfter.
+        :func:`verify_certificate` raises error when the verification time is
+        set at notAfter.
         """
         store = X509Store()
         store.add_cert(self.root_cert)
         store.add_cert(self.intermediate_cert)
 
-        expire_time = self.intermediate_server_cert.get_notAfter().decode('utf-8')
-        expire_datetime = datetime.strptime(expire_time, '%Y%m%d%H%M%SZ')
+        expire_time = self.intermediate_server_cert.get_notAfter()
+        expire_datetime = datetime.strptime(
+            expire_time.decode('utf-8'), '%Y%m%d%H%M%SZ'
+        )
         store.set_time(expire_datetime)
 
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3740,6 +3740,23 @@ class X509StoreContextTests(TestCase):
         store_ctx.set_store(store_good)
         self.assertEqual(store_ctx.verify_certificate(), None)
 
+    def test_verify_with_time(self):
+        """
+        :func:`verify_certificate` raises error when the verification time is set at notAfter.
+        """
+        store = X509Store()
+        store.add_cert(self.root_cert)
+        store.add_cert(self.intermediate_cert)
+
+        expire_time = self.intermediate_server_cert.get_notAfter().decode('utf-8')
+        expire_datetime = datetime.strptime(expire_time, '%Y%m%d%H%M%SZ')
+        store.set_time(expire_datetime)
+
+        store_ctx = X509StoreContext(store, self.intermediate_server_cert)
+        with pytest.raises(X509StoreContextError) as e:
+            store_ctx.verify_certificate()
+            assert e.args[0][2] == 'certificate has expired'
+
 
 class SignVerifyTests(TestCase):
     """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3742,7 +3742,7 @@ class X509StoreContextTests(TestCase):
 
     def test_verify_with_time(self):
         """
-        :func:`verify_certificate` raises error when the verification time is
+        `verify_certificate` raises error when the verification time is
         set at notAfter.
         """
         store = X509Store()

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     coverage>=4.2
     pytest>=3.0.1
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
-    cryptographyMinimum: cryptography==1.6
+    cryptographyMinimum: cryptography<1.7
 setenv =
     # Do not allow the executing environment to pollute the test environment
     # with extra packages.

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     coverage>=4.2
     pytest>=3.0.1
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
-    cryptographyMinimum: cryptography<1.4
+    cryptographyMinimum: cryptography==1.6
 setenv =
     # Do not allow the executing environment to pollute the test environment
     # with extra packages.


### PR DESCRIPTION
This PR add a `set_time` methods on `OpenSSL.crypto.X509Store`.

This new methods:
- create a `X509_VERIFY_PARAM`
- "set" the given time (a `datetime.datetime` instance)
- and finally "set" the param on the `X509Store`

One things I'm worried about is if the `X509_VERIFY_PARAM` should be "gc"ed manually? or it will be cleaned when the `X509Store` will be "gc"ed?

I chose to implement the method on `X509Store` because it's more convenient to set the time only once on the store, and then verify multiple certificates (instead of having to set it in each `X509StoreContext`).

Thanks!
