### PR TITLE
Convert ALPN and SessionTests to use pytest-style tests

### DIFF
--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1854,7 +1854,7 @@ class TestNextProtoNegotiation(object):
         assert select_args == []
 
 
-class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
+class TestApplicationLayerProtoNegotiation(object):
     """
     Tests for ALPN in PyOpenSSL.
     """
@@ -1892,12 +1892,12 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             client = Connection(client_context, None)
             client.set_connect_state()
 
-            self._interactInMemory(server, client)
+            interact_in_memory(server, client)
 
-            self.assertEqual([(server, [b'http/1.1', b'spdy/2'])], select_args)
+            assert select_args == [(server, [b'http/1.1', b'spdy/2'])]
 
-            self.assertEqual(server.get_alpn_proto_negotiated(), b'spdy/2')
-            self.assertEqual(client.get_alpn_proto_negotiated(), b'spdy/2')
+            assert server.get_alpn_proto_negotiated() == b'spdy/2'
+            assert client.get_alpn_proto_negotiated() == b'spdy/2'
 
         def test_alpn_set_on_connection(self):
             """
@@ -1931,12 +1931,12 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             client.set_alpn_protos([b'http/1.1', b'spdy/2'])
             client.set_connect_state()
 
-            self._interactInMemory(server, client)
+            interact_in_memory(server, client)
 
-            self.assertEqual([(server, [b'http/1.1', b'spdy/2'])], select_args)
+            assert select_args == [(server, [b'http/1.1', b'spdy/2'])]
 
-            self.assertEqual(server.get_alpn_proto_negotiated(), b'spdy/2')
-            self.assertEqual(client.get_alpn_proto_negotiated(), b'spdy/2')
+            assert server.get_alpn_proto_negotiated() == b'spdy/2'
+            assert client.get_alpn_proto_negotiated() == b'spdy/2'
 
         def test_alpn_server_fail(self):
             """
@@ -1969,9 +1969,10 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             client.set_connect_state()
 
             # If the client doesn't return anything, the connection will fail.
-            self.assertRaises(Error, self._interactInMemory, server, client)
+            with pytest.raises(Error):
+                interact_in_memory(server, client)
 
-            self.assertEqual([(server, [b'http/1.1', b'spdy/2'])], select_args)
+            assert select_args == [(server, [b'http/1.1', b'spdy/2'])]
 
         def test_alpn_no_server(self):
             """
@@ -1997,9 +1998,9 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             client.set_connect_state()
 
             # Do the dance.
-            self._interactInMemory(server, client)
+            interact_in_memory(server, client)
 
-            self.assertEqual(client.get_alpn_proto_negotiated(), b'')
+            assert client.get_alpn_proto_negotiated() == b''
 
         def test_alpn_callback_exception(self):
             """
@@ -2030,10 +2031,9 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             client = Connection(client_context, None)
             client.set_connect_state()
 
-            self.assertRaises(
-                TypeError, self._interactInMemory, server, client
-            )
-            self.assertEqual([(server, [b'http/1.1', b'spdy/2'])], select_args)
+            with pytest.raises(TypeError):
+                interact_in_memory(server, client)
+            assert select_args == [(server, [b'http/1.1', b'spdy/2'])]
 
     else:
         # No ALPN.
@@ -2043,18 +2043,15 @@ class ApplicationLayerProtoNegotiationTests(TestCase, _LoopbackMixin):
             """
             # Test the context methods first.
             context = Context(TLSv1_METHOD)
-            self.assertRaises(
-                NotImplementedError, context.set_alpn_protos, None
-            )
-            self.assertRaises(
-                NotImplementedError, context.set_alpn_select_callback, None
-            )
+            with pytest.raises(NotImplementedError):
+                context.set_alpn_protos(None)
+            with pytest.raises(NotImplementedError):
+                context.set_alpn_select_callback(None)
 
             # Now test a connection.
             conn = Connection(context)
-            self.assertRaises(
-                NotImplementedError, conn.set_alpn_protos, None
-            )
+            with pytest.raises(NotImplementedError):
+                conn.set_alpn_protos(None)
 
 
 class SessionTests(TestCase):

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2054,7 +2054,7 @@ class TestApplicationLayerProtoNegotiation(object):
                 conn.set_alpn_protos(None)
 
 
-class SessionTests(TestCase):
+class TestSession(object):
     """
     Unit tests for :py:obj:`OpenSSL.SSL.Session`.
     """
@@ -2064,16 +2064,7 @@ class SessionTests(TestCase):
         a new instance of that type.
         """
         new_session = Session()
-        self.assertTrue(isinstance(new_session, Session))
-
-    def test_construction_wrong_args(self):
-        """
-        If any arguments are passed to :py:class:`Session`, :py:obj:`TypeError`
-        is raised.
-        """
-        self.assertRaises(TypeError, Session, 123)
-        self.assertRaises(TypeError, Session, "hello")
-        self.assertRaises(TypeError, Session, object())
+        assert isinstance(new_session, Session)
 
 
 class ConnectionTests(TestCase, _LoopbackMixin):


### PR DESCRIPTION
I did the ALPN tests, and then `SessionTests` was so short I just did that as well.

Throwing away `test_construction_wrong_args` is based on this comment: https://github.com/pyca/pyopenssl/pull/563#discussion_r84685308

Addresses #340.

---

This is part of breaking up #561.
