### PR TITLE
Provide a destructor for the CRL object

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -2898,7 +2898,7 @@ def load_crl(type, buffer):
         _raise_current_error()
 
     result = CRL.__new__(CRL)
-    result._crl = crl
+    result._crl = _ffi.gc(crl, _lib.X509_CRL_free)
     return result
 
 


### PR DESCRIPTION
This frees the memory allocated for the CRL object. Prior to this
commit, the following script would leak memory:

```
from OpenSSL.crypto import load_crl, FILETYPE_PEM

crl = """
-----BEGIN X509 CRL-----
MIIBfDCB5jANBgkqhkiG9w0BAQsFADCBoDELMAkGA1UEBhMCVVMxCzAJBgNVBAgT
Ak5DMRAwDgYDVQQHEwdSYWxlaWdoMRcwFQYDVQQKEw5GZWRvcmEgUHJvamVjdDEP
MA0GA1UECxMGZmVkbXNnMQ8wDQYDVQQDEwZmZWRtc2cxDzANBgNVBCkTBmZlZG1z
ZzEmMCQGCSqGSIb3DQEJARYXYWRtaW5AZmVkb3JhcHJvamVjdC5vcmcXDTE3MDYx
NTIxMDMwOFoXDTM3MDYxMDIxMDMwOFowFDASAgECFw0xMjA3MTUyMTE4NTJaMA0G
CSqGSIb3DQEBCwUAA4GBAGOBuDxmRFNcYP71LBsCOfFzKij00qpxM01d5/G6+0kM
WJT8oTajMQoY6oISvQDq6TkwEoKc1yl6Ld1/XTtCNOhbybzRBAVf/Lxi/nRPP1JO
qOdZs5jMLLQq1mRJz+MgKHHTDlnvpbjHMuyTss1RblFDr4iZPHMcBNKPGIj3pmpA
-----END X509 CRL-----
"""

for _ in range(0, 1000000):
    load_crl(FILETYPE_PEM, crl)
```

I'm happy to write tests for this change, but I didn't see any existing tests to model my tests from so any pointers would be most welcome. I did see the memoryleak directory, but it I wasn't sure if that's being used/maintained as it didn't work with Python 3.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>