### PR TITLE
Raise an Error with "no cipher match" even with TLS 1.3

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1189,13 +1189,22 @@ class Context(object):
         # invalid cipher string is passed, but without the following check
         # for the TLS 1.3 specific cipher suites it would never error.
         tmpconn = Connection(self, None)
-        _openssl_assert(
-            tmpconn.get_cipher_list() != [
+        if (
+            tmpconn.get_cipher_list() == [
                 'TLS_AES_256_GCM_SHA384',
                 'TLS_CHACHA20_POLY1305_SHA256',
                 'TLS_AES_128_GCM_SHA256'
             ]
-        )
+        ):
+            raise Error(
+                [
+                    (
+                        'SSL routines',
+                        'SSL_CTX_set_cipher_list',
+                        'no cipher match',
+                    ),
+                ],
+            )
 
     def set_client_ca_list(self, certificate_authorities):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -410,18 +410,13 @@ class TestContext(object):
 
         assert "AES128-SHA" in conn.get_cipher_list()
 
-    @pytest.mark.parametrize("cipher_list,error", [
-        (object(), TypeError),
-        ("imaginary-cipher", Error),
-    ])
-    def test_set_cipher_list_wrong_args(self, context, cipher_list, error):
+    def test_set_cipher_list_wrong_type(self, context):
         """
         `Context.set_cipher_list` raises `TypeError` when passed a non-string
-        argument and raises `OpenSSL.SSL.Error` when passed an incorrect cipher
-        list string.
+        argument.
         """
-        with pytest.raises(error):
-            context.set_cipher_list(cipher_list)
+        with pytest.raises(TypeError):
+            context.set_cipher_list(object())
 
     def test_set_cipher_list_no_cipher_match(self, context):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -423,6 +423,24 @@ class TestContext(object):
         with pytest.raises(error):
             context.set_cipher_list(cipher_list)
 
+    def test_set_cipher_list_no_cipher_match(self, context):
+        """
+        `Context.set_cipher_list` raises `OpenSSL.SSL.Error` with a
+        `"no cipher match"` reason string regardless of the TLS
+        version.
+        """
+        with pytest.raises(Error) as excinfo:
+            context.set_cipher_list(b"imaginary-cipher")
+        assert excinfo.value.args == (
+                [
+                    (
+                        'SSL routines',
+                        'SSL_CTX_set_cipher_list',
+                        'no cipher match',
+                    ),
+                ],
+            )
+
     def test_load_client_ca(self, context, ca_file):
         """
         `Context.load_client_ca` works as far as we can tell.


### PR DESCRIPTION
This makes Twisted's OpenSSLAcceptableCiphers.fromOpenSSLCipherString
and seamlessly work with TLS 1.3:

https://github.com/twisted/twisted/pull/1100/files/a5df2fb373ac67b0e3032acc9291ae88dfd0b3b1#diff-df501bac724aab523150498f84749b88R1767