### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/examples/proxy.py
+++ b/examples/proxy.py
@@ -8,6 +8,7 @@
 #
 # $Id: proxy.py,v 1.2 2004/07/22 12:01:25 martin Exp $
 
+from __future__ import print_function
 import sys
 import socket
 import string
@@ -16,9 +17,9 @@ from OpenSSL import SSL
 
 
 def usage(exit_code=0):
-    print "Usage: %s server[:port] proxy[:port]" % sys.argv[0]
-    print "  Connects SSL to the specified server (port 443 by default)"
-    print "    using the specified proxy (port 8080 by default)"
+    print("Usage: %s server[:port] proxy[:port]" % sys.argv[0])
+    print("  Connects SSL to the specified server (port 443 by default)")
+    print("    using the specified proxy (port 8080 by default)")
     sys.exit(exit_code)
 
 
@@ -44,13 +45,13 @@ def run(server, proxy):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         s.connect(proxy)
-    except socket.error, e:
-        print "Unable to connect to %s:%s %s" % (proxy[0], proxy[1], str(e))
+    except socket.error as e:
+        print("Unable to connect to %s:%s %s" % (proxy[0], proxy[1], str(e)))
         sys.exit(-1)
 
     # Use the CONNECT method to get a connection to the actual server
     s.send("CONNECT %s:%s HTTP/1.0\n\n" % (server[0], server[1]))
-    print "Proxy response: %s" % string.strip(s.recv(1024))
+    print("Proxy response: %s" % string.strip(s.recv(1024)))
 
     ctx = SSL.Context(SSL.SSLv23_METHOD)
     conn = SSL.Connection(ctx, s)
@@ -61,16 +62,16 @@ def run(server, proxy):
     # start using HTTP
 
     conn.send("HEAD / HTTP/1.0\n\n")
-    print "Sever response:"
-    print "-" * 40
-    while 1:
+    print("Sever response:")
+    print("-" * 40)
+    while True:
         try:
             buff = conn.recv(4096)
         except SSL.ZeroReturnError:
             # we're done
             break
 
-        print buff,
+        print(buff, end=' ')
 
 
 if __name__ == '__main__':

--- a/examples/simple/client.py
+++ b/examples/simple/client.py
@@ -45,7 +45,7 @@ ctx.load_verify_locations(os.path.join(dir, 'CA.cert'))
 sock = SSL.Connection(ctx, socket.socket(socket.AF_INET, socket.SOCK_STREAM))
 sock.connect((sys.argv[1], int(sys.argv[2])))
 
-while 1:
+while True:
     line = sys.stdin.readline()
     if line == '':
         break

--- a/examples/simple/server.py
+++ b/examples/simple/server.py
@@ -68,7 +68,7 @@ def dropClient(cli, errors=None):
     cli.close()
 
 
-while 1:
+while True:
     try:
         r, w, _ = select.select(
             [server] + list(clients.keys()), list(writers.keys()), []

--- a/examples/sni/client.py
+++ b/examples/sni/client.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (C) Jean-Paul Calderone
 # See LICENSE for details.
 
@@ -13,21 +14,21 @@ def main():
     by argv[1], of it.
     """
     if len(argv) < 2:
-        print 'Usage: %s <hostname>' % (argv[0],)
+        print('Usage: %s <hostname>' % (argv[0],))
         return 1
 
     client = socket()
 
-    print 'Connecting...',
+    print('Connecting...', end=' ')
     stdout.flush()
     client.connect(('127.0.0.1', 8443))
-    print 'connected', client.getpeername()
+    print('connected', client.getpeername())
 
     client_ssl = Connection(Context(TLSv1_METHOD), client)
     client_ssl.set_connect_state()
     client_ssl.set_tlsext_host_name(argv[1])
     client_ssl.do_handshake()
-    print 'Server subject is', client_ssl.get_peer_certificate().get_subject()
+    print('Server subject is', client_ssl.get_peer_certificate().get_subject())
     client_ssl.close()
 
 

--- a/examples/sni/server.py
+++ b/examples/sni/server.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (C) Jean-Paul Calderone
 # See LICENSE for details.
 
@@ -29,10 +30,10 @@ def main():
     port.bind(('', 8443))
     port.listen(3)
 
-    print 'Accepting...',
+    print('Accepting...', end=' ')
     stdout.flush()
     server, addr = port.accept()
-    print 'accepted', addr
+    print('accepted', addr)
 
     server_context = Context(TLSv1_METHOD)
     server_context.set_tlsext_servername_callback(pick_certificate)

--- a/leakcheck/context-info-callback.py
+++ b/leakcheck/context-info-callback.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (C) Jean-Paul Calderone
 # See LICENSE for details.
 #
@@ -58,7 +59,7 @@ def go():
 
     called = []
     def info(conn, where, ret):
-        print count.next()
+        print(next(count))
         called.append(None)
     context = Context(TLSv1_METHOD)
     context.set_info_callback(info)
@@ -67,7 +68,7 @@ def go():
     context.use_privatekey(
         load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM))
 
-    while 1:
+    while True:
         client = socket()
         client.setblocking(False)
         client.connect_ex(port.getsockname())
@@ -90,7 +91,7 @@ def go():
                     pass
 
 
-threads = [Thread(target=go, args=()) for i in xrange(2)]
+threads = [Thread(target=go, args=()) for i in range(2)]
 for th in threads:
     th.start()
 for th in threads:

--- a/leakcheck/context-passphrase-callback.py
+++ b/leakcheck/context-passphrase-callback.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (C) Jean-Paul Calderone
 # See LICENSE for details.
 #
@@ -15,19 +16,19 @@ from OpenSSL.crypto import TYPE_RSA, FILETYPE_PEM, PKey, dump_privatekey
 
 k = PKey()
 k.generate_key(TYPE_RSA, 128)
-file('pkey.pem', 'w').write(dump_privatekey(FILETYPE_PEM, k, "blowfish", "foobar"))
+open('pkey.pem', 'w').write(dump_privatekey(FILETYPE_PEM, k, "blowfish", "foobar"))
 
 count = count()
 def go():
     def cb(a, b, c):
-        print count.next()
+        print(next(count))
         return "foobar"
     c = Context(TLSv1_METHOD)
     c.set_passwd_cb(cb)
-    while 1:
+    while True:
         c.use_privatekey_file('pkey.pem')
 
-threads = [Thread(target=go, args=()) for i in xrange(2)]
+threads = [Thread(target=go, args=()) for i in range(2)]
 for th in threads:
     th.start()
 for th in threads:

--- a/leakcheck/context-verify-callback.py
+++ b/leakcheck/context-verify-callback.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (C) Jean-Paul Calderone
 # See LICENSE for details.
 #
@@ -58,7 +59,7 @@ def go():
 
     called = []
     def info(*args):
-        print count.next()
+        print(next(count))
         called.append(None)
         return 1
     context = Context(TLSv1_METHOD)
@@ -68,7 +69,7 @@ def go():
     context.use_privatekey(
         load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM))
 
-    while 1:
+    while True:
         client = socket()
         client.setblocking(False)
         client.connect_ex(port.getsockname())
@@ -87,11 +88,11 @@ def go():
             for ssl in clientSSL, serverSSL:
                 try:
                     ssl.send('foo')
-                except WantReadError, e:
+                except WantReadError as e:
                     pass
 
 
-threads = [Thread(target=go, args=()) for i in xrange(2)]
+threads = [Thread(target=go, args=()) for i in range(2)]
 for th in threads:
     th.start()
 for th in threads:

--- a/leakcheck/crypto.py
+++ b/leakcheck/crypto.py
@@ -1,7 +1,10 @@
+from __future__ import print_function
 # Copyright (C) Jean-Paul Calderone
 # See LICENSE for details.
 
 import sys
+
+from six.moves import xrange
 
 from OpenSSL.crypto import (
     FILETYPE_PEM, TYPE_DSA, Error, PKey, X509, load_privatekey, CRL, Revoked,
@@ -162,7 +165,7 @@ class Checker_EllipticCurve(BaseChecker):
 
 
 def vmsize():
-    return [x for x in file('/proc/self/status').readlines() if 'VmSize' in x]
+    return [x for x in open('/proc/self/status').readlines() if 'VmSize' in x]
 
 
 def main(iterations='1000'):
@@ -170,13 +173,13 @@ def main(iterations='1000'):
     for klass in globals():
         if klass.startswith('Checker_'):
             klass = globals()[klass]
-            print klass
+            print(klass)
             checker = klass(iterations)
             for meth in dir(checker):
                 if meth.startswith('check_'):
-                    print '\t', meth, vmsize(), '...',
+                    print('\t', meth, vmsize(), '...', end=' ')
                     getattr(checker, meth)()
-                    print vmsize()
+                    print(vmsize())
 
 
 if __name__ == '__main__':

--- a/leakcheck/thread-crash.py
+++ b/leakcheck/thread-crash.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (C) Jean-Paul Calderone
 # See LICENSE for details.
 #
@@ -12,20 +13,22 @@
 from socket import socket
 from threading import Thread
 
+from six.moves import xrange
+
 from OpenSSL.SSL import Connection, Context, TLSv1_METHOD
 
 def send(conn):
-    while 1:
+    while True:
         for i in xrange(1024 * 32):
             conn.send('x')
-        print 'Sent 32KB on', hex(id(conn))
+        print('Sent 32KB on', hex(id(conn)))
 
 
 def recv(conn):
-    while 1:
+    while True:
         for i in xrange(1024 * 64):
             conn.recv(1)
-        print 'Received 64KB on', hex(id(conn))
+        print('Received 64KB on', hex(id(conn)))
 
 
 def main():

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -546,7 +546,7 @@ class X509Name(object):
 
         # Note: we really do not want str subclasses here, so we do not use
         # isinstance.
-        if type(name) is not str:
+        if not isinstance(name, str):
             raise TypeError("attribute name must be string, not '%.200s'" % (
                 type(value).__name__,))
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1507,7 +1507,7 @@ WpOdIpB8KksUTCzV591Nr1wd
         certificate = X509()
         assert isinstance(certificate, X509)
         assert type(certificate).__name__ == 'X509'
-        assert type(certificate) == X509
+        assert isinstance(certificate, X509)
 
     def test_set_version_wrong_args(self):
         """
@@ -3014,7 +3014,7 @@ class TestRevoked(object):
         """
         revoked = Revoked()
         assert isinstance(revoked, Revoked)
-        assert type(revoked) == Revoked
+        assert isinstance(revoked, Revoked)
         assert revoked.get_serial() == b'00'
         assert revoked.get_rev_date() is None
         assert revoked.get_reason() is None
@@ -3308,8 +3308,8 @@ class TestCRL(object):
 
         revs = crl.get_revoked()
         assert len(revs) == 2
-        assert type(revs[0]) == Revoked
-        assert type(revs[1]) == Revoked
+        assert isinstance(revs[0], Revoked)
+        assert isinstance(revs[1], Revoked)
         assert revs[0].get_serial() == b'03AB'
         assert revs[1].get_serial() == b'0100'
         assert revs[0].get_rev_date() == now

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -86,6 +86,10 @@ from .test_crypto import (
     client_cert_pem, client_key_pem, server_cert_pem, server_key_pem,
     root_cert_pem)
 
+if PY3:
+    buffer = bytes
+    long = int
+
 
 # openssl dhparam 1024 -out dh-1024.pem (note that 1024 is a small number of
 # bits to use)
@@ -108,7 +112,7 @@ def join_bytes_or_unicode(prefix, suffix):
     The return type is the same as the type of ``prefix``.
     """
     # If the types are the same, nothing special is necessary.
-    if type(prefix) == type(suffix):
+    if isinstance(prefix, type(suffix)):
         return join(prefix, suffix)
 
     # Otherwise, coerce suffix to the type of prefix.

--- a/tests/util.py
+++ b/tests/util.py
@@ -28,7 +28,7 @@ def is_consistent_type(theType, name, *constructionArgs):
     assert theType.__name__ == name
     assert isinstance(theType, type)
     instance = theType(*constructionArgs)
-    assert type(instance) is theType
+    assert isinstance(instance, theType)
     return True
 
 


### PR DESCRIPTION
Fixes issues discovered in #815

Use __print()__ function in both Python 2 and Python 3
* Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Old style exceptions --> new style for Python 3
* Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.

@alex Your review please.