### PR TITLE
Limit SSL_write bufsize to avoid OverflowErrors

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1456,7 +1456,8 @@ class Connection(object):
         if not isinstance(buf, bytes):
             raise TypeError("data must be a memoryview, buffer or byte string")
 
-        result = _lib.SSL_write(self._ssl, buf, len(buf))
+        buf_len = min(len(buf), 2147483647)  # cannot send more than 2**31-1 bytes at once.
+        result = _lib.SSL_write(self._ssl, buf, buf_len)
         self._raise_ssl_error(self._ssl, result)
         return result
     write = send
@@ -1486,7 +1487,7 @@ class Connection(object):
         data = _ffi.new("char[]", buf)
 
         while left_to_send:
-            result = _lib.SSL_write(self._ssl, data + total_sent, left_to_send)
+            result = _lib.SSL_write(self._ssl, data + total_sent, min(left_to_send, 2147483647))
             self._raise_ssl_error(self._ssl, result)
             total_sent += result
             left_to_send -= result


### PR DESCRIPTION
We got [this](https://github.com/mitmproxy/mitmproxy/issues/1961) bug report where @ohhorob triggered an OverflowError when trying to `.sendall()` more than 2,2GB of data. ¯\\\_(ツ)_/¯
```
  File "/usr/local/lib/python3.6/site-packages/mitmproxy/net/tcp.py", line 188, in write
    return self.o.sendall(v)
  File "/usr/local/lib/python3.6/site-packages/OpenSSL/SSL.py", line 1285, in sendall
    result = _lib.SSL_write(self._ssl, data + total_sent, left_to_send)
OverflowError: integer 3114393428 does not fit '32-bit int'
```
`SSL_write` only accepts an int32 as length argument, so we can't send everything at once. Here's a fix that limits the buffer size to 2**32-1 bytes to fit into an int32. Not sure how this could be tested without sending 2,2GB over the wire (that'd be an expensive test) or mocking very heavily, so this comes without tests for now. I'm happy to take suggestions on what to do about testing 😃 