### PR TITLE
enable direct CSR creation

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -830,212 +830,6 @@ X509ExtensionType = deprecated(
 )
 
 
-class X509Req(object):
-    """
-    An X.509 certificate signing requests.
-    """
-
-    def __init__(self):
-        req = _lib.X509_REQ_new()
-        self._req = _ffi.gc(req, _lib.X509_REQ_free)
-        # Default to version 0.
-        self.set_version(0)
-
-    def to_cryptography(self):
-        """
-        Export as a ``cryptography`` certificate signing request.
-
-        :rtype: ``cryptography.x509.CertificateSigningRequest``
-
-        .. versionadded:: 17.1.0
-        """
-        from cryptography.hazmat.backends.openssl.x509 import (
-            _CertificateSigningRequest
-        )
-        backend = _get_backend()
-        return _CertificateSigningRequest(backend, self._req)
-
-    @classmethod
-    def from_cryptography(cls, crypto_req):
-        """
-        Construct based on a ``cryptography`` *crypto_req*.
-
-        :param crypto_req: A ``cryptography`` X.509 certificate signing request
-        :type crypto_req: ``cryptography.x509.CertificateSigningRequest``
-
-        :rtype: PKey
-
-        .. versionadded:: 17.1.0
-        """
-        if not isinstance(crypto_req, x509.CertificateSigningRequest):
-            raise TypeError("Must be a certificate signing request")
-
-        req = cls()
-        req._req = crypto_req._x509_req
-        return req
-
-    def set_pubkey(self, pkey):
-        """
-        Set the public key of the certificate signing request.
-
-        :param pkey: The public key to use.
-        :type pkey: :py:class:`PKey`
-
-        :return: ``None``
-        """
-        set_result = _lib.X509_REQ_set_pubkey(self._req, pkey._pkey)
-        _openssl_assert(set_result == 1)
-
-    def get_pubkey(self):
-        """
-        Get the public key of the certificate signing request.
-
-        :return: The public key.
-        :rtype: :py:class:`PKey`
-        """
-        pkey = PKey.__new__(PKey)
-        pkey._pkey = _lib.X509_REQ_get_pubkey(self._req)
-        _openssl_assert(pkey._pkey != _ffi.NULL)
-        pkey._pkey = _ffi.gc(pkey._pkey, _lib.EVP_PKEY_free)
-        pkey._only_public = True
-        return pkey
-
-    def set_version(self, version):
-        """
-        Set the version subfield (RFC 2459, section 4.1.2.1) of the certificate
-        request.
-
-        :param int version: The version number.
-        :return: ``None``
-        """
-        set_result = _lib.X509_REQ_set_version(self._req, version)
-        _openssl_assert(set_result == 1)
-
-    def get_version(self):
-        """
-        Get the version subfield (RFC 2459, section 4.1.2.1) of the certificate
-        request.
-
-        :return: The value of the version subfield.
-        :rtype: :py:class:`int`
-        """
-        return _lib.X509_REQ_get_version(self._req)
-
-    def get_subject(self):
-        """
-        Return the subject of this certificate signing request.
-
-        This creates a new :class:`X509Name` that wraps the underlying subject
-        name field on the certificate signing request. Modifying it will modify
-        the underlying signing request, and will have the effect of modifying
-        any other :class:`X509Name` that refers to this subject.
-
-        :return: The subject of this certificate signing request.
-        :rtype: :class:`X509Name`
-        """
-        name = X509Name.__new__(X509Name)
-        name._name = _lib.X509_REQ_get_subject_name(self._req)
-        _openssl_assert(name._name != _ffi.NULL)
-
-        # The name is owned by the X509Req structure.  As long as the X509Name
-        # Python object is alive, keep the X509Req Python object alive.
-        name._owner = self
-
-        return name
-
-    def add_extensions(self, extensions):
-        """
-        Add extensions to the certificate signing request.
-
-        :param extensions: The X.509 extensions to add.
-        :type extensions: iterable of :py:class:`X509Extension`
-        :return: ``None``
-        """
-        stack = _lib.sk_X509_EXTENSION_new_null()
-        _openssl_assert(stack != _ffi.NULL)
-
-        stack = _ffi.gc(stack, _lib.sk_X509_EXTENSION_free)
-
-        for ext in extensions:
-            if not isinstance(ext, X509Extension):
-                raise ValueError("One of the elements is not an X509Extension")
-
-            # TODO push can fail (here and elsewhere)
-            _lib.sk_X509_EXTENSION_push(stack, ext._extension)
-
-        add_result = _lib.X509_REQ_add_extensions(self._req, stack)
-        _openssl_assert(add_result == 1)
-
-    def get_extensions(self):
-        """
-        Get X.509 extensions in the certificate signing request.
-
-        :return: The X.509 extensions in this request.
-        :rtype: :py:class:`list` of :py:class:`X509Extension` objects.
-
-        .. versionadded:: 0.15
-        """
-        exts = []
-        native_exts_obj = _lib.X509_REQ_get_extensions(self._req)
-        for i in range(_lib.sk_X509_EXTENSION_num(native_exts_obj)):
-            ext = X509Extension.__new__(X509Extension)
-            ext._extension = _lib.sk_X509_EXTENSION_value(native_exts_obj, i)
-            exts.append(ext)
-        return exts
-
-    def sign(self, pkey, digest):
-        """
-        Sign the certificate signing request with this key and digest type.
-
-        :param pkey: The key pair to sign with.
-        :type pkey: :py:class:`PKey`
-        :param digest: The name of the message digest to use for the signature,
-            e.g. :py:data:`b"sha256"`.
-        :type digest: :py:class:`bytes`
-        :return: ``None``
-        """
-        if pkey._only_public:
-            raise ValueError("Key has only public part")
-
-        if not pkey._initialized:
-            raise ValueError("Key is uninitialized")
-
-        digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
-        if digest_obj == _ffi.NULL:
-            raise ValueError("No such digest method")
-
-        sign_result = _lib.X509_REQ_sign(self._req, pkey._pkey, digest_obj)
-        _openssl_assert(sign_result > 0)
-
-    def verify(self, pkey):
-        """
-        Verifies the signature on this certificate signing request.
-
-        :param PKey key: A public key.
-
-        :return: ``True`` if the signature is correct.
-        :rtype: bool
-
-        :raises OpenSSL.crypto.Error: If the signature is invalid or there is a
-            problem verifying the signature.
-        """
-        if not isinstance(pkey, PKey):
-            raise TypeError("pkey must be a PKey instance")
-
-        result = _lib.X509_REQ_verify(self._req, pkey._pkey)
-        if result <= 0:
-            _raise_current_error()
-
-        return result
-
-
-X509ReqType = deprecated(
-    X509Req, __name__,
-    "X509ReqType has been deprecated, use X509Req instead",
-    DeprecationWarning
-)
-
-
 class X509(object):
     """
     An X.509 certificate.
@@ -1504,6 +1298,212 @@ class X509(object):
 X509Type = deprecated(
     X509, __name__,
     "X509Type has been deprecated, use X509 instead",
+    DeprecationWarning
+)
+
+
+class X509Req(object):
+    """
+    An X.509 certificate signing requests.
+    """
+
+    def __init__(self):
+        req = _lib.X509_REQ_new()
+        self._req = _ffi.gc(req, _lib.X509_REQ_free)
+        # Default to version 0.
+        self.set_version(0)
+
+    def to_cryptography(self):
+        """
+        Export as a ``cryptography`` certificate signing request.
+
+        :rtype: ``cryptography.x509.CertificateSigningRequest``
+
+        .. versionadded:: 17.1.0
+        """
+        from cryptography.hazmat.backends.openssl.x509 import (
+            _CertificateSigningRequest
+        )
+        backend = _get_backend()
+        return _CertificateSigningRequest(backend, self._req)
+
+    @classmethod
+    def from_cryptography(cls, crypto_req):
+        """
+        Construct based on a ``cryptography`` *crypto_req*.
+
+        :param crypto_req: A ``cryptography`` X.509 certificate signing request
+        :type crypto_req: ``cryptography.x509.CertificateSigningRequest``
+
+        :rtype: PKey
+
+        .. versionadded:: 17.1.0
+        """
+        if not isinstance(crypto_req, x509.CertificateSigningRequest):
+            raise TypeError("Must be a certificate signing request")
+
+        req = cls()
+        req._req = crypto_req._x509_req
+        return req
+
+    def set_pubkey(self, pkey):
+        """
+        Set the public key of the certificate signing request.
+
+        :param pkey: The public key to use.
+        :type pkey: :py:class:`PKey`
+
+        :return: ``None``
+        """
+        set_result = _lib.X509_REQ_set_pubkey(self._req, pkey._pkey)
+        _openssl_assert(set_result == 1)
+
+    def get_pubkey(self):
+        """
+        Get the public key of the certificate signing request.
+
+        :return: The public key.
+        :rtype: :py:class:`PKey`
+        """
+        pkey = PKey.__new__(PKey)
+        pkey._pkey = _lib.X509_REQ_get_pubkey(self._req)
+        _openssl_assert(pkey._pkey != _ffi.NULL)
+        pkey._pkey = _ffi.gc(pkey._pkey, _lib.EVP_PKEY_free)
+        pkey._only_public = True
+        return pkey
+
+    def set_version(self, version):
+        """
+        Set the version subfield (RFC 2459, section 4.1.2.1) of the certificate
+        request.
+
+        :param int version: The version number.
+        :return: ``None``
+        """
+        set_result = _lib.X509_REQ_set_version(self._req, version)
+        _openssl_assert(set_result == 1)
+
+    def get_version(self):
+        """
+        Get the version subfield (RFC 2459, section 4.1.2.1) of the certificate
+        request.
+
+        :return: The value of the version subfield.
+        :rtype: :py:class:`int`
+        """
+        return _lib.X509_REQ_get_version(self._req)
+
+    def get_subject(self):
+        """
+        Return the subject of this certificate signing request.
+
+        This creates a new :class:`X509Name` that wraps the underlying subject
+        name field on the certificate signing request. Modifying it will modify
+        the underlying signing request, and will have the effect of modifying
+        any other :class:`X509Name` that refers to this subject.
+
+        :return: The subject of this certificate signing request.
+        :rtype: :class:`X509Name`
+        """
+        name = X509Name.__new__(X509Name)
+        name._name = _lib.X509_REQ_get_subject_name(self._req)
+        _openssl_assert(name._name != _ffi.NULL)
+
+        # The name is owned by the X509Req structure.  As long as the X509Name
+        # Python object is alive, keep the X509Req Python object alive.
+        name._owner = self
+
+        return name
+
+    def add_extensions(self, extensions):
+        """
+        Add extensions to the certificate signing request.
+
+        :param extensions: The X.509 extensions to add.
+        :type extensions: iterable of :py:class:`X509Extension`
+        :return: ``None``
+        """
+        stack = _lib.sk_X509_EXTENSION_new_null()
+        _openssl_assert(stack != _ffi.NULL)
+
+        stack = _ffi.gc(stack, _lib.sk_X509_EXTENSION_free)
+
+        for ext in extensions:
+            if not isinstance(ext, X509Extension):
+                raise ValueError("One of the elements is not an X509Extension")
+
+            # TODO push can fail (here and elsewhere)
+            _lib.sk_X509_EXTENSION_push(stack, ext._extension)
+
+        add_result = _lib.X509_REQ_add_extensions(self._req, stack)
+        _openssl_assert(add_result == 1)
+
+    def get_extensions(self):
+        """
+        Get X.509 extensions in the certificate signing request.
+
+        :return: The X.509 extensions in this request.
+        :rtype: :py:class:`list` of :py:class:`X509Extension` objects.
+
+        .. versionadded:: 0.15
+        """
+        exts = []
+        native_exts_obj = _lib.X509_REQ_get_extensions(self._req)
+        for i in range(_lib.sk_X509_EXTENSION_num(native_exts_obj)):
+            ext = X509Extension.__new__(X509Extension)
+            ext._extension = _lib.sk_X509_EXTENSION_value(native_exts_obj, i)
+            exts.append(ext)
+        return exts
+
+    def sign(self, pkey, digest):
+        """
+        Sign the certificate signing request with this key and digest type.
+
+        :param pkey: The key pair to sign with.
+        :type pkey: :py:class:`PKey`
+        :param digest: The name of the message digest to use for the signature,
+            e.g. :py:data:`b"sha256"`.
+        :type digest: :py:class:`bytes`
+        :return: ``None``
+        """
+        if pkey._only_public:
+            raise ValueError("Key has only public part")
+
+        if not pkey._initialized:
+            raise ValueError("Key is uninitialized")
+
+        digest_obj = _lib.EVP_get_digestbyname(_byte_string(digest))
+        if digest_obj == _ffi.NULL:
+            raise ValueError("No such digest method")
+
+        sign_result = _lib.X509_REQ_sign(self._req, pkey._pkey, digest_obj)
+        _openssl_assert(sign_result > 0)
+
+    def verify(self, pkey):
+        """
+        Verifies the signature on this certificate signing request.
+
+        :param PKey key: A public key.
+
+        :return: ``True`` if the signature is correct.
+        :rtype: bool
+
+        :raises OpenSSL.crypto.Error: If the signature is invalid or there is a
+            problem verifying the signature.
+        """
+        if not isinstance(pkey, PKey):
+            raise TypeError("pkey must be a PKey instance")
+
+        result = _lib.X509_REQ_verify(self._req, pkey._pkey)
+        if result <= 0:
+            _raise_current_error()
+
+        return result
+
+
+X509ReqType = deprecated(
+    X509Req, __name__,
+    "X509ReqType has been deprecated, use X509Req instead",
     DeprecationWarning
 )
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -719,8 +719,8 @@ class X509Extension(object):
                 raise TypeError("issuer must be an X509 instance")
             ctx.issuer_cert = issuer._x509
         if subject is not None:
-            if not isinstance(subject, X509):
-                raise TypeError("subject must be an X509 instance")
+            if not isinstance(subject, (X509, X509Req)):
+                raise TypeError("subject must be an X509 or X509Req instance")
             ctx.subject_cert = subject._x509
 
         if critical:
@@ -1302,12 +1302,13 @@ X509Type = deprecated(
 )
 
 
-class X509Req(object):
+class X509Req(X509):
     """
     An X.509 certificate signing requests.
     """
 
     def __init__(self):
+        super(X509Req, self).__init__()
         req = _lib.X509_REQ_new()
         self._req = _ffi.gc(req, _lib.X509_REQ_free)
         # Default to version 0.


### PR DESCRIPTION
By deriving the class X509Req from X509 certificate requests can be generated from simple dictionaries, thus allowing very easy request templates.
Additionally the keywords from the OpenSSL can be used, which is very beneficial when the user wants to transition existing configurations.

Please see the following example for template based request generation:
```python
from cryptography.hazmat.backends import default_backend
from cryptography.hazmat.primitives.asymmetric import rsa, ec
from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, NoEncryption
from OpenSSL import crypto
from OpenSSL.crypto import X509Extension

def gen_ecdsa_key(curve_name, length):
    ec_curve = crypto.get_elliptic_curve(curve_name)
    key = ec.generate_private_key(ec_curve, default_backend())
    key_pem = key.private_bytes(encoding=Encoding.PEM,
            format=PrivateFormat.TraditionalOpenSSL,
            encryption_algorithm=NoEncryption())
    return crypto.load_privatekey(crypto.FILETYPE_PEM, key_pem)

class WrapExtension(object):
    """wrapper for OpenSSL.crypto.X509Extension
    Allows to Wrap an extension in a template dict and build it on certificate/
    request generation.
    """
    def __init__(self, name, value, critical=False):
        self.name = name
        self.value = value
        self.critical = critical
        self.subject = None
        self.issuer = None

    def build_extension(self):
        obj = X509Extension(self.name, self.critical, self.value,
                self.subject, self.issuer)
        return obj


def create_cert_req(pkey, digest="sha256", **name):
    req = crypto.X509Req()
    subj = req.get_subject()
    wrapped_extensions = []

    for key, value in name.items():
        if "extensions" == key:
            #delay extension construction till all req-params are set
            wrapped_extensions = value
        else:
            setattr(subj, key, value)
    req.set_pubkey(pkey)

    # build extensions
    extensions = []
    for e in wrapped_extensions:
        e.subject = req
        extensions.append(e.build_extension())

    req.add_extensions(extensions)
    req.sign(pkey, digest)
    return req


CERT_TMPL_1 = { "countryName": "DE",
    "organizationName": "Test CA",
    "organizationalUnitName": "Example AG",
    "commonName": "empty",
    "stateOrProvinceName": "Saxony",
    "localityName": "Dresden",
    "emailAddress": "user@example.com",
    "extensions": [WrapExtension('keyUsage', 'digitalSignature', True),
                   WrapExtension('extendedKeyUsage', 'clientAuth'),
                   WrapExtension('subjectKeyIdentifier', 'hash')]
    }


def request_from_tmpl(cert_tmpl, user):
    """create a certificate request based on a template-dictionary """
    key = gen_ecdsa_key("secp256k1", 256)
    req_param = dict(cert_tmpl) #copy template
    req_param["commonName"] = user
    req_param["emailAddress"] = user + "@example.com"
    req = create_cert_req(key, **req_param)
    return req


request_from_tmpl(CERT_TMPL_1, "user1234")
```