### PR TITLE
ALPN: complete handshake without accepting a client's protocols.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Changes:
 
 - Support ``bytearray`` in ``SSL.Connection.send()`` by using cffi's from_buffer.
   `#852 <https://github.com/pyca/pyopenssl/pull/852>`_
+- The ``OpenSSL.SSL.Context.set_alpn_select_callback`` can return a new ``NO_OVERLAPPING_PROTOCOLS`` sentinel value
+  to allow a TLS handshake to complete without an application protocol.
 
 
 ----

--- a/doc/api/ssl.rst
+++ b/doc/api/ssl.rst
@@ -119,6 +119,15 @@ Context, Connection.
     for details.
 
 
+.. py:data:: NO_OVERLAPPING_PROTOCOLS
+
+    A sentinel value that can be returned by the callback passed to
+    :py:meth:`Context.set_alpn_select_callback` to indicate that
+    the handshake can continue without a specific application protocol.
+
+    .. versionadded:: 19.1
+
+
 .. autofunction:: SSLeay_version
 
 

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1507,7 +1507,7 @@ class Context(object):
             one of those bytestrings to indicate the chosen protocol, the
             empty bytestring to terminate the TLS connection, or the
             :py:obj:`NO_OVERLAPPING_PROTOCOLS` to indicate that no offered
-            protocol was selected.
+            protocol was selected, but that the connection should not be aborted.
         """
         self._alpn_select_helper = _ALPNSelectHelper(callback)
         self._alpn_select_callback = self._alpn_select_helper.callback

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -428,19 +428,7 @@ class _NpnSelectHelper(_CallbackExceptionHelper):
         )
 
 
-class _Sentinel(object):
-    """
-    A sentinel value.
-    """
-
-    def __init__(self, value):
-        self._value = value
-
-    def __repr__(self):
-        return "<Sentinel {!r}>".format(self._value)
-
-
-NO_OVERLAPPING_PROTOCOLS = _Sentinel("NO_OVERLAPPING_PROTOCOLS")
+NO_OVERLAPPING_PROTOCOLS = object()
 
 
 class _ALPNSelectHelper(_CallbackExceptionHelper):
@@ -450,10 +438,6 @@ class _ALPNSelectHelper(_CallbackExceptionHelper):
 
     def __init__(self, callback):
         _CallbackExceptionHelper.__init__(self)
-
-        SSL_TLSEXT_ERR_OK = _lib.SSL_TLSEXT_ERR_OK
-        SSL_TLSEXT_ERR_NOACK = _lib.SSL_TLSEXT_ERR_NOACK
-        SSL_TLSEXT_ERR_ALERT_FATAL = _lib.SSL_TLSEXT_ERR_ALERT_FATAL
 
         @wraps(callback)
         def wrapper(ssl, out, outlen, in_, inlen, arg):
@@ -493,11 +477,11 @@ class _ALPNSelectHelper(_CallbackExceptionHelper):
                 outlen[0] = conn._alpn_select_callback_args[0][0]
                 out[0] = conn._alpn_select_callback_args[1]
                 if not any_accepted:
-                    return SSL_TLSEXT_ERR_NOACK
-                return SSL_TLSEXT_ERR_OK
+                    return _lib.SSL_TLSEXT_ERR_NOACK
+                return _lib.SSL_TLSEXT_ERR_OK
             except Exception as e:
                 self._problems.append(e)
-                return SSL_TLSEXT_ERR_ALERT_FATAL
+                return _lib.SSL_TLSEXT_ERR_ALERT_FATAL
 
         self.callback = _ffi.callback(
             ("int (*)(SSL *, unsigned char **, unsigned char *, "

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1491,7 +1491,8 @@ class Context(object):
             one of those bytestrings to indicate the chosen protocol, the
             empty bytestring to terminate the TLS connection, or the
             :py:obj:`NO_OVERLAPPING_PROTOCOLS` to indicate that no offered
-            protocol was selected, but that the connection should not be aborted.
+            protocol was selected, but that the connection should not be
+            aborted.
         """
         self._alpn_select_helper = _ALPNSelectHelper(callback)
         self._alpn_select_callback = self._alpn_select_helper.callback

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -67,7 +67,7 @@ from OpenSSL._util import ffi as _ffi, lib as _lib
 
 from OpenSSL.SSL import (
     OP_NO_QUERY_MTU, OP_COOKIE_EXCHANGE, OP_NO_TICKET, OP_NO_COMPRESSION,
-    MODE_RELEASE_BUFFERS)
+    MODE_RELEASE_BUFFERS, NO_OVERLAPPING_PROTOCOLS)
 
 from OpenSSL.SSL import (
     SSL_ST_CONNECT, SSL_ST_ACCEPT, SSL_ST_MASK,
@@ -1959,6 +1959,42 @@ class TestApplicationLayerProtoNegotiation(object):
                 interact_in_memory(server, client)
 
             assert select_args == [(server, [b'http/1.1', b'spdy/2'])]
+
+        def test_alpn_no_server_overlap(self):
+            """
+            A server can allow a TLS handshake to complete without
+            agreeing to an application protocol by returning
+            ``NO_OVERLAPPING_PROTOCOLS``.
+            """
+            refusal_args = []
+
+            def refusal(conn, options):
+                refusal_args.append((conn, options))
+                return NO_OVERLAPPING_PROTOCOLS
+
+            client_context = Context(TLSv1_METHOD)
+            client_context.set_alpn_protos([b'http/1.1', b'spdy/2'])
+
+            server_context = Context(TLSv1_METHOD)
+            server_context.set_alpn_select_callback(refusal)
+
+            # Necessary to actually accept the connection
+            server_context.use_privatekey(
+                load_privatekey(FILETYPE_PEM, server_key_pem))
+            server_context.use_certificate(
+                load_certificate(FILETYPE_PEM, server_cert_pem))
+
+            # Do a little connection to trigger the logic
+            server = Connection(server_context, None)
+            server.set_accept_state()
+
+            client = Connection(client_context, None)
+            client.set_connect_state()
+
+            # Do the dance.
+            interact_in_memory(server, client)
+
+            assert client.get_alpn_proto_negotiated() == b''
 
         def test_alpn_no_server(self):
             """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1994,6 +1994,8 @@ class TestApplicationLayerProtoNegotiation(object):
             # Do the dance.
             interact_in_memory(server, client)
 
+            assert refusal_args == [(server, [b'http/1.1', b'spdy/2'])]
+
             assert client.get_alpn_proto_negotiated() == b''
 
         def test_alpn_no_server(self):

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1972,10 +1972,10 @@ class TestApplicationLayerProtoNegotiation(object):
                 refusal_args.append((conn, options))
                 return NO_OVERLAPPING_PROTOCOLS
 
-            client_context = Context(TLSv1_METHOD)
+            client_context = Context(SSLv23_METHOD)
             client_context.set_alpn_protos([b'http/1.1', b'spdy/2'])
 
-            server_context = Context(TLSv1_METHOD)
+            server_context = Context(SSLv23_METHOD)
             server_context.set_alpn_select_callback(refusal)
 
             # Necessary to actually accept the connection

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1998,6 +1998,45 @@ class TestApplicationLayerProtoNegotiation(object):
 
             assert client.get_alpn_proto_negotiated() == b''
 
+        def test_alpn_select_cb_returns_invalid_value(self):
+            """
+            If the ALPN selection callback returns anything other than
+            a bytestring or ``NO_OVERLAPPING_PROTOCOLS``, a
+            :py:exc:`TypeError` is raised.
+            """
+            invalid_cb_args = []
+
+            def invalid_cb(conn, options):
+                invalid_cb_args.append((conn, options))
+                return u"can't return unicode"
+
+            client_context = Context(SSLv23_METHOD)
+            client_context.set_alpn_protos([b'http/1.1', b'spdy/2'])
+
+            server_context = Context(SSLv23_METHOD)
+            server_context.set_alpn_select_callback(invalid_cb)
+
+            # Necessary to actually accept the connection
+            server_context.use_privatekey(
+                load_privatekey(FILETYPE_PEM, server_key_pem))
+            server_context.use_certificate(
+                load_certificate(FILETYPE_PEM, server_cert_pem))
+
+            # Do a little connection to trigger the logic
+            server = Connection(server_context, None)
+            server.set_accept_state()
+
+            client = Connection(client_context, None)
+            client.set_connect_state()
+
+            # Do the dance.
+            with pytest.raises(TypeError):
+                interact_in_memory(server, client)
+
+            assert invalid_cb_args == [(server, [b'http/1.1', b'spdy/2'])]
+
+            assert client.get_alpn_proto_negotiated() == b''
+
         def test_alpn_no_server(self):
             """
             When clients and servers cannot agree on what protocol to use next


### PR DESCRIPTION
The callback passed to `SSL_CTX_set_alpn_select_cb` can return
`SSL_TLSEXT_ERR_NOACK` to allow the handshake to continue without
accepting any of the client's offered protocols.

This commit introduces `NO_OVERLAPPING_PROTOCOLS`, which the Python
callback passed to `Context.set_alpn_select_callback` can return to
achieve the same thing.

It does not change the previous meaning of an empty string, which
still terminates the handshake.