### PR TITLE
change empty CRL get_revoked to empty tuple

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -2137,8 +2137,7 @@ class CRL(object):
             pyrev = Revoked.__new__(Revoked)
             pyrev._revoked = _ffi.gc(revoked_copy, _lib.X509_REVOKED_free)
             results.append(pyrev)
-        if results:
-            return tuple(results)
+        return tuple(results)
 
     def add_revoked(self, revoked):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3117,7 +3117,7 @@ class TestCRL(object):
         """
         crl = CRL()
         assert isinstance(crl, CRL)
-        assert crl.get_revoked() is None
+        assert crl.get_revoked() is ()
 
     def _get_crl(self):
         """


### PR DESCRIPTION
resolves remaining issue in #258 by switching empty `get_revoked` return to effective empty tuple.

This was breaking functional tests in a pyOpenSSL integration.
