### PR TITLE
Activate intersphinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -52,9 +52,12 @@ sys.path.insert(0, os.path.abspath(os.path.join(DOC_DIR, "..")))
 # If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = '1.0'
 
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.autodoc"]
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+extensions = [
+    "sphinx.ext.autodoc",
+    'sphinx.ext.intersphinx',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -71,7 +74,7 @@ master_doc = 'index'
 # General information about the project.
 project = u'pyOpenSSL'
 authors = u"The pyOpenSSL developers"
-copyright = u"2001-{0}, {1}".format(datetime.date.today().year, authors)
+copyright = u"2001 " + authors
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -249,3 +252,8 @@ man_pages = [
     ('index', 'pyopenssl', u'pyOpenSSL Documentation',
      [authors], 1)
 ]
+
+intersphinx_mapping = {
+    "https://docs.python.org/3": None,
+    "https://cryptography.io/en/latest/": None,
+}

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -283,8 +283,10 @@ class PKey(object):
 
         This is the Python equivalent of OpenSSL's ``RSA_check_key``.
 
-        :return: True if key is consistent.
-        :raise Error: if the key is inconsistent.
+        :return: ``True`` if key is consistent.
+
+        :raise OpenSSL.crypto.Error: if the key is inconsistent.
+
         :raise TypeError: if the key is of a type which cannot be checked.
             Only RSA keys can currently be checked.
         """
@@ -974,11 +976,12 @@ class X509Req(object):
         """
         Verifies the signature on this certificate signing request.
 
-        :param key: A public key.
-        :type key: :py:class:`PKey`
-        :return: :py:data:`True` if the signature is correct.
-        :rtype: :py:class:`bool`
-        :raises Error: If the signature is invalid or there is a
+        :param PKey key: A public key.
+
+        :return: ``True`` if the signature is correct.
+        :rtype: bool
+
+        :raises OpenSSL.crypto.Error: If the signature is invalid or there is a
             problem verifying the signature.
         """
         if not isinstance(pkey, PKey):
@@ -1471,8 +1474,12 @@ class X509Store(object):
         *trusted* certificate.
 
         :param X509 cert: The certificate to add to this store.
+
         :raises TypeError: If the certificate is not an :class:`X509`.
-        :raises Error: If OpenSSL was unhappy with your certificate.
+
+        :raises OpenSSL.crypto.Error: If OpenSSL was unhappy with your
+            certificate.
+
         :return: ``None`` if the certificate was added successfully.
         """
         if not isinstance(cert, X509):
@@ -2425,14 +2432,13 @@ class NetscapeSPKI(object):
         """
         Verifies a signature on a certificate request.
 
-        :param key: The public key that signature is supposedly from.
-        :type pkey: :py:class:`PKey`
+        :param PKey key: The public key that signature is supposedly from.
 
-        :return: :py:const:`True` if the signature is correct.
-        :rtype: :py:class:`bool`
+        :return: ``True`` if the signature is correct.
+        :rtype: bool
 
-        :raises Error: If the signature is invalid, or there was a problem
-            verifying the signature.
+        :raises OpenSSL.crypto.Error: If the signature is invalid, or there was
+            a problem verifying the signature.
         """
         answer = _lib.NETSCAPE_SPKI_verify(self._spki, key._pkey)
         if answer <= 0:


### PR DESCRIPTION
That adds links to CPython docs and cryptography.

Also let the copyright at 2001 which seems to be just fine and gives us
reproducible builds.