### PR TITLE
[WIP] Deprecate backwards compatible type names

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1422,7 +1422,10 @@ class X509(object):
         return ext
 
 
-X509Type = X509
+def X509Type(*args, **kwargs):
+    _warn('The `X509Type` class is deprecated; use `X509` instead.',
+          category=DeprecationWarning)
+    return X509(*args, **kwargs)
 
 
 class X509StoreFlags(object):

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -657,7 +657,10 @@ class X509Name(object):
         return result
 
 
-X509NameType = X509Name
+def X509NameType(*args, **kwargs):
+    _warn('The `X509NameType` class is deprecated; use `X509Name` instead.',
+          category=DeprecationWarning)
+    return X509Name(*args, **kwargs)
 
 
 class X509Extension(object):

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -957,14 +957,20 @@ class TestX509Name(object):
 
     def test_type(self):
         """
-        The type of X509Name objects is `X509NameType`.
+        The type of X509Name objects is `X509Name`.
         """
-        assert X509Name is X509NameType
-        assert X509NameType.__name__ == 'X509Name'
-        assert isinstance(X509NameType, type)
+        assert X509Name.__name__ == 'X509Name'
+        assert isinstance(X509Name, type)
 
         name = x509_name()
-        assert isinstance(name, X509NameType)
+        assert isinstance(name, X509Name)
+
+    def test_deprecated_constructor(self):
+        """
+        Using `X509NameType` raises a DeprecationWarning.
+        """
+        with pytest.warns(DeprecationWarning):
+            X509NameType('foo')
 
     def test_only_string_attributes(self):
         """
@@ -1307,7 +1313,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         """
         request = X509Req()
         subject = request.get_subject()
-        assert isinstance(subject, X509NameType)
+        assert isinstance(subject, X509Name)
         subject.commonName = "foo"
         assert request.get_subject().commonName == "foo"
         del request

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1438,21 +1438,25 @@ WpOdIpB8KksUTCzV591Nr1wd
 
     def test_type(self):
         """
-        `X509` and `X509Type` refer to the same type object and can be used to
-        create instances of that type.
+        `X509` can be used to create instances of that type.
         """
-        assert X509 is X509Type
         assert is_consistent_type(X509, 'X509')
+
+    def test_deprecated_constructor(self):
+        """
+        Using `X509Type` raises a DeprecationWarning.
+        """
+        with pytest.warns(DeprecationWarning):
+            X509Type()
 
     def test_construction(self):
         """
-        `X509` takes no arguments and returns an instance of `X509Type`.
+        `X509` takes no arguments and returns an instance of `X509`.
         """
         certificate = X509()
-        assert isinstance(certificate, X509Type)
-        assert type(X509Type).__name__ == 'type'
+        assert isinstance(certificate, X509)
+        assert type(X509).__name__ == 'type'
         assert type(certificate).__name__ == 'X509'
-        assert type(certificate) == X509Type
         assert type(certificate) == X509
 
     def test_set_version_wrong_args(self):


### PR DESCRIPTION
This addresses #486.

There’s more to do, and I’m aware my use of `X509NameType` is causing a broken test, but I wanted to check I was going in the right direction before I did the whole set.