### PR TITLE
fix wantWriteError to error even with big socket buffers

### DIFF
--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2632,7 +2632,7 @@ class TestConnection(object):
         # always happen on all platforms (FreeBSD and OS X particular) for the
         # very last bit of available buffer space.
         msg = b"x"
-        for i in range(1024 * 1024 * 4):
+        for i in range(1024 * 1024 * 64):
             try:
                 client_socket.send(msg)
             except error as e:


### PR DESCRIPTION
My system apparently has larger socket buffers than this test assumes, so it fails.
(Debian 9, Linux 4.16, Python 3.7) 
So let's increase the size of the buffers such that it works for me.
This was the smallest power of 2 that worked.