### PR TITLE
move deps to extras

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include             LICENSE MANIFEST.in *.rst tox.ini docs-requirements.txt .coveragerc
+include             LICENSE MANIFEST.in *.rst tox.ini .coveragerc
 exclude             leakcheck
 recursive-include   tests           *.py
 recursive-include   doc             *

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,2 +1,0 @@
-sphinx
-sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -99,4 +99,15 @@ if __name__ == "__main__":
             "cryptography>=1.9",
             "six>=1.5.2"
         ],
+        extras_require={
+            "test": [
+                "flaky",
+                "pretend",
+                "pytest>=3.0.1",
+            ],
+            "docs": [
+                "sphinx",
+                "sphinx_rtd_theme",
+            ]
+        },
     )

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,10 @@ envlist = {pypy,py26,py27,py33,py34,py35,py36}{,-cryptographyMaster,-cryptograph
 whitelist_externals =
     openssl
 passenv = ARCHFLAGS CFLAGS LC_ALL LDFLAGS PATH LD_LIBRARY_PATH TERM
+extras =
+    test
 deps =
     coverage>=4.2
-    pytest>=3.0.1
-    pretend
-    flaky
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
     cryptographyMinimum: cryptography<=1.9
 setenv =
@@ -71,7 +70,8 @@ commands =
     check-manifest
 
 [testenv:docs]
-deps = -rdocs-requirements.txt
+extras =
+    docs
 basepython = python2.7
 commands =
      sphinx-build -W -b html doc doc/_build/html


### PR DESCRIPTION
This will make it so we don't have to keep updating the cryptography jenkinsfile whenever we change a test dep in pyopenssl.