### PR TITLE
Travis CI: Run flake8 on Python instead of legacy Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: true
 language: python
 
 cache:
@@ -81,7 +80,7 @@ matrix:
   - python: "2.7"
     env: TOXENV=pypi-readme
 
-  - python: "2.7"
+  - python: "3.7"
     env: TOXENV=flake8
 
   - python: "2.7"


### PR DESCRIPTION
Python 3 syntax is stricter than Python 2 syntax.

Also, __sudo: required__ no longer is...  [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo:__ in your __.travis.yml__, we recommend removing that configuration_"