### PR TITLE
fix a memory leak and a potential UAF and also #722

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ The third digit is only for regressions.
 Backward-incompatible changes:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*none*
+* The minimum ``cryptography`` version is now 2.1.4.
 
 
 Deprecations:
@@ -23,8 +23,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-
-*none*
+- Fixed a potential use-after-free in the verify callback and resolved a memory leak when loading PKCS12 files with ``cacerts``.
+  `#723 <https://github.com/pyca/pyopenssl/pull/723>`_
 
 ----
 

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             # Fix cryptographyMinimum in tox.ini when changing this!
-            "cryptography>=1.9",
+            "cryptography>=2.1.4",
             "six>=1.5.2"
         ],
         extras_require={

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -310,8 +310,7 @@ class _VerifyHelper(_CallbackExceptionHelper):
         @wraps(callback)
         def wrapper(ok, store_ctx):
             x509 = _lib.X509_STORE_CTX_get_current_cert(store_ctx)
-            res = _lib.X509_up_ref(x509)
-            _openssl_assert(res == 1)
+            _lib.X509_up_ref(x509)
             cert = X509._from_raw_x509_ptr(x509)
             error_number = _lib.X509_STORE_CTX_get_error(store_ctx)
             error_depth = _lib.X509_STORE_CTX_get_error_depth(store_ctx)

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -309,8 +309,10 @@ class _VerifyHelper(_CallbackExceptionHelper):
 
         @wraps(callback)
         def wrapper(ok, store_ctx):
-            cert = X509.__new__(X509)
-            cert._x509 = _lib.X509_STORE_CTX_get_current_cert(store_ctx)
+            x509 = _lib.X509_STORE_CTX_get_current_cert(store_ctx)
+            res = _lib.X509_up_ref(x509)
+            _openssl_assert(res == 1)
+            cert = X509._from_raw_x509_ptr(x509)
             error_number = _lib.X509_STORE_CTX_get_error(store_ctx)
             error_depth = _lib.X509_STORE_CTX_get_error_depth(store_ctx)
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -3058,8 +3058,7 @@ def load_pkcs12(buffer, passphrase=None):
         pycert = None
         friendlyname = None
     else:
-        pycert = X509.__new__(X509)
-        pycert._x509 = _ffi.gc(cert[0], _lib.X509_free)
+        pycert = X509._from_raw_x509_ptr(cert[0])
 
         friendlyname_length = _ffi.new("int*")
         friendlyname_buffer = _lib.X509_alias_get0(
@@ -3073,8 +3072,8 @@ def load_pkcs12(buffer, passphrase=None):
 
     pycacerts = []
     for i in range(_lib.sk_X509_num(cacerts)):
-        pycacert = X509.__new__(X509)
-        pycacert._x509 = _lib.sk_X509_value(cacerts, i)
+        x509 = _lib.sk_X509_value(cacerts, i)
+        pycacert = X509._from_raw_x509_ptr(x509)
         pycacerts.append(pycacert)
     if not pycacerts:
         pycacerts = None

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ extras =
 deps =
     coverage>=4.2
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
-    cryptographyMinimum: cryptography<=1.9
+    cryptographyMinimum: cryptography==2.1.4
 setenv =
     # Do not allow the executing environment to pollute the test environment
     # with extra packages.


### PR DESCRIPTION
In the callback we were creating an X509 object that didn't own its own memory so if you retained a reference to it after the callback completed you could end up in a UAF situation.

In PKCS12 we freed the stack but freeing the stack doesn't free the underlying objects. This meant that any PKCS12 with cacerts was leaking memory every load.

Finally, we clean up one other little area where we can use `_from_raw_x509_ptr`.

This needs CHANGELOG entries, but it also can't be merged until we backport https://github.com/pyca/cryptography/pull/4028 and release a 2.1.4 (and then upgrade our minimum dep in pyOpenSSL to 2.1.4, d'oh)