### PR TITLE
Fix invalid cast from ASN1_TIME to ASN1_GENERALIZEDTIME

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             # Fix cryptographyMinimum in tox.ini when changing this!
-            "cryptography>=1.7",
+            "cryptography>=1.9",
             "six>=1.5.2"
         ],
     )

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -103,7 +103,7 @@ def _set_asn1_time(boundary, when):
     """
     The the time value of an ASN1 time object.
 
-    @param boundary: An ASN1_GENERALIZEDTIME pointer (or an object safely
+    @param boundary: An ASN1_TIME pointer (or an object safely
         castable to that type) which will have its value set.
     @param when: A string representation of the desired time value.
 
@@ -116,17 +116,9 @@ def _set_asn1_time(boundary, when):
     if not isinstance(when, bytes):
         raise TypeError("when must be a byte string")
 
-    set_result = _lib.ASN1_GENERALIZEDTIME_set_string(
-        _ffi.cast('ASN1_GENERALIZEDTIME*', boundary), when)
+    set_result = _lib.ASN1_TIME_set_string(boundary, when)
     if set_result == 0:
-        dummy = _ffi.gc(_lib.ASN1_STRING_new(), _lib.ASN1_STRING_free)
-        _lib.ASN1_STRING_set(dummy, when, len(when))
-        check_result = _lib.ASN1_GENERALIZEDTIME_check(
-            _ffi.cast('ASN1_GENERALIZEDTIME*', dummy))
-        if not check_result:
-            raise ValueError("Invalid string")
-        else:
-            _untested_error()
+        raise ValueError("Invalid string")
 
 
 def _get_asn1_time(timestamp):

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     coverage>=4.2
     pytest>=3.0.1
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
-    cryptographyMinimum: cryptography<1.8
+    cryptographyMinimum: cryptography<=1.9
 setenv =
     # Do not allow the executing environment to pollute the test environment
     # with extra packages.


### PR DESCRIPTION
`X509_get_notBefore()` and `X509_get_notAfter()` return a `ASN1_TIME` structure which is not compatible with `ASN1_GENERALIZEDTIME`, but the original code recklessly casts it to `ASN1_GENERALIZEDTIME` and pass it to `ASN1_GENERALIZEDTIME_set_string()`.

LibreSSL is rigorous enough to reject such.

https://github.com/pyca/cryptography/pull/3491 needs to be applied to cryptography before the application of this patch.
