### PR TITLE
Fix for Python 4

### DIFF
--- a/src/OpenSSL/_util.py
+++ b/src/OpenSSL/_util.py
@@ -1,7 +1,7 @@
 import sys
 import warnings
 
-from six import PY3, binary_type, text_type
+from six import PY2, binary_type, text_type
 
 from cryptography.hazmat.bindings.openssl.binding import Binding
 
@@ -81,12 +81,12 @@ def native(s):
     """
     if not isinstance(s, (binary_type, text_type)):
         raise TypeError("%r is neither bytes nor unicode" % s)
-    if PY3:
-        if isinstance(s, binary_type):
-            return s.decode("utf-8")
-    else:
+    if PY2:
         if isinstance(s, text_type):
             return s.encode("utf-8")
+    else:
+        if isinstance(s, binary_type):
+            return s.decode("utf-8")
     return s
 
 
@@ -107,12 +107,12 @@ def path_string(s):
         raise TypeError("Path must be represented as bytes or unicode string")
 
 
-if PY3:
-    def byte_string(s):
-        return s.encode("charmap")
-else:
+if PY2:
     def byte_string(s):
         return s
+else:
+    def byte_string(s):
+        return s.encode("charmap")
 
 
 # A marker object to observe whether some optional arguments are passed any

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -25,7 +25,7 @@ import pytest
 
 from pretend import raiser
 
-from six import PY3, text_type
+from six import PY2, text_type
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -101,7 +101,7 @@ V7H54LmltOT/hEh6QWsJqb6BQgH65bswvV/XkYGja8/T0GzvbaVzAgEC
 """
 
 
-skip_if_py3 = pytest.mark.skipif(PY3, reason="Python 2 only")
+skip_if_py3 = pytest.mark.skipif(not PY2, reason="Python 2 only")
 
 
 def socket_any_family():
@@ -2138,7 +2138,7 @@ class TestConnection(object):
         with pytest.raises(TypeError):
             conn.set_tlsext_host_name(b"with\0null")
 
-        if PY3:
+        if not PY2:
             # On Python 3.x, don't accidentally implicitly convert from text.
             with pytest.raises(TypeError):
                 conn.set_tlsext_host_name(b"example.com".decode("ascii"))

--- a/tests/util.py
+++ b/tests/util.py
@@ -6,7 +6,7 @@ Helpers for the OpenSSL test suite, largely copied from
 U{Twisted<http://twistedmatrix.com/>}.
 """
 
-from six import PY3
+from six import PY2
 
 
 # This is the UTF-8 encoding of the SNOWMAN unicode code point.
@@ -152,7 +152,7 @@ class EqualityTestsMixin(object):
 
 
 # The type name expected in warnings about using the wrong string type.
-if PY3:
-    WARNING_TYPE_EXPECTED = "str"
-else:
+if PY2:
     WARNING_TYPE_EXPECTED = "unicode"
+else:
+    WARNING_TYPE_EXPECTED = "str"


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule).

There's some code which checks the Python major version is exactly 3 using `six`, essentially similar to this:

```python
if sys.version_info[0] == 3:
    pass  # Python 3+ code
else:
    pass  # Python 2 code
```

When run on Python 4, this will run the Python 2 code! Instead, flip the check:

```python
if sys.version_info[0] == 2:
    pass  # Python 2 code
else:
    pass  # Python 3+ code
```

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./tests/util.py:155:4: YTT202: `six.PY3` referenced (python4), use `not six.PY2`
./tests/test_ssl.py:104:34: YTT202: `six.PY3` referenced (python4), use `not six.PY2`
./tests/test_ssl.py:2141:12: YTT202: `six.PY3` referenced (python4), use `not six.PY2`
./src/OpenSSL/_util.py:84:8: YTT202: `six.PY3` referenced (python4), use `not six.PY2`
./src/OpenSSL/_util.py:110:4: YTT202: `six.PY3` referenced (python4), use `not six.PY2`
```
