### PR TITLE
Pin pytest until we drop 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,9 @@ if __name__ == "__main__":
             "test": [
                 "flaky",
                 "pretend",
-                "pytest>=3.0.1",
+                # pytest 3.3 doesn't support Python 2.6 anymore.
+                # Remove this pin once we drop Python 2.6 too.
+                "pytest>=3.0.1,<3.3.0",
             ],
             "docs": [
                 "sphinx",


### PR DESCRIPTION
pytest 3.3 drops Python 2.6 and (ironically) Python 3.3.

I would of course much prefer to drop 2.6 and cryptography 2.2 is dropping 2.6 so an alternative PR to this one would be to kill 2.6 with fire if cryptography 2.2 is on a realistic horizon.

We need to do either of those two because otherwise our tests will fail.