### PR TITLE
Add DHparams class and methods to dump and load

### DIFF
--- a/doc/api/crypto.rst
+++ b/doc/api/crypto.rst
@@ -72,6 +72,13 @@ Certificate revocation lists
 
 .. autofunction:: load_pkcs12
 
+Diffie-Hellman parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: dump_dhparams
+
+.. autofunction:: load_dhparams
+
 Signing and verifying signatures
 --------------------------------
 
@@ -183,6 +190,12 @@ PKCS12 objects
                :members:
 
 .. _openssl-509ext:
+
+DHparams objects
+----------------
+
+.. autoclass:: DHparams
+               :members:                  
 
 X509Extension objects
 ---------------------

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1169,6 +1169,18 @@ class Context(object):
         dh = _ffi.gc(dh, _lib.DH_free)
         _lib.SSL_CTX_set_tmp_dh(self._context, dh)
 
+    def load_tmp_dhparams(self, dh):
+        """
+        Load parameters for Ephemeral Diffie-Hellman
+
+        :param DHparams dh: The DHparams object to load the
+		Diffie-Hellman parameters from
+
+        :return: None
+        """
+        _lib.SSL_CTX_set_tmp_dh(self._context, dh._dh)
+
+
     def set_tmp_ecdh(self, curve):
         """
         Select a curve to use for ECDHE key exchange.

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -30,8 +30,10 @@ from OpenSSL.crypto import (
 )
 from OpenSSL.crypto import X509Req
 from OpenSSL.crypto import X509Extension
+from OpenSSL.crypto import DHparams
 from OpenSSL.crypto import load_certificate, load_privatekey
 from OpenSSL.crypto import load_publickey, dump_publickey
+from OpenSSL.crypto import load_dhparams, dump_dhparams
 from OpenSSL.crypto import FILETYPE_PEM, FILETYPE_ASN1, FILETYPE_TEXT
 from OpenSSL.crypto import dump_certificate, load_certificate_request
 from OpenSSL.crypto import dump_certificate_request, dump_privatekey
@@ -560,6 +562,10 @@ MnY2KReEPfz7ZjAKBggqhkjOPQQDAwNpADBmAjEA3+G1oVCxGjYX4iUN93QYcNHe
 e3fJQJwX9+KsHRut6qNZDUbvRbtO1YIAwB4UJZjwAjEAtXCPURS5A4McZHnSwgTi
 Td8GMrwKz0557OxxtKN6uVVy4ACFMqEw0zN/KJI1vxc9
 -----END CERTIFICATE-----"""
+
+dh_params_256 = b"""-----BEGIN DH PARAMETERS-----
+MCYCIQDPvtehIUOc4qMdxwqiFnRVGewaZYOpJH64+bS0TTJAewIBAg==
+-----END DH PARAMETERS-----"""
 
 
 @pytest.fixture
@@ -3811,3 +3817,27 @@ class TestEllipticCurveHash(object):
             get_elliptic_curve(self.curve_factory.another_curve_name)
         ])
         assert curve not in curves
+
+class TestDHParameters(object):
+    """
+    Tests for `DHParams` object.
+    """
+
+    def test_generate_dhparams(self):
+        # Basic setup stuff to generate a certificate
+        dh = DHparams()
+
+        # We generate a very small DH to make this test
+        # not wait 20s for a 2048 bit DH key.
+        dh.generate_dh(256)
+        dh.check()
+        dh_pem = dump_dhparams(dh)
+        dh2 = load_dhparams(dh_params_256)
+
+    def test_load_dhparams(self):
+        dh = load_dhparams(dh_params_256)
+        dh.check()
+        dh_pem = dump_dhparams(dh)
+        assert dh_pem.strip() == dh_params_256.strip()
+
+        

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -39,6 +39,7 @@ from OpenSSL.crypto import TYPE_RSA, FILETYPE_PEM
 from OpenSSL.crypto import PKey, X509, X509Extension, X509Store
 from OpenSSL.crypto import dump_privatekey, load_privatekey
 from OpenSSL.crypto import dump_certificate, load_certificate
+from OpenSSL.crypto import load_dhparams
 from OpenSSL.crypto import get_elliptic_curves
 
 from OpenSSL.SSL import OPENSSL_VERSION_NUMBER, SSLEAY_VERSION, SSLEAY_CFLAGS
@@ -1472,6 +1473,11 @@ class TestContext(object):
 
         context.load_tmp_dh(dhfilename)
         # XXX What should I assert here? -exarkun
+
+    def test_load_tmp_dh_dhparams(self):
+        context = Context(TLSv1_METHOD)
+        dh = load_dhparams(dhparam)
+        context.load_tmp_dhparams(dh)
 
     def test_load_tmp_dh_bytes(self, tmpfile):
         """


### PR DESCRIPTION
This add support for loading, dumping and generating Diffie-Hellman
parameters to pyOpenSSL. The interface is modelled to be similar to
the existing interfaces.