### PR TITLE
Make sure a NotImplementedError is always raised on Connection.makefile()

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2019,7 +2019,7 @@ class Connection(object):
             result.append(pyname)
         return result
 
-    def makefile(self, mode=None, bufsize=None):
+    def makefile(self, *args, **kwargs):
         """
         The makefile() method is not implemented, since there is no dup
         semantics for SSL connections

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2019,7 +2019,7 @@ class Connection(object):
             result.append(pyname)
         return result
 
-    def makefile(self):
+    def makefile(self, mode=None, bufsize=None):
         """
         The makefile() method is not implemented, since there is no dup
         semantics for SSL connections


### PR DESCRIPTION
With this patch, code which calls (for example) `conn.makefile('rb')` will get a `NotImplementedError` instead of a confusing `TypeError`:

    TypeError: makefile() takes 1 positional argument but 2 were given