### PR TITLE
use _ffi.from_buffer() to support bytearray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ doc/_build/
 examples/simple/*.cert
 examples/simple/*.pkey
 .cache
+.mypy_cache

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Support ``bytearray`` in ``SSL.Connection.send()`` by using cffi's from_buffer.
+  `#852 <https://github.com/pyca/pyopenssl/pull/852>`_
 
 
 ----

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -15,6 +15,7 @@ from OpenSSL._util import (
     UNSPECIFIED as _UNSPECIFIED,
     exception_from_error_queue as _exception_from_error_queue,
     ffi as _ffi,
+    from_buffer as _from_buffer,
     lib as _lib,
     make_assert as _make_assert,
     native as _native,
@@ -1725,14 +1726,18 @@ class Connection(object):
         # Backward compatibility
         buf = _text_to_bytes_and_warn("buf", buf)
 
-        buf = _ffi.from_buffer(buf)
+        with _from_buffer(buf) as buf:
 
-        if len(buf) > 2147483647:
-            raise ValueError("Cannot send more than 2**31-1 bytes at once.")
+            # THE TEST MOCK HAS ZERO BYTES HERE
 
-        result = _lib.SSL_write(self._ssl, buf, len(buf))
-        self._raise_ssl_error(self._ssl, result)
+            if len(buf) > 2147483647:
+                raise ValueError("Cannot send more than 2**31-1 bytes at once.")
+
+            result = _lib.SSL_write(self._ssl, buf, len(buf))
+            self._raise_ssl_error(self._ssl, result)
+            
         return result
+
     write = send
 
     def sendall(self, buf, flags=0):
@@ -1748,28 +1753,24 @@ class Connection(object):
         """
         buf = _text_to_bytes_and_warn("buf", buf)
 
-        if isinstance(buf, memoryview):
-            buf = buf.tobytes()
-        if isinstance(buf, _buffer):
-            buf = str(buf)
-        if not isinstance(buf, bytes):
-            raise TypeError("buf must be a memoryview, buffer or byte string")
+        with _from_buffer(buf) as data:
+            
+            left_to_send = len(buf)
+            total_sent = 0
 
-        left_to_send = len(buf)
-        total_sent = 0
-        data = _ffi.new("char[]", buf)
+            while left_to_send:
+                # SSL_write's num arg is an int,
+                # so we cannot send more than 2**31-1 bytes at once.
+                result = _lib.SSL_write(
+                    self._ssl,
+                    data + total_sent,
+                    min(left_to_send, 2147483647)
+                )
+                self._raise_ssl_error(self._ssl, result)
+                total_sent += result
+                left_to_send -= result
 
-        while left_to_send:
-            # SSL_write's num arg is an int,
-            # so we cannot send more than 2**31-1 bytes at once.
-            result = _lib.SSL_write(
-                self._ssl,
-                data + total_sent,
-                min(left_to_send, 2147483647)
-            )
-            self._raise_ssl_error(self._ssl, result)
-            total_sent += result
-            left_to_send -= result
+        return total_sent
 
     def recv(self, bufsiz, flags=None):
         """

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1725,14 +1725,10 @@ class Connection(object):
         # Backward compatibility
         buf = _text_to_bytes_and_warn("buf", buf)
 
-        if isinstance(buf, memoryview):
-            buf = buf.tobytes()
-        if isinstance(buf, _buffer):
-            buf = str(buf)
-        if not isinstance(buf, bytes):
-            raise TypeError("data must be a memoryview, buffer or byte string")
         if len(buf) > 2147483647:
             raise ValueError("Cannot send more than 2**31-1 bytes at once.")
+
+        buf = _ffi.from_buffer(buf)
 
         result = _lib.SSL_write(self._ssl, buf, len(buf))
         self._raise_ssl_error(self._ssl, result)

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1726,14 +1726,12 @@ class Connection(object):
         # Backward compatibility
         buf = _text_to_bytes_and_warn("buf", buf)
 
-        with _from_buffer(buf) as buf:
-
-            # THE TEST MOCK HAS ZERO BYTES HERE
-
+        with _from_buffer(buf) as data:
+            # check len(buf) instead of len(data) for testability
             if len(buf) > 2147483647:
                 raise ValueError("Cannot send more than 2**31-1 bytes at once.")
 
-            result = _lib.SSL_write(self._ssl, buf, len(buf))
+            result = _lib.SSL_write(self._ssl, data, len(data))
             self._raise_ssl_error(self._ssl, result)
             
         return result

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1734,7 +1734,7 @@ class Connection(object):
             result = _lib.SSL_write(self._ssl, data, len(data))
             self._raise_ssl_error(self._ssl, result)
             
-        return result
+            return result
 
     write = send
 
@@ -1768,7 +1768,7 @@ class Connection(object):
                 total_sent += result
                 left_to_send -= result
 
-        return total_sent
+            return total_sent
 
     def recv(self, bufsiz, flags=None):
         """
@@ -1882,10 +1882,11 @@ class Connection(object):
         if self._into_ssl is None:
             raise TypeError("Connection sock was not None")
 
-        result = _lib.BIO_write(self._into_ssl, buf, len(buf))
-        if result <= 0:
-            self._handle_bio_errors(self._into_ssl, result)
-        return result
+        with _from_buffer(buf) as data:
+            result = _lib.BIO_write(self._into_ssl, data, len(data))
+            if result <= 0:
+                self._handle_bio_errors(self._into_ssl, result)
+            return result
 
     def renegotiate(self):
         """

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1729,11 +1729,13 @@ class Connection(object):
         with _from_buffer(buf) as data:
             # check len(buf) instead of len(data) for testability
             if len(buf) > 2147483647:
-                raise ValueError("Cannot send more than 2**31-1 bytes at once.")
+                raise ValueError(
+                    "Cannot send more than 2**31-1 bytes at once."
+                )
 
             result = _lib.SSL_write(self._ssl, data, len(data))
             self._raise_ssl_error(self._ssl, result)
-            
+
             return result
 
     write = send
@@ -1752,7 +1754,7 @@ class Connection(object):
         buf = _text_to_bytes_and_warn("buf", buf)
 
         with _from_buffer(buf) as data:
-            
+
             left_to_send = len(buf)
             total_sent = 0
 

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1725,10 +1725,10 @@ class Connection(object):
         # Backward compatibility
         buf = _text_to_bytes_and_warn("buf", buf)
 
+        buf = _ffi.from_buffer(buf)
+
         if len(buf) > 2147483647:
             raise ValueError("Cannot send more than 2**31-1 bytes at once.")
-
-        buf = _ffi.from_buffer(buf)
 
         result = _lib.SSL_write(self._ssl, buf, len(buf))
         self._raise_ssl_error(self._ssl, result)

--- a/src/OpenSSL/_util.py
+++ b/src/OpenSSL/_util.py
@@ -46,13 +46,10 @@ def exception_from_error_queue(exception_type):
         error = lib.ERR_get_error()
         if error == 0:
             break
-        errors.append(
-            (
-                text(lib.ERR_lib_error_string(error)),
-                text(lib.ERR_func_error_string(error)),
-                text(lib.ERR_reason_error_string(error)),
-            )
-        )
+        errors.append((
+            text(lib.ERR_lib_error_string(error)),
+            text(lib.ERR_func_error_string(error)),
+            text(lib.ERR_reason_error_string(error))))
 
     raise exception_type(errors)
 
@@ -62,7 +59,6 @@ def make_assert(error):
     Create an assert function that uses :func:`exception_from_error_queue` to
     raise an exception wrapped by *error*.
     """
-
     def openssl_assert(ok):
         """
         If *ok* is not True, retrieve the error from OpenSSL and raise it.
@@ -112,13 +108,9 @@ def path_string(s):
 
 
 if PY3:
-
     def byte_string(s):
         return s.encode("charmap")
-
-
 else:
-
     def byte_string(s):
         return s
 
@@ -127,7 +119,9 @@ else:
 # value or not.
 UNSPECIFIED = object()
 
-_TEXT_WARNING = text_type.__name__ + " for {0} is no longer accepted, use bytes"
+_TEXT_WARNING = (
+    text_type.__name__ + " for {0} is no longer accepted, use bytes"
+)
 
 
 def text_to_bytes_and_warn(label, obj):
@@ -145,9 +139,11 @@ def text_to_bytes_and_warn(label, obj):
     """
     if isinstance(obj, text_type):
         warnings.warn(
-            _TEXT_WARNING.format(label), category=DeprecationWarning, stacklevel=3
+            _TEXT_WARNING.format(label),
+            category=DeprecationWarning,
+            stacklevel=3
         )
-        return obj.encode("utf-8")
+        return obj.encode('utf-8')
     return obj
 
 

--- a/src/OpenSSL/_util.py
+++ b/src/OpenSSL/_util.py
@@ -46,10 +46,13 @@ def exception_from_error_queue(exception_type):
         error = lib.ERR_get_error()
         if error == 0:
             break
-        errors.append((
-            text(lib.ERR_lib_error_string(error)),
-            text(lib.ERR_func_error_string(error)),
-            text(lib.ERR_reason_error_string(error))))
+        errors.append(
+            (
+                text(lib.ERR_lib_error_string(error)),
+                text(lib.ERR_func_error_string(error)),
+                text(lib.ERR_reason_error_string(error)),
+            )
+        )
 
     raise exception_type(errors)
 
@@ -59,6 +62,7 @@ def make_assert(error):
     Create an assert function that uses :func:`exception_from_error_queue` to
     raise an exception wrapped by *error*.
     """
+
     def openssl_assert(ok):
         """
         If *ok* is not True, retrieve the error from OpenSSL and raise it.
@@ -108,9 +112,13 @@ def path_string(s):
 
 
 if PY3:
+
     def byte_string(s):
         return s.encode("charmap")
+
+
 else:
+
     def byte_string(s):
         return s
 
@@ -119,9 +127,7 @@ else:
 # value or not.
 UNSPECIFIED = object()
 
-_TEXT_WARNING = (
-    text_type.__name__ + " for {0} is no longer accepted, use bytes"
-)
+_TEXT_WARNING = text_type.__name__ + " for {0} is no longer accepted, use bytes"
 
 
 def text_to_bytes_and_warn(label, obj):
@@ -139,9 +145,21 @@ def text_to_bytes_and_warn(label, obj):
     """
     if isinstance(obj, text_type):
         warnings.warn(
-            _TEXT_WARNING.format(label),
-            category=DeprecationWarning,
-            stacklevel=3
+            _TEXT_WARNING.format(label), category=DeprecationWarning, stacklevel=3
         )
-        return obj.encode('utf-8')
+        return obj.encode("utf-8")
     return obj
+
+
+try:
+    # newer versions of cffi free the buffer deterministically
+    with ffi.from_buffer(b""):
+        pass
+    from_buffer = ffi.from_buffer
+except AttributeError:
+    # cffi < 0.12 frees the buffer with refcounting gc
+    from contextlib import contextmanager
+
+    @contextmanager
+    def from_buffer(*args):
+        yield ffi.from_buffer(*args)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2842,6 +2842,16 @@ class TestConnectionSend(object):
         assert count == 2
         assert client.recv(2) == b'xy'
 
+    def test_short_bytearray(self):
+        """
+        When passed a short bytearray, `Connection.send` transmits all of
+        it and returns the number of bytes sent.
+        """
+        server, client = loopback()
+        count = server.send(bytearray(b'xy'))
+        assert count == 2
+        assert client.recv(2) == b'xy'
+
     @skip_if_py3
     def test_short_buffer(self):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2097,8 +2097,8 @@ class TestConnection(object):
 
     def test_bio_write(self):
         """
-        `Connection.bio_write` does not raise if called with bytes or bytearray,
-        warns if called with text.
+        `Connection.bio_write` does not raise if called with bytes or
+        bytearray, warns if called with text.
         """
         context = Context(TLSv1_METHOD)
         connection = Connection(context, None)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2805,7 +2805,7 @@ class TestConnectionSend(object):
         with pytest.raises(TypeError):
             connection.send(object())
         with pytest.raises(TypeError):
-            connection.send([1,2,3])
+            connection.send([1, 2, 3])
 
     def test_short_bytes(self):
         """
@@ -3025,7 +3025,7 @@ class TestConnectionSendall(object):
         with pytest.raises(TypeError):
             connection.sendall(object())
         with pytest.raises(TypeError):
-            connection.sendall([1,2,3])
+            connection.sendall([1, 2, 3])
 
     def test_short(self):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2084,6 +2084,29 @@ class TestConnection(object):
         with pytest.raises(TypeError):
             Connection(bad_context)
 
+    @pytest.mark.parametrize('bad_bio', [object(), None, 1, [1, 2, 3]])
+    def test_bio_write_wrong_args(self, bad_bio):
+        """
+        `Connection.bio_write` raises `TypeError` if called with a non-bytes
+        (or text) argument.
+        """
+        context = Context(TLSv1_METHOD)
+        connection = Connection(context, None)
+        with pytest.raises(TypeError):
+            connection.bio_write(bad_bio)
+
+    def test_bio_write(self):
+        """
+        `Connection.bio_write` does not raise if called with bytes or bytearray,
+        warns if called with text.
+        """
+        context = Context(TLSv1_METHOD)
+        connection = Connection(context, None)
+        connection.bio_write(b'xy')
+        connection.bio_write(bytearray(b'za'))
+        with pytest.warns(DeprecationWarning):
+            connection.bio_write(u'deprecated')
+
     def test_get_context(self):
         """
         `Connection.get_context` returns the `Context` instance used to

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -3063,8 +3063,9 @@ class TestConnectionSendall(object):
         `Connection.sendall` transmits all of them.
         """
         server, client = loopback()
-        server.sendall(buffer(b'x'))
-        assert client.recv(1) == b'x'
+        count = server.sendall(buffer(b'xy'))
+        assert count == 2
+        assert client.recv(1) == b'xy'
 
     def test_long(self):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -3069,7 +3069,7 @@ class TestConnectionSendall(object):
         server, client = loopback()
         count = server.sendall(buffer(b'xy'))
         assert count == 2
-        assert client.recv(1) == b'xy'
+        assert client.recv(2) == b'xy'
 
     def test_long(self):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2804,6 +2804,8 @@ class TestConnectionSend(object):
         connection = Connection(Context(TLSv1_METHOD), None)
         with pytest.raises(TypeError):
             connection.send(object())
+        with pytest.raises(TypeError):
+            connection.send([1,2,3])
 
     def test_short_bytes(self):
         """
@@ -3022,6 +3024,8 @@ class TestConnectionSendall(object):
         connection = Connection(Context(TLSv1_METHOD), None)
         with pytest.raises(TypeError):
             connection.sendall(object())
+        with pytest.raises(TypeError):
+            connection.sendall([1,2,3])
 
     def test_short(self):
         """


### PR DESCRIPTION
If you try to send a dict it produces this error message: `TypeError: a bytes-like object is required, not 'dict'`

It doesn't accept `bytearray` without `from_buffer` (cffi doesn't automatically convert that type for `char*` arguments)