### PR TITLE
X509Store.add_cert no longer raises an error on duplicate cert

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,8 @@ The third digit is only for regressions.
 Backward-incompatible changes:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*none*
+- ``X509Store.add_cert`` no longer raises an error if you add a duplicate cert.
+  `#787 <https://github.com/pyca/pyopenssl/pull/787>`_
 
 
 Deprecations:
@@ -23,8 +24,7 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-- ``X509Store.add_cert`` no longer raises an error if you add a duplicate cert.
-  `#787 <https://github.com/pyca/pyopenssl/pull/787>`_
+*none*
 
 
 ----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- ``X509Store.add_cert`` no longer raises an error if you add a duplicate cert.
+  `#787 <https://github.com/pyca/pyopenssl/pull/787>`_
 
 
 ----

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2016,16 +2016,15 @@ class TestX509Store(object):
         with pytest.raises(TypeError):
             store.add_cert(cert)
 
-    def test_add_cert_rejects_duplicate(self):
+    def test_add_cert_accepts_duplicate(self):
         """
-        `X509Store.add_cert` raises `OpenSSL.crypto.Error` if an attempt is
-        made to add the same certificate to the store more than once.
+        `X509Store.add_cert` doesn't raise `OpenSSL.crypto.Error` if an attempt
+        is made to add the same certificate to the store more than once.
         """
         cert = load_certificate(FILETYPE_PEM, cleartextCertificatePEM)
         store = X509Store()
         store.add_cert(cert)
-        with pytest.raises(Error):
-            store.add_cert(cert)
+        store.add_cert(cert)
 
 
 class TestPKCS12(object):


### PR DESCRIPTION
OpenSSL 1.1.0i changed X509_STORE_add_cert such that it no longer raises an error if a duplicate cert is added. This patch makes it so we behave consistently (and do not error) on all versions.