### PR TITLE
Fixed #461 -- make the tests pass when SSLv3 isn't supported

### DIFF
--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2425,7 +2425,7 @@ class TestConnection(object):
         if SSL_ST_INIT is None:
             v1 = TLSv1_2_METHOD
             v2 = TLSv1_METHOD
-        elif hasattr(_lib, "SSLv3_method()"):
+        elif hasattr(_lib, "SSLv3_method"):
             v1 = TLSv1_METHOD
             v2 = SSLv3_METHOD
          else:

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2419,8 +2419,17 @@ class TestConnection(object):
         with a context using a different SSL method than the `Connection`
         is using, a `OpenSSL.SSL.Error` is raised.
         """
-        v1 = TLSv1_METHOD
-        v2 = TLSv1_2_METHOD
+        # Make this work on both OpenSSL 1.0.0, which doesn't support TLSv1.2
+        # and also on OpenSSL 1.1.0 which doesn't support SSLv3. (SSL_ST_INIT
+        # is a way to check for 1.1.0)
+        if SSL_ST_INIT is None:
+            v1 = TLSv1_2_METHOD
+            v2 = TLSv1_METHOD
+        elif hasattr(_lib, "SSLv3_method()"):
+            v1 = TLSv1_METHOD
+            v2 = SSLv3_METHOD
+         else:
+            pytest.skip("Test requires either OpenSSL 1.1.0 or SSLv3")
 
         key = load_privatekey(FILETYPE_PEM, server_key_pem)
         cert = load_certificate(FILETYPE_PEM, server_cert_pem)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2419,15 +2419,8 @@ class TestConnection(object):
         with a context using a different SSL method than the `Connection`
         is using, a `OpenSSL.SSL.Error` is raised.
         """
-        # Make this work on both OpenSSL 1.0.0, which doesn't support TLSv1.2
-        # and also on OpenSSL 1.1.0 which doesn't support SSLv3. (SSL_ST_INIT
-        # is a way to check for 1.1.0)
-        if SSL_ST_INIT is not None:
-            v1 = TLSv1_METHOD
-            v2 = SSLv3_METHOD
-        else:
-            v1 = TLSv1_2_METHOD
-            v2 = TLSv1_METHOD
+        v1 = TLSv1_2_METHOD
+        v2 = TLSv1_METHOD
 
         key = load_privatekey(FILETYPE_PEM, server_key_pem)
         cert = load_certificate(FILETYPE_PEM, server_cert_pem)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2419,8 +2419,8 @@ class TestConnection(object):
         with a context using a different SSL method than the `Connection`
         is using, a `OpenSSL.SSL.Error` is raised.
         """
-        v1 = TLSv1_2_METHOD
-        v2 = TLSv1_METHOD
+        v1 = TLSv1_METHOD
+        v2 = TLSv1_2_METHOD
 
         key = load_privatekey(FILETYPE_PEM, server_key_pem)
         cert = load_certificate(FILETYPE_PEM, server_cert_pem)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2428,7 +2428,7 @@ class TestConnection(object):
         elif hasattr(_lib, "SSLv3_method"):
             v1 = TLSv1_METHOD
             v2 = SSLv3_METHOD
-         else:
+        else:
             pytest.skip("Test requires either OpenSSL 1.1.0 or SSLv3")
 
         key = load_privatekey(FILETYPE_PEM, server_key_pem)


### PR DESCRIPTION
We no longer support OpenSSL 1.0.0, so TLSv1.2 should always be available and this code can be simplified.