### PR TITLE
Add Connection.get_certificate method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Added ``Connection.get_certificate`` to retrieve the local certificate.
+  `#733 <https://github.com/pyca/pyopenssl/pull/733>`_
 
 
 ----

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2156,6 +2156,18 @@ class Connection(object):
         """
         return self._socket.shutdown(*args, **kwargs)
 
+    def get_certificate(self):
+        """
+        Retrieve the local certificate (if any)
+
+        :return: The local certificate
+        """
+        cert = _lib.SSL_get_certificate(self._ssl)
+        if cert != _ffi.NULL:
+            _lib.X509_up_ref(cert)
+            return X509._from_raw_x509_ptr(cert)
+        return None
+
     def get_peer_certificate(self):
         """
         Retrieve the other side's certificate (if any)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2388,6 +2388,31 @@ class TestConnection(object):
         with pytest.raises(NotImplementedError):
             conn.makefile()
 
+    def test_get_certificate(self):
+        """
+        `Connection.get_certificate` returns the local certificate.
+        """
+        chain = _create_certificate_chain()
+        [(cakey, cacert), (ikey, icert), (skey, scert)] = chain
+
+        context = Context(TLSv1_METHOD)
+        context.use_certificate(scert)
+        client = Connection(context, None)
+        cert = client.get_certificate()
+        assert cert is not None
+        assert "Server Certificate" == cert.get_subject().CN
+
+    def test_get_certificate_none(self):
+        """
+        `Connection.get_certificate` returns the local certificate.
+
+        If there is no certificate, it returns None.
+        """
+        context = Context(TLSv1_METHOD)
+        client = Connection(context, None)
+        cert = client.get_certificate()
+        assert cert is None
+
     def test_get_peer_cert_chain(self):
         """
         `Connection.get_peer_cert_chain` returns a list of certificates


### PR DESCRIPTION
This makes it possible to retrieve the local certificate (if any)
for a Connection.

An example where this is useful is when negotiating a DTLS-SRTP
connection, the fingerprint of the local certificate needs to be
communicated to the remote party out-of-band via SDP.

This depends on:
https://github.com/pyca/cryptography/pull/4100