### PR TITLE
Add support for OCSP stapling.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,10 @@ Changes:
 
 - Added ``OpenSSL.X509Store.set_time()`` to set a custom verification time when verifying certificate chains.
   `#567 <https://github.com/pyca/pyopenssl/pull/567>`_
+- Added a collection of functions for working with OCSP stapling.
+  None of these functions make it possible to validate OCSP assertions, only to staple them into the handshake and to retrieve the stapled assertion if provided.
+  Users will need to write their own code to handle OCSP assertions.
+  We specifically added: ``Context.set_ocsp_server_callback``, ``Context.set_ocsp_client_callback``, and ``Connection.request_ocsp``.
 - Changed the ``SSL`` module's memory allocation policy to avoid zeroing memory it allocates when unnecessary.
   This reduces CPU usage and memory allocation time by an amount proportional to the size of the allocation.
   For applications that process a lot of TLS data or that use very lage allocations this can provide considerable performance improvements.

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             # Fix cryptographyMinimum in tox.ini when changing this!
-            "cryptography>=1.6",
+            "cryptography>=1.7",
             "six>=1.5.2"
         ],
     )

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1337,6 +1337,8 @@ class Connection(object):
             self._context._npn_select_helper.raise_if_problem()
         if self._context._alpn_select_helper is not None:
             self._context._alpn_select_helper.raise_if_problem()
+        if self._context._ocsp_helper is not None:
+            self._context._ocsp_helper.raise_if_problem()
 
         error = _lib.SSL_get_error(ssl, result)
         if error == _lib.SSL_ERROR_WANT_READ:

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2122,6 +2122,18 @@ class Connection(object):
 
         return _ffi.buffer(data[0], data_len[0])[:]
 
+    def request_ocsp(self):
+        """
+        Called to request that the server sends stapled OCSP data, if
+        available. If this is not called on the client side then the server
+        will not send OCSP data. Should be used in conjunction with
+        :meth:`Context.set_ocsp_client_callback`.
+        """
+        rc = _lib.SSL_set_tlsext_status_type(
+            self._ssl, _lib.TLSEXT_STATUSTYPE_ocsp
+        )
+        _openssl_assert(rc == 1)
+
 
 ConnectionType = Connection
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -3889,7 +3889,7 @@ class TestOCSP(_LoopbackMixin):
     def test_callbacks_arent_called_by_default(self):
         """
         If both the client and the server have registered OCSP callbacks, but
-        the client does not sent the OCSP request, neither callback gets
+        the client does not send the OCSP request, neither callback gets
         called.
         """
         called = []

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -3842,3 +3842,244 @@ class TestRequires(object):
 
         assert "Error text" in str(e.value)
         assert results == []
+
+
+class TestOCSP(_LoopbackMixin):
+    """
+    Tests for PyOpenSSL's OCSP stapling support.
+    """
+    sample_ocsp_data = b"this is totally ocsp data"
+
+    def _client_connection(self, callback, data, request_ocsp=True):
+        """
+        Builds a client connection suitable for using OCSP.
+
+        :param callback: The callback to register for OCSP.
+        :param data: The opaque data object that will be handed to the
+            OCSP callback.
+        :param request_ocsp: Whether the client will actually ask for OCSP
+            stapling. Useful for testing only.
+        """
+        ctx = Context(SSLv23_METHOD)
+        ctx.set_ocsp_client_callback(callback, data)
+        client = Connection(ctx)
+
+        if request_ocsp:
+            client.request_ocsp()
+
+        client.set_connect_state()
+        return client
+
+    def _server_connection(self, callback, data):
+        """
+        Builds a server connection suitable for using OCSP.
+
+        :param callback: The callback to register for OCSP.
+        :param data: The opaque data object that will be handed to the
+            OCSP callback.
+        """
+        ctx = Context(SSLv23_METHOD)
+        ctx.use_privatekey(load_privatekey(FILETYPE_PEM, server_key_pem))
+        ctx.use_certificate(load_certificate(FILETYPE_PEM, server_cert_pem))
+        ctx.set_ocsp_server_callback(callback, data)
+        server = Connection(ctx)
+        server.set_accept_state()
+        return server
+
+    def test_callbacks_arent_called_by_default(self):
+        """
+        If both the client and the server have registered OCSP callbacks, but
+        the client does not sent the OCSP request, neither callback gets
+        called.
+        """
+        called = []
+        def ocsp_callback(*args, **kwargs):
+            called.append((args, kwargs))
+
+        client = self._client_connection(
+            callback=ocsp_callback, data=None, request_ocsp=False
+        )
+        server = self._server_connection(callback=ocsp_callback, data=None)
+        self._handshakeInMemory(client, server)
+
+        assert not called
+
+    def test_client_negotiates_without_server(self):
+        """
+        If the client wants to do OCSP but the server does not, the handshake
+        succeeds, and the client callback fires with an empty byte string.
+        """
+        called = []
+        def ocsp_callback(conn, ocsp_data, ignored):
+            called.append(ocsp_data)
+            return True
+
+        client = self._client_connection(callback=ocsp_callback, data=None)
+        server = self._loopbackServerFactory(socket=None)
+        self._handshakeInMemory(client, server)
+
+        assert len(called) == 1
+        assert called[0] == b''
+
+    def test_client_receives_servers_data(self):
+        """
+        The data the server sends in its callback is received by the client.
+        """
+        calls = []
+        def server_callback(*args, **kwargs):
+            return self.sample_ocsp_data
+
+        def client_callback(conn, ocsp_data, ignored):
+            calls.append(ocsp_data)
+            return True
+
+        client = self._client_connection(callback=client_callback, data=None)
+        server = self._server_connection(callback=server_callback, data=None)
+        self._handshakeInMemory(client, server)
+
+        assert len(calls) == 1
+        assert calls[0] == self.sample_ocsp_data
+
+    def test_callbacks_are_invoked_with_connections(self):
+        """
+        The first arguments to both callbacks are their respective connections.
+        """
+        client_calls = []
+        server_calls = []
+
+        def client_callback(conn, *args, **kwargs):
+            client_calls.append(conn)
+            return True
+
+        def server_callback(conn, *args, **kwargs):
+            server_calls.append(conn)
+            return self.sample_ocsp_data
+
+        client = self._client_connection(callback=client_callback, data=None)
+        server = self._server_connection(callback=server_callback, data=None)
+        self._handshakeInMemory(client, server)
+
+        assert len(client_calls) == 1
+        assert len(server_calls) == 1
+        assert client_calls[0] is client
+        assert server_calls[0] is server
+
+    def test_opaque_data_is_passed_through(self):
+        """
+        Both callbacks receive an opaque, user-provided piece of data in their
+        callbacks as the final argument.
+        """
+        calls = []
+
+        def server_callback(*args):
+            calls.append(args)
+            return self.sample_ocsp_data
+
+        def client_callback(*args):
+            calls.append(args)
+            return True
+
+        sentinel = object()
+
+        client = self._client_connection(
+            callback=client_callback, data=sentinel
+        )
+        server = self._server_connection(
+            callback=server_callback, data=sentinel
+        )
+        self._handshakeInMemory(client, server)
+
+        assert len(calls) == 2
+        assert calls[0][-1] is sentinel
+        assert calls[1][-1] is sentinel
+
+    def test_server_returns_empty_string(self):
+        """
+        If the server returns an empty bytestring from its callback, the
+        client callback is called with the empty bytestring.
+        """
+        client_calls = []
+
+        def server_callback(*args):
+            return b''
+
+        def client_callback(conn, ocsp_data, ignored):
+            client_calls.append(ocsp_data)
+            return True
+
+        client = self._client_connection(callback=client_callback, data=None)
+        server = self._server_connection(callback=server_callback, data=None)
+        self._handshakeInMemory(client, server)
+
+        assert len(client_calls) == 1
+        assert client_calls[0] == b''
+
+    def test_client_returns_false_terminates_handshake(self):
+        """
+        If the client returns False from its callback, the handshake fails.
+        """
+        def server_callback(*args):
+            return self.sample_ocsp_data
+
+        def client_callback(*args):
+            return False
+
+        client = self._client_connection(callback=client_callback, data=None)
+        server = self._server_connection(callback=server_callback, data=None)
+
+        with pytest.raises(Error):
+            self._handshakeInMemory(client, server)
+
+    def test_exceptions_in_client_bubble_up(self):
+        """
+        The callbacks thrown in the client callback bubble up to the caller.
+        """
+        class SentinelException(Exception):
+            pass
+
+        def server_callback(*args):
+            return self.sample_ocsp_data
+
+        def client_callback(*args):
+            raise SentinelException()
+
+        client = self._client_connection(callback=client_callback, data=None)
+        server = self._server_connection(callback=server_callback, data=None)
+
+        with pytest.raises(SentinelException):
+            self._handshakeInMemory(client, server)
+
+    def test_exceptions_in_server_bubble_up(self):
+        """
+        The callbacks thrown in the server callback bubble up to the caller.
+        """
+        class SentinelException(Exception):
+            pass
+
+        def server_callback(*args):
+            raise SentinelException()
+
+        def client_callback(*args):
+            pytest.fail("Should not be called")
+
+        client = self._client_connection(callback=client_callback, data=None)
+        server = self._server_connection(callback=server_callback, data=None)
+
+        with pytest.raises(SentinelException):
+            self._handshakeInMemory(client, server)
+
+    def test_server_must_return_bytes(self):
+        """
+        The server callback must return a bytestring, or a TypeError is thrown.
+        """
+        def server_callback(*args):
+            return self.sample_ocsp_data.decode('ascii')
+
+        def client_callback(*args):
+            pytest.fail("Should not be called")
+
+        client = self._client_connection(callback=client_callback, data=None)
+        server = self._server_connection(callback=server_callback, data=None)
+
+        with pytest.raises(TypeError):
+            self._handshakeInMemory(client, server)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -3893,6 +3893,7 @@ class TestOCSP(_LoopbackMixin):
         called.
         """
         called = []
+
         def ocsp_callback(*args, **kwargs):
             called.append((args, kwargs))
 
@@ -3910,6 +3911,7 @@ class TestOCSP(_LoopbackMixin):
         succeeds, and the client callback fires with an empty byte string.
         """
         called = []
+
         def ocsp_callback(conn, ocsp_data, ignored):
             called.append(ocsp_data)
             return True
@@ -3926,6 +3928,7 @@ class TestOCSP(_LoopbackMixin):
         The data the server sends in its callback is received by the client.
         """
         calls = []
+
         def server_callback(*args, **kwargs):
             return self.sample_ocsp_data
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     coverage>=4.2
     pytest>=3.0.1
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
-    cryptographyMinimum: cryptography<1.7
+    cryptographyMinimum: cryptography<1.8
 setenv =
     # Do not allow the executing environment to pollute the test environment
     # with extra packages.


### PR DESCRIPTION
This PR adds a collection of functions that add support for server and client side OCSP stapling.

In the spirit of PyOpenSSL's "thin wrapper" policy, these functions specifically do not provide any *validation* of stapled OCSP assertions: that's officially Someone Else's Problem. However, they do provide a mechanism whereby servers may staple OCSP assertions if they desire, and clients may retrieve those stapled OCSP assertions.

**This PR cannot be merged yet, it will fail tests against most cryptography versions**. We will need to wait until a new cryptography release is cut (specifically 1.7) and then make that our minimum supported cryptography version in order to properly enable this functionality.