### PR TITLE
bump the minimum cryptography version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Backward-incompatible changes:
 - Removed deprecated ``ContextType``, ``ConnectionType``, ``PKeyType``, ``X509NameType``, ``X509ReqType``, ``X509Type``, ``X509StoreType``, ``CRLType``, ``PKCS7Type``, ``PKCS12Type``, and ``NetscapeSPKIType`` aliases.
   Use the classes without the ``Type`` suffix instead.
   `#814 <https://github.com/pyca/pyopenssl/pull/814>`_
+- The minimum ``cryptography`` version is now 2.8 due to issues on macOS with a transitive dependency.
+  `#875 <https://github.com/pyca/pyopenssl/pull/875>`_
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             # Fix cryptographyMinimum in tox.ini when changing this!
-            "cryptography>=2.3",
+            "cryptography>=2.8",
             "six>=1.5.2"
         ],
         extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ extras =
 deps =
     coverage>=4.2
     cryptographyMaster: git+https://github.com/pyca/cryptography.git
-    cryptographyMinimum: cryptography==2.3.0
+    cryptographyMinimum: cryptography==2.8
     randomorder: pytest-randomly
 setenv =
     # Do not allow the executing environment to pollute the test environment


### PR DESCRIPTION
Users with older cryptography (and hence potentially older asn1crypto, a
transitive dependency) are seeing a serious bug on macOS catalina due to
the way older asn1crypto loads a shared library. While this isn't a
pyOpenSSL bug bumping this dep might prevent the bug from impacting
some users.

fixes #874 