### PR TITLE
We should consider actually testing Twisted.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
 commands =
     python -c "import OpenSSL.SSL; print(OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION))"
     python -c "import cryptography; print(cryptography.__version__)"
-    python -m twisted.trial
+    python -m twisted.trial --reporter=text twisted
 
 [testenv:py35-urllib3Master]
 basepython=python3.5


### PR DESCRIPTION
Currently we're not actually running any Twisted tests: see [this build](https://travis-ci.org/pyca/pyopenssl/jobs/179282980). This patch actually runs them.