### PR TITLE
Prevent _PassphraseHelper.raise_if_problem() from eating exceptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,8 @@ Changes:
   `#578 <https://github.com/pyca/pyopenssl/pull/578>`_
 - Automatically set ``SSL_CTX_set_ecdh_auto()`` on ``OpenSSL.SSL.Context``.
   `#575 <https://github.com/pyca/pyopenssl/pull/575>`_
+- Fix empty exceptions from ``OpenSSL.crypto.load_privatekey()``.
+  `#581 <https://github.com/pyca/pyopenssl/pull/581>`_
 
 
 ----

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -771,11 +771,10 @@ class Context(object):
             _raise_current_error()
 
     def _raise_passphrase_exception(self):
-        if self._passphrase_helper is None:
-            _raise_current_error()
-        exception = self._passphrase_helper.raise_if_problem(Error)
-        if exception is not None:
-            raise exception
+        if self._passphrase_helper is not None:
+            self._passphrase_helper.raise_if_problem(Error)
+
+        _raise_current_error()
 
     def use_privatekey_file(self, keyfile, filetype=_UNSPECIFIED):
         """

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -2523,13 +2523,15 @@ class _PassphraseHelper(object):
             )
 
     def raise_if_problem(self, exceptionType=Error):
-        try:
-            _exception_from_error_queue(exceptionType)
-        except exceptionType as e:
-            from_queue = e
         if self._problems:
-            raise self._problems[0]
-        return from_queue
+
+            # Flush the OpenSSL error queue
+            try:
+                _exception_from_error_queue(exceptionType)
+            except exceptionType:
+                pass
+
+            raise self._problems.pop(0)
 
     def _read_passphrase(self, buf, size, rwflag, userdata):
         try:

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2595,9 +2595,10 @@ class FunctionTests(TestCase):
         :py:obj:`load_privatekey` raises :py:obj:`OpenSSL.crypto.Error` when it
         is passed an encrypted PEM and an incorrect passphrase.
         """
-        self.assertRaises(
+        exc = self.assertRaises(
             Error,
             load_privatekey, FILETYPE_PEM, encryptedPrivateKeyPEM, b"quack")
+        self.assertNotEqual(exc.args[0], [])
 
     def test_load_privatekey_passphraseWrongType(self):
         """
@@ -2642,10 +2643,11 @@ class FunctionTests(TestCase):
         def cb(*a):
             called.append(None)
             return b"quack"
-        self.assertRaises(
+        exc = self.assertRaises(
             Error,
             load_privatekey, FILETYPE_PEM, encryptedPrivateKeyPEM, cb)
         self.assertTrue(called)
+        self.assertNotEqual(exc.args[0], [])
 
     def test_load_privatekey_passphraseCallback(self):
         """


### PR DESCRIPTION
When `_PassphraseHelper.raise_if_problem()` does not raise an exception, it still flushes the OpenSSL error queue, possibly causing subsequent code to `raise crypto.Error([])` as in bugs #456, #119.

This changeset modifies `_PassphraseHelper.raise_if_problem()` to flush the error queue only when it raises an exception, thus leaving the OpenSSL errors untouched when it does not raise an exception.