### PR TITLE
dump_privatekey with FILETYPE_TEXT only supports RSA keys

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1779,6 +1779,9 @@ def dump_privatekey(type, pkey, cipher=None, passphrase=None):
     """
     bio = _new_mem_buf()
 
+    if not isinstance(pkey, PKey):
+        raise TypeError("pkey must be a PKey")
+
     if cipher is not None:
         if passphrase is None:
             raise TypeError(

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1799,6 +1799,9 @@ def dump_privatekey(type, pkey, cipher=None, passphrase=None):
     elif type == FILETYPE_ASN1:
         result_code = _lib.i2d_PrivateKey_bio(bio, pkey._pkey)
     elif type == FILETYPE_TEXT:
+        if _lib.EVP_PKEY_id(pkey._pkey) != _lib.EVP_PKEY_RSA:
+            raise TypeError("Only RSA keys are supported for FILETYPE_TEXT")
+
         rsa = _ffi.gc(
             _lib.EVP_PKEY_get1_RSA(pkey._pkey),
             _lib.RSA_free

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2623,6 +2623,10 @@ class TestFunction(object):
         with pytest.raises(TypeError):
             dump_privatekey(FILETYPE_TEXT, key)
 
+    def test_dump_privatekey_invalid_pkey(self):
+        with pytest.raises(TypeError):
+            dump_privatekey(FILETYPE_TEXT, object())
+
     def test_dump_privatekey_unknown_cipher(self):
         """
         `dump_privatekey` raises `ValueError` if called with an unrecognized

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2613,6 +2613,16 @@ class TestFunction(object):
         with pytest.raises(TypeError):
             dump_privatekey(FILETYPE_PEM, key, cipher=GOOD_CIPHER)
 
+    def test_dump_privatekey_not_rsa_key(self):
+        """
+        `dump_privatekey` raises `TypeError` if called with a key that is
+        not RSA.
+        """
+        key = PKey()
+        key.generate_key(TYPE_DSA, 512)
+        with pytest.raises(TypeError):
+            dump_privatekey(FILETYPE_TEXT, key)
+
     def test_dump_privatekey_unknown_cipher(self):
         """
         `dump_privatekey` raises `ValueError` if called with an unrecognized


### PR DESCRIPTION
FILETYPE_TEXT is terrible but everyone hold their nose

Fixes #259. Sort of. As good as it's gonna get for now.