### PR TITLE
try loading trusted certs from a list of fallbacks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Changes:
 
 - Added ``OpenSSL.debug`` that allows to get an overview of used library versions (including linked OpenSSL) and other useful runtime information using ``python -m OpenSSL.debug``.
   `#620 <https://github.com/pyca/pyopenssl/pull/620>`_
+- Added a fallback path to `Context.set_default_verify_paths` to accommodate the upcoming release of ``cryptography`` ``manylinux1`` wheels. `#633 <https://github.com/pyca/pyopenssl/pull/633>`_
 
 
 ----

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -717,8 +717,8 @@ class Context(object):
         # This function will attempt to load certs from both a cafile and
         # capath that are set at compile time. However, it will first check
         # environment variables and, if present, load those paths instead
-        # set_result = _lib.SSL_CTX_set_default_verify_paths(self._context)
-        # _openssl_assert(set_result == 1)
+        set_result = _lib.SSL_CTX_set_default_verify_paths(self._context)
+        _openssl_assert(set_result == 1)
         # After attempting to set default_verify_paths we need to know whether
         # to go down the fallback path.
         # First we'll check to see if any env vars have been set. If so,

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -770,7 +770,7 @@ class Context(object):
             return any(
                 [re.match(b'^[0-9a-f]{8}\.[0-9]', x) is not None for x in l]
             )
-        except (NotADirectoryError, FileNotFoundError):
+        except OSError:
             return False
 
     def _check_num_store_objects(self):

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -144,8 +144,8 @@ _CERTIFICATE_PATH_LOCATIONS = [
     "/etc/ssl/certs",  # SLES10/SLES11
 ]
 
-_CRYPTOGRAPHY_MANYLINUX1_CA_DIR = "/pyca/cryptography/openssl/certs"
-_CRYPTOGRAPHY_MANYLINUX1_CA_FILE = "/pyca/cryptography/openssl/cert.pem"
+_CRYPTOGRAPHY_MANYLINUX1_CA_DIR = "/opt/pyca/cryptography/openssl/certs"
+_CRYPTOGRAPHY_MANYLINUX1_CA_FILE = "/opt/pyca/cryptography/openssl/cert.pem"
 
 
 class Error(Exception):

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -724,18 +724,16 @@ class Context(object):
         # First we'll check to see if any env vars have been set. If so,
         # we won't try to do anything else because the user has set the path
         # themselves.
-        if self._verify_env_vars_set():
-            return
-
-        # If no env vars are set next we want to see if any certs were loaded.
-        # For a cafile this is simple and we can just ask how many objects are
-        # present. However, the cert directory (capath) is lazily loaded and
-        # num will always be zero so we need to check if the dir exists and
-        # has valid file names in it to cover that case.
-        num = self._check_num_store_objects()
-        if num == 0 and not self._default_dir_exists():
-            # No certs and no default dir, let's load our fallbacks
-            self._fallback_default_verify_paths()
+        if not self._verify_env_vars_set():
+            # If no env vars are set next we want to see if any certs were
+            # loaded. For a cafile this is simple and we can just ask how many
+            # objects are present. However, the cert directory (capath) is
+            # lazily loaded and num will always be zero so we need to check if
+            # the dir exists and has valid file names in it to cover that case.
+            num = self._check_num_store_objects()
+            if num == 0 and not self._default_dir_exists():
+                # No certs and no default dir, let's load our fallbacks
+                self._fallback_default_verify_paths()
 
     def _verify_env_vars_set(self):
         """

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -740,7 +740,10 @@ class Context(object):
             default_dir = _ffi.string(_lib.X509_get_default_cert_dir())
             if num == 0 and not self._default_dir_exists(default_dir):
                 # No certs and no default dir, let's load our fallbacks
-                self._fallback_default_verify_paths()
+                self._fallback_default_verify_paths(
+                    _CERTIFICATE_FILE_LOCATIONS,
+                    _CERTIFICATE_PATH_LOCATIONS
+                )
 
     def _verify_env_vars_set(self, dir_env_var, file_env_var):
         """
@@ -784,7 +787,7 @@ class Context(object):
         _openssl_assert(sk_obj != _ffi.NULL)
         return _lib.sk_X509_OBJECT_num(sk_obj)
 
-    def _fallback_default_verify_paths(self):
+    def _fallback_default_verify_paths(self, file_path, dir_path):
         """
         Default verify paths are based on the compiled version of OpenSSL.
         However, when pyca/cryptography is compiled as a manylinux1 wheel
@@ -794,12 +797,12 @@ class Context(object):
 
         :return: None
         """
-        for cafile in _CERTIFICATE_FILE_LOCATIONS:
+        for cafile in file_path:
             if os.path.isfile(cafile):
                 self.load_verify_locations(cafile)
                 break
 
-        for capath in _CERTIFICATE_PATH_LOCATIONS:
+        for capath in dir_path:
             if os.path.isdir(capath):
                 self.load_verify_locations(None, capath)
                 break

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -768,7 +768,7 @@ class Context(object):
             # Arguably this is overkill and we could just assume that if the
             # dir exists it's fine.
             return any(
-                [re.match('^[0-9a-f]{8}\.[0-9]', x) is not None for x in l]
+                [re.match(b'^[0-9a-f]{8}\.[0-9]', x) is not None for x in l]
             )
         except (NotADirectoryError, FileNotFoundError):
             return False

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1,5 +1,4 @@
 import os
-import re
 import socket
 from sys import platform
 from functools import wraps, partial

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -6,7 +6,6 @@ Unit tests for :mod:`OpenSSL.SSL`.
 """
 
 import datetime
-import os
 import sys
 import uuid
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -37,7 +37,6 @@ from OpenSSL.crypto import dump_privatekey, load_privatekey
 from OpenSSL.crypto import dump_certificate, load_certificate
 from OpenSSL.crypto import get_elliptic_curves
 
-from OpenSSL import SSL
 from OpenSSL.SSL import OPENSSL_VERSION_NUMBER, SSLEAY_VERSION, SSLEAY_CFLAGS
 from OpenSSL.SSL import SSLEAY_PLATFORM, SSLEAY_DIR, SSLEAY_BUILT_ON
 from OpenSSL.SSL import SENT_SHUTDOWN, RECEIVED_SHUTDOWN

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1141,7 +1141,10 @@ class TestContext(object):
             _ffi.string(_lib.X509_get_default_cert_dir())
         )
         context.set_default_verify_paths()
-        num = context._check_num_store_objects()
+        store = context.get_cert_store()
+        sk_obj = _lib.X509_STORE_get0_objects(store._store)
+        assert sk_obj != _ffi.NULL
+        num = _lib.sk_X509_OBJECT_num(sk_obj)
         assert num != 0
 
     def test_check_env_vars(self, monkeypatch):

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1109,6 +1109,20 @@ class TestContext(object):
             context.load_verify_locations(object(), object())
 
     @pytest.mark.skipif(
+        platform != "linux",
+        reason="Loading fallback paths is a linux-specific behavior to "
+        "accommodate pyca/cryptography manylinux1 wheels"
+    )
+    def test_fallback_default_verify_paths(self, monkeypatch):
+        context = Context(TLSv1_METHOD)
+        monkeypatch.setattr(
+            _lib, "SSL_CTX_set_default_verify_paths", lambda x: 1
+        )
+        context.set_default_verify_paths()
+        num = context._check_num_store_objects()
+        assert num != 0
+
+    @pytest.mark.skipif(
         platform == "win32",
         reason="set_default_verify_paths appears not to work on Windows.  "
         "See LP#404343 and LP#404344."

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1113,7 +1113,7 @@ class TestContext(object):
             context.load_verify_locations(object(), object())
 
     @pytest.mark.skipif(
-        platform != "linux",
+        not platform.startswith("linux"),
         reason="Loading fallback paths is a linux-specific behavior to "
         "accommodate pyca/cryptography manylinux1 wheels"
     )

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1217,6 +1217,17 @@ class TestContext(object):
         clientSSL.send(b"GET / HTTP/1.0\r\n\r\n")
         assert clientSSL.recv(1024)
 
+    def test_fallback_path_is_not_file_or_dir(self):
+        """
+        Test that when passed empty arrays or paths that do not exist no
+        errors are raised.
+        """
+        context = Context(TLSv1_METHOD)
+        context._fallback_default_verify_paths([], [])
+        context._fallback_default_verify_paths(
+            ["/not/a/file"], ["/not/a/dir"]
+        )
+
     def test_add_extra_chain_cert_invalid_cert(self):
         """
         `Context.add_extra_chain_cert` raises `TypeError` if called with an

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1118,6 +1118,7 @@ class TestContext(object):
         monkeypatch.setattr(
             _lib, "SSL_CTX_set_default_verify_paths", lambda x: 1
         )
+        monkeypatch.setattr(context, "_default_dir_exists", lambda: False)
         context.set_default_verify_paths()
         num = context._check_num_store_objects()
         assert num != 0

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
 deps =
     coverage>=4.2
     pytest>=3.0.1
+    pretend
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
     cryptographyMinimum: cryptography<1.8
 setenv =


### PR DESCRIPTION
pyca/cryptography will shortly begin shipping a wheel. Since SSL_CTX_set_default_verify_paths uses a hardcoded path compiled into the library, this will start failing to load the proper certificates for users on many linux distributions. To avoid this we can use the Go solution of iterating over a list of potential candidates and loading it when found.

fixes #632 

Update: The approach has been modified to use the default cert file and default cert dir to detect whether the installed cryptography is sourced from a manylinux1 wheel. If it is (and the OpenSSL env vars that override default dirs are not set) then we load the fallbacks. This should address most if not all of the previous concerns that have been raised.