### PR TITLE
added method to export keying material from an ssl connection

### DIFF
--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -3355,15 +3355,15 @@ class TestMemoryBIO(object):
         assert client_conn.client_random() != client_conn.server_random()
 
         # Export key material for other uses.
-        cekm = client_conn.export_keying_material("LABEL", 32)
-        sekm = server_conn.export_keying_material("LABEL", 32)
+        cekm = client_conn.export_keying_material(b'LABEL', 32)
+        sekm = server_conn.export_keying_material(b'LABEL', 32)
         assert cekm is not None
         assert sekm is not None
         assert cekm == sekm
         assert len(sekm) == 32
 
-        cekmc = client_conn.export_keying_material("LABEL", 32, "CONTEXT")
-        sekmc = server_conn.export_keying_material("LABEL", 32, "CONTEXT")
+        cekmc = client_conn.export_keying_material(b'LABEL', 32, b'CONTEXT')
+        sekmc = server_conn.export_keying_material(b'LABEL', 32, b'CONTEXT')
         assert cekmc is not None
         assert sekmc is not None
         assert cekmc == sekmc

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -3354,6 +3354,20 @@ class TestMemoryBIO(object):
         assert server_conn.client_random() != server_conn.server_random()
         assert client_conn.client_random() != client_conn.server_random()
 
+        # Export key material for other uses.
+        cekm = client_conn.export_keying_material("LABEL", 32)
+        sekm = server_conn.export_keying_material("LABEL", 32)
+        assert cekm is not None
+        assert sekm is not None
+        assert cekm == sekm
+        assert len(sekm) == 32
+
+        cekmc = client_conn.export_keying_material("LABEL", 32, "CONTEXT")
+        sekmc = server_conn.export_keying_material("LABEL", 32, "CONTEXT")
+        assert cekmc is not None
+        assert sekmc is not None
+        assert cekmc == sekmc
+
         # Here are the bytes we'll try to send.
         important_message = b'One if by land, two if by sea.'
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -3362,6 +3362,7 @@ class TestMemoryBIO(object):
         assert cekm == sekm
         assert len(sekm) == 32
 
+        # Export key material for other uses with additional context.
         cekmc = client_conn.export_keying_material(b'LABEL', 32, b'CONTEXT')
         sekmc = server_conn.export_keying_material(b'LABEL', 32, b'CONTEXT')
         assert cekmc is not None

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ extras =
 deps =
     coverage>=4.2
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
-    cryptographyMinimum: cryptography<=1.9
+    cryptographyMinimum: cryptography<=2.1
 setenv =
     # Do not allow the executing environment to pollute the test environment
     # with extra packages.


### PR DESCRIPTION
This adds a new method to export keying material from an SSL connection (RFC 5705).

It currently will not work without merging in https://github.com/pyca/cryptography/pull/3878.