### PR TITLE
Updated a couple of tests to run with multiple TLS versions.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 # Copyright (c) The pyOpenSSL developers
 # See LICENSE for details.
 
+from OpenSSL.SSL import (
+    Context,
+    SSLv2_METHOD, SSLv3_METHOD, SSLv23_METHOD, TLSv1_METHOD,
+    TLSv1_1_METHOD, TLSv1_2_METHOD)
 from tempfile import mktemp
 
 import pytest
@@ -24,3 +28,26 @@ def tmpfile(tmpdir):
     The file will be cleaned up after the test run.
     """
     return mktemp(dir=tmpdir.dirname).encode("utf-8")
+
+def _get_tls_versions():
+    versions = [TLSv1_METHOD, SSLv23_METHOD]
+    ids = ["TLSv1_METHOD", "SSLv23_METHOD"]
+    for (tls_version, name) in [ (SSLv2_METHOD, "SSLv2_METHOD"), 
+                                 (SSLv3_METHOD, "SSLv3_METHOD"),
+                                 (TLSv1_1_METHOD, "TLSv1_1_METHOD"),
+                                 (TLSv1_2_METHOD, "TLSv1_2_METHOD")
+                                ]:
+        try:
+            Context(tls_version)
+            versions.append(tls_version)
+            ids.append(name)
+        except Exception:
+            # Some versions of OpenSSL have SSLv2 / TLSv1.1 / TLSv1.2, some
+            # don't.  Difficult to say in advance.
+            pass
+    return versions, ids
+
+def pytest_generate_tests(metafunc):
+    if 'tls_version' in metafunc.fixturenames:
+        versions, ids = _get_tls_versions()
+        metafunc.parametrize("tls_version", versions, ids=ids)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1301,19 +1301,19 @@ class TestContext(object):
 
         handshake_in_memory(clientConnection, serverConnection)
 
-    def test_set_verify_callback_exception(self):
+    def test_set_verify_callback_exception(self, tls_version):
         """
         If the verify callback passed to `Context.set_verify` raises an
         exception, verification fails and the exception is propagated to the
         caller of `Connection.do_handshake`.
         """
-        serverContext = Context(TLSv1_METHOD)
+        serverContext = Context(tls_version)
         serverContext.use_privatekey(
             load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM))
         serverContext.use_certificate(
             load_certificate(FILETYPE_PEM, cleartextCertificatePEM))
 
-        clientContext = Context(TLSv1_METHOD)
+        clientContext = Context(tls_version)
 
         def verify_callback(*args):
             raise Exception("silly verify failure")
@@ -1324,7 +1324,7 @@ class TestContext(object):
 
         assert "silly verify failure" == str(exc.value)
 
-    def test_add_extra_chain_cert(self, tmpdir):
+    def test_add_extra_chain_cert(self, tmpdir, tls_version):
         """
         `Context.add_extra_chain_cert` accepts an `X509`
         instance to add to the certificate chain.
@@ -1354,14 +1354,14 @@ class TestContext(object):
                 f.write(dump_privatekey(FILETYPE_PEM, key).decode('ascii'))
 
         # Create the server context
-        serverContext = Context(TLSv1_METHOD)
+        serverContext = Context(tls_version)
         serverContext.use_privatekey(skey)
         serverContext.use_certificate(scert)
         # The client already has cacert, we only need to give them icert.
         serverContext.add_extra_chain_cert(icert)
 
         # Create the client
-        clientContext = Context(TLSv1_METHOD)
+        clientContext = Context(tls_version)
         clientContext.set_verify(
             VERIFY_PEER | VERIFY_FAIL_IF_NO_PEER_CERT, verify_cb)
         clientContext.load_verify_locations(str(tmpdir.join("ca.pem")))

--- a/tests/test_tsafe.py
+++ b/tests/test_tsafe.py
@@ -5,7 +5,7 @@
 Unit tests for `OpenSSL.tsafe`.
 """
 
-from OpenSSL.SSL import TLSv1_METHOD, Context
+from OpenSSL.SSL import Context
 from OpenSSL.tsafe import Connection
 
 

--- a/tests/test_tsafe.py
+++ b/tests/test_tsafe.py
@@ -13,11 +13,11 @@ class TestConnection(object):
     """
     Tests for `OpenSSL.tsafe.Connection`.
     """
-    def test_instantiation(self):
+    def test_instantiation(self, tls_version):
         """
         `OpenSSL.tsafe.Connection` can be instantiated.
         """
         # The following line should not throw an error.  This isn't an ideal
         # test.  It would be great to refactor the other Connection tests so
         # they could automatically be applied to this class too.
-        Connection(Context(TLSv1_METHOD), None)
+        Connection(Context(tls_version), None)


### PR DESCRIPTION
This commit adds a pytest.parametrize "tls_version" parameter so that tests can be run against multiple versions of TLS to fix #758. All versions supported by the installed OpenSSL library are used.