### PR TITLE
Add support for sending bytearrays.

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1453,10 +1453,16 @@ class Connection(object):
             buf = buf.tobytes()
         if isinstance(buf, _buffer):
             buf = str(buf)
-        if not isinstance(buf, bytes):
-            raise TypeError("data must be a memoryview, buffer or byte string")
+
+        if not isinstance(buf, (bytes, bytearray)):
+            raise TypeError(
+                "data must be a memoryview, buffer, bytearray or byte string"
+            )
+
         if len(buf) > 2147483647:
             raise ValueError("Cannot send more than 2**31-1 bytes at once.")
+
+        buf = _ffi.from_buffer(buf)
 
         result = _lib.SSL_write(self._ssl, buf, len(buf))
         self._raise_ssl_error(self._ssl, result)
@@ -1480,12 +1486,14 @@ class Connection(object):
             buf = buf.tobytes()
         if isinstance(buf, _buffer):
             buf = str(buf)
-        if not isinstance(buf, bytes):
-            raise TypeError("buf must be a memoryview, buffer or byte string")
+        if not isinstance(buf, (bytes, bytearray)):
+            raise TypeError(
+                "buf must be a memoryview, buffer, bytearray or byte string"
+            )
 
         left_to_send = len(buf)
         total_sent = 0
-        data = _ffi.new("char[]", buf)
+        data = _ffi.from_buffer(buf)
 
         while left_to_send:
             # SSL_write's num arg is an int,

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2696,6 +2696,22 @@ class TestConnection(object):
         data = conn.bio_read(long(2))
         assert 2 == len(data)
 
+    def test_send_bytearray(self):
+        """
+        The ``Connection.send`` method accepts bytearrays.
+        """
+        server, client = loopback()
+        server.send(bytearray(b'xy'))
+        assert client.recv(2) == b'xy'
+
+    def test_sendall_bytearray(self):
+        """
+        The ``Connection.sendall`` method accepts bytearrays.
+        """
+        server, client = loopback()
+        server.sendall(bytearray(b'xy'))
+        assert client.recv(2) == b'xy'
+
 
 class TestConnectionGetCipherList(object):
     """


### PR DESCRIPTION
Resolves #621.

This patch adds support for sending bytearrays by using `ffi.from_buffer` for both bytearrays and byte strings.

In general this patch is a good idea, however, it has some caveats. Most notable is that bytearray and byte string support for `from_buffer` only landed in cffi 1.8, but our lowest supported cryptography version only requires cffi 1.4. That may make this patch unacceptable. The *minimum* we could get away with would be cffi 1.7, and only then if we add separate code paths for byte strings and byte arrays.

On the other hand, if we could go up to requiring cffi 1.10 then we could remove the conditionals for handling memoryview and buffer objects, as `ffi.from_buffer` also supports them directly.

Anyway, here's a PoC, we can discuss whether it's acceptable or not.