### PR TITLE
Fix broken links in the documentation

### DIFF
--- a/doc/api/crypto.rst
+++ b/doc/api/crypto.rst
@@ -319,7 +319,7 @@ For example, :const:`b"sha256"` or :const:`b"sha384"`.
 
 More information and a list of these digest names can be found in the ``EVP_DigestInit(3)`` man page of your OpenSSL installation.
 This page can be found online for the latest version of OpenSSL:
-https://www.openssl.org/docs/manmaster/crypto/EVP_DigestInit.html
+https://www.openssl.org/docs/manmaster/man3/EVP_DigestInit.html
 
 
 Backwards compatible type names

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -684,7 +684,7 @@ class X509Extension(object):
         :param issuer: Optional X509 certificate to use as issuer.
         :type issuer: :py:class:`X509`
 
-        .. _extension: https://www.openssl.org/docs/manmaster/apps/
+        .. _extension: https://www.openssl.org/docs/manmaster/man5/
             x509v3_config.html#STANDARD-EXTENSIONS
         """
         ctx = _ffi.new("X509V3_CTX*")

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1433,7 +1433,7 @@ class X509StoreFlags(object):
     See `OpenSSL Verification Flags`_ for details.
 
     .. _OpenSSL Verification Flags:
-        https://www.openssl.org/docs/manmaster/crypto/X509_VERIFY_PARAM_set_flags.html
+        https://www.openssl.org/docs/manmaster/man3/X509_VERIFY_PARAM_set_flags.html
     """
     CRL_CHECK = _lib.X509_V_FLAG_CRL_CHECK
     CRL_CHECK_ALL = _lib.X509_V_FLAG_CRL_CHECK_ALL


### PR DESCRIPTION
Resolves #610.

Looks like the OpenSSL manpages have been slightly rearranged recently. I fixed the link reported in that issue, and then ran a link checker over the rest of the documentation to find other broken links.