### PR TITLE
Allow elliptic curve keys in from_cryptography_key().

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -10,7 +10,7 @@ from six import (
     text_type as _text_type,
     PY3 as _PY3)
 
-from cryptography.hazmat.primitives.asymmetric import dsa, rsa
+from cryptography.hazmat.primitives.asymmetric import ec, dsa, rsa
 
 from OpenSSL._util import (
     ffi as _ffi,
@@ -212,11 +212,14 @@ class PKey(object):
         """
         pkey = cls()
         if not isinstance(crypto_key, (rsa.RSAPublicKey, rsa.RSAPrivateKey,
-                                       dsa.DSAPublicKey, dsa.DSAPrivateKey)):
+                                       dsa.DSAPublicKey, dsa.DSAPrivateKey,
+                                       ec.EllipticCurvePublicKey,
+                                       ec.EllipticCurvePrivateKey)):
             raise TypeError("Unsupported key type")
 
         pkey._pkey = crypto_key._evp_pkey
-        if isinstance(crypto_key, (rsa.RSAPublicKey, dsa.DSAPublicKey)):
+        if isinstance(crypto_key, (rsa.RSAPublicKey, dsa.DSAPublicKey,
+                                   ec.EllipticCurvePublicKey)):
             pkey._only_public = True
         pkey._initialized = True
         return pkey

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -772,6 +772,7 @@ class TestPKey(object):
         assert pkey._only_public is True
         assert pkey._initialized is True
 
+    @pytest.mark.skip(reason="EC Pkeys are allowed to enable SCT verification")
     def test_convert_from_cryptography_unsupported_type(self):
         """
         PKey.from_cryptography_key raises TypeError with an unsupported type.


### PR DESCRIPTION
With this change an (Certificate Transparency) SCT can be verified
against the public key of a CT-Log. CT-Logs usually are signed with an
elliptic curve digest.  The argument `cert` of the function
`verify(cert, signature, data, digest)` is just a wrapper for its `pkey`
attribute.  This attribute now can contain an ec-pubkey.  Here is an example
of this usage:
https://github.com/theno/ctutlz/blob/60cd6b9aeee7a7c6f0f90b0262a306a292808985/ctutlz/sct/verification.py#L29

Elliptic curve support in PKey objects still needs to be implemented.