### PR TITLE
Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
     env: TOXENV=py34
   - python: "3.5"
     env: TOXENV=py35
+  - python: "3.6"
+    env: TOXENV=py36
   - python: "pypy"
     env: TOXENV=pypy
 
@@ -43,6 +45,8 @@ matrix:
     env: TOXENV=py34-cryptographyMaster
   - python: "3.5"
     env: TOXENV=py35-cryptographyMaster
+  - python: "3.6"
+    env: TOXENV=py36-cryptographyMaster
   - python: "pypy"
     env: TOXENV=pypy-cryptographyMaster
 
@@ -57,6 +61,8 @@ matrix:
     env: TOXENV=py34-cryptographyMinimum
   - python: "3.5"
     env: TOXENV=py35-cryptographyMinimum
+  - python: "3.6"
+    env: TOXENV=py36-cryptographyMinimum
   - python: "pypy"
     env: TOXENV=pypy-cryptographyMinimum
 
@@ -89,6 +95,7 @@ matrix:
   - env: TOXENV=py33-cryptographyMaster
   - env: TOXENV=py34-cryptographyMaster
   - env: TOXENV=py35-cryptographyMaster
+  - env: TOXENV=py36-cryptographyMaster
   - env: TOXENV=pypy-cryptographyMaster
 
 install:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,11 @@
 include             LICENSE MANIFEST.in *.rst tox.ini docs-requirements.txt .coveragerc
 exclude             leakcheck
-recursive-include   tests       *.py
-recursive-include   doc         *
-recursive-include   examples    *
-recursive-include   rpm         *
-recursive-exclude   leakcheck   *.py *.pem
+recursive-include   tests           *.py
+recursive-include   doc             *
+recursive-include   examples        *
+recursive-include   rpm             *
+recursive-exclude   leakcheck       *.py *.pem
+recursive-exclude   examples/simple *.cert *.pkey
 prune               doc/_build
 prune               .travis
 prune               .mention-bot

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ if __name__ == "__main__":
             'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
 
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {pypy,py26,py27,py33,py34,py35}{,-cryptographyMaster,-cryptographyMinimum},py27-twistedMaster,pypi-readme,check-manifest,flake8,docs,coverage-report
+envlist = {pypy,py26,py27,py33,py34,py35,py36}{,-cryptographyMaster,-cryptographyMinimum},py27-twistedMaster,pypi-readme,check-manifest,flake8,docs,coverage-report
 
 [testenv]
 whitelist_externals =


### PR DESCRIPTION
Additionally adds one line to MANIFEST.in to stop local tox failing if the example files have been created.