### PR TITLE
Change X509_NAME_oneline for X509_NAME_print_ex [Fixes #745]

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -644,8 +644,9 @@ class X509Name(object):
         String representation of an X509Name
         """
         bio = _new_mem_buf()
-        res = _lib.X509_NAME_print_ex(bio, self._name, 0, _lib.XN_FLAG_RFC2253)
-        assert res == 1
+        print_result = _lib.X509_NAME_print_ex(
+                           bio, self._name, 0, _lib.XN_FLAG_RFC2253)
+        _openssl_assert(print_result >= 0)
         return "<X509Name object '%s'>" % (
             _native(_bio_to_string(bio)),)
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -645,6 +645,7 @@ class X509Name(object):
         """
         bio = _new_mem_buf()
         res = _lib.X509_NAME_print_ex(bio, self._name, 0, _lib.XN_FLAG_RFC2253)
+        assert res == 1
         return "<X509Name object '%s'>" % (
             _native(_bio_to_string(bio)),)
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -643,13 +643,10 @@ class X509Name(object):
         """
         String representation of an X509Name
         """
-        result_buffer = _ffi.new("char[]", 512)
-        format_result = _lib.X509_NAME_oneline(
-            self._name, result_buffer, len(result_buffer))
-        _openssl_assert(format_result != _ffi.NULL)
-
+        bio = _new_mem_buf()
+        res = _lib.X509_NAME_print_ex(bio, self._name, 0, _lib.XN_FLAG_RFC2253)
         return "<X509Name object '%s'>" % (
-            _native(_ffi.string(result_buffer)),)
+            _native(_bio_to_string(bio)),)
 
     def hash(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1090,7 +1090,7 @@ class TestX509Name(object):
         a description of the type and the NIDs which have been set on it.
         """
         name = x509_name(commonName="foo", emailAddress="bar")
-        assert repr(name) == "<X509Name object '/emailAddress=bar/CN=foo'>"
+        assert repr(name) == "<X509Name object 'emailAddress=bar,CN=foo'>"
 
     def test_comparison(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1087,10 +1087,11 @@ class TestX509Name(object):
     def test_repr(self):
         """
         `repr` passed an `X509Name` instance should return a string containing
-        a description of the type and the NIDs which have been set on it.
+        a description of the type and the NIDs which have been set on it.  The
+        internal string object is now formattted according to XN_FLAG_RFC2212.
         """
         name = x509_name(commonName="foo", emailAddress="bar")
-        assert repr(name) == "<X509Name object 'emailAddress=bar,CN=foo'>"
+        assert repr(name) == "<X509Name object 'CN=foo,emailAddress=bar'>"
 
     def test_comparison(self):
         """


### PR DESCRIPTION
Additionally, makes stringified part conformant to RFC2253