### PR TITLE
Fix SSL_CTX_set_tlsext_servername_callback type signature.

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1367,7 +1367,7 @@ class Context(object):
             return 0
 
         self._tlsext_servername_callback = _ffi.callback(
-            "int (*)(const SSL *, int *, void *)", wrapper)
+            "int (*)(SSL *, int *, void *)", wrapper)
         _lib.SSL_CTX_set_tlsext_servername_callback(
             self._context, self._tlsext_servername_callback)
 


### PR DESCRIPTION
See also https://github.com/pyca/cryptography/pull/4227. I suspect this
is a no-op since cffi is probably just generating its own function
stubs and every ABI makes const and non-const pointers the same. Still,
better to match things. (In C, this would be undefined behavior.)