### PR TITLE
Allow accessing a connection's verfied certificate chain

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,14 +21,14 @@ Deprecations:
 
 - Deprecated ``OpenSSL.crypto.loads_pkcs7`` and ``OpenSSL.crypto.loads_pkcs12``.
 
-*none*
-
-
 Changes:
 ^^^^^^^^
 
 - Added ``Context.set_keylog_callback`` to log key material.
   `#910 <https://github.com/pyca/pyopenssl/pull/910>`_
+- Added ``OpenSSL.SSL.Connection.get_verified_chain`` to retrieve the
+  verified certificate chain of the peer.
+  `#894 <https://github.com/pyca/pyopenssl/pull/894>`_.
 
 
 19.1.0 (2019-11-18)

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2168,7 +2168,7 @@ class Connection(object):
 
         .. versionadded:: 20.0
         """
-        if hasattr(_lib, 'SSL_get0_verified_chain'):
+        if hasattr(_lib, "SSL_get0_verified_chain"):
             # OpenSSL 1.1+
             cert_stack = _lib.SSL_get0_verified_chain(self._ssl)
             if cert_stack == _ffi.NULL:

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2189,7 +2189,7 @@ class Connection(object):
             return None
 
         pystorectx = X509StoreContext(pystore, pycert)
-        pystorectx._add_chain(cert_stack)
+        pystorectx._chain = cert_stack
         return pystorectx.get_verified_chain()
 
     def want_read(self):

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2180,9 +2180,9 @@ class Connection(object):
         if pycert is None:
             return None
 
+        # Should never be NULL because the peer presented a certificate.
         cert_stack = _lib.SSL_get_peer_cert_chain(self._ssl)
-        if cert_stack == _ffi.NULL:
-            return None
+        _openssl_assert(cert_stack != _ffi.NULL)
 
         pystore = self._context.get_cert_store()
         if pystore is None:

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1829,14 +1829,12 @@ class X509StoreContext(object):
 
         # Note: X509_STORE_CTX_get1_chain returns a deep copy of the chain.
         cert_stack = _lib.X509_STORE_CTX_get1_chain(self._store_ctx)
-        if cert_stack == _ffi.NULL:
-            # TODO: This is untested.
-            self._cleanup()
-            return None
+        _openssl_assert(cert_stack != _ffi.NULL)
 
         result = []
         for i in range(_lib.sk_X509_num(cert_stack)):
             cert = _lib.sk_X509_value(cert_stack, i)
+            _openssl_assert(cert != _ffi.NULL)
             pycert = X509._from_raw_x509_ptr(cert)
             result.append(pycert)
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1718,12 +1718,6 @@ class X509StoreContext(object):
         # :meth:`_init` have no adverse affect.
         self._init()
 
-    def _add_chain(self, chain):
-        """
-        Internal helper to set the untrusted certification chain (peer chain).
-        """
-        self._chain = chain
-
     def _init(self):
         """
         Set up the store context for a subsequent verification operation.

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1712,10 +1712,17 @@ class X509StoreContext(object):
         self._store_ctx = _ffi.gc(store_ctx, _lib.X509_STORE_CTX_free)
         self._store = store
         self._cert = certificate
+        self._chain = _ffi.NULL
         # Make the store context available for use after instantiating this
         # class by initializing it now. Per testing, subsequent calls to
         # :meth:`_init` have no adverse affect.
         self._init()
+
+    def _add_chain(self, chain):
+        """
+        Internal helper to set the untrusted certification chain (peer chain).
+        """
+        self._chain = chain
 
     def _init(self):
         """
@@ -1725,7 +1732,7 @@ class X509StoreContext(object):
         :meth:`_cleanup` will leak memory.
         """
         ret = _lib.X509_STORE_CTX_init(
-            self._store_ctx, self._store._store, self._cert._x509, _ffi.NULL
+            self._store_ctx, self._store._store, self._cert._x509, self._chain
         )
         if ret <= 0:
             _raise_current_error()
@@ -1796,6 +1803,47 @@ class X509StoreContext(object):
         self._cleanup()
         if ret <= 0:
             raise self._exception_from_context()
+
+    def get_verified_chain(self):
+        """
+        Verify a certificate in a context and return the complete validated
+        chain.
+
+        :raises X509StoreContextError: If an error occurred when validating a
+          certificate in the context. Sets ``certificate`` attribute to
+          indicate which certificate caused the error.
+
+        .. versionadded:: 20.0
+        """
+        # Always re-initialize the store context in case
+        # :meth:`verify_certificate` is called multiple times.
+        #
+        # :meth:`_init` is called in :meth:`__init__` so _cleanup is called
+        # before _init to ensure memory is not leaked.
+        self._cleanup()
+        self._init()
+        ret = _lib.X509_verify_cert(self._store_ctx)
+        if ret <= 0:
+            self._cleanup()
+            raise self._exception_from_context()
+
+        # Note: X509_STORE_CTX_get1_chain returns a deep copy of the chain.
+        cert_stack = _lib.X509_STORE_CTX_get1_chain(self._store_ctx)
+        if cert_stack == _ffi.NULL:
+            # TODO: This is untested.
+            self._cleanup()
+            return None
+
+        result = []
+        for i in range(_lib.sk_X509_num(cert_stack)):
+            cert = _lib.sk_X509_value(cert_stack, i)
+            pycert = X509._from_raw_x509_ptr(cert)
+            result.append(pycert)
+
+        # Free the stack but not the members which are freed by the X509 class.
+        _lib.sk_X509_free(cert_stack)
+        self._cleanup()
+        return result
 
 
 def load_certificate(type, buffer):

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3859,17 +3859,13 @@ class TestX509StoreContext(object):
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         chain = store_ctx.get_verified_chain()
         assert len(chain) == 3
-        assert (chain[0].get_subject() ==
-                self.intermediate_server_cert.get_subject())
+        intermediate_subject = self.intermediate_server_cert.get_subject()
+        assert chain[0].get_subject() == intermediate_subject
         assert chain[1].get_subject() == self.intermediate_cert.get_subject()
         assert chain[2].get_subject() == self.root_cert.get_subject()
         # Test reuse
-        chain = store_ctx.get_verified_chain()
-        assert len(chain) == 3
-        assert (chain[0].get_subject() ==
-                self.intermediate_server_cert.get_subject())
-        assert chain[1].get_subject() == self.intermediate_cert.get_subject()
-        assert chain[2].get_subject() == self.root_cert.get_subject()
+        chain2 = store_ctx.get_verified_chain()
+        assert chain == chain2
 
     def test_get_verified_chain_invalid_chain_no_root(self):
         """
@@ -3882,8 +3878,8 @@ class TestX509StoreContext(object):
         with pytest.raises(X509StoreContextError) as exc:
             store_ctx.get_verified_chain()
 
-        assert exc.value.args[0][2] == 'unable to get issuer certificate'
-        assert exc.value.certificate.get_subject().CN == 'intermediate'
+        assert exc.value.args[0][2] == "unable to get issuer certificate"
+        assert exc.value.certificate.get_subject().CN == "intermediate"
 
 
 class TestSignVerify(object):

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3864,8 +3864,11 @@ class TestX509StoreContext(object):
         assert chain[1].get_subject() == self.intermediate_cert.get_subject()
         assert chain[2].get_subject() == self.root_cert.get_subject()
         # Test reuse
-        chain2 = store_ctx.get_verified_chain()
-        assert chain == chain2
+        chain = store_ctx.get_verified_chain()
+        assert len(chain) == 3
+        assert chain[0].get_subject() == intermediate_subject
+        assert chain[1].get_subject() == self.intermediate_cert.get_subject()
+        assert chain[2].get_subject() == self.root_cert.get_subject()
 
     def test_get_verified_chain_invalid_chain_no_root(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3849,6 +3849,42 @@ class TestX509StoreContext(object):
 
         assert exc.value.args[0][2] == "certificate has expired"
 
+    def test_get_verified_chain(self):
+        """
+        `get_verified_chain` returns the verified chain.
+        """
+        store = X509Store()
+        store.add_cert(self.root_cert)
+        store.add_cert(self.intermediate_cert)
+        store_ctx = X509StoreContext(store, self.intermediate_server_cert)
+        chain = store_ctx.get_verified_chain()
+        assert len(chain) == 3
+        assert (chain[0].get_subject() ==
+                self.intermediate_server_cert.get_subject())
+        assert chain[1].get_subject() == self.intermediate_cert.get_subject()
+        assert chain[2].get_subject() == self.root_cert.get_subject()
+        # Test reuse
+        chain = store_ctx.get_verified_chain()
+        assert len(chain) == 3
+        assert (chain[0].get_subject() ==
+                self.intermediate_server_cert.get_subject())
+        assert chain[1].get_subject() == self.intermediate_cert.get_subject()
+        assert chain[2].get_subject() == self.root_cert.get_subject()
+
+    def test_get_verified_chain_invalid_chain_no_root(self):
+        """
+        `get_verified_chain` raises error when cert verification fails.
+        """
+        store = X509Store()
+        store.add_cert(self.intermediate_cert)
+        store_ctx = X509StoreContext(store, self.intermediate_server_cert)
+
+        with pytest.raises(X509StoreContextError) as exc:
+            store_ctx.get_verified_chain()
+
+        assert exc.value.args[0][2] == 'unable to get issuer certificate'
+        assert exc.value.certificate.get_subject().CN == 'intermediate'
+
 
 class TestSignVerify(object):
     """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2453,7 +2453,7 @@ class TestConnection(object):
         chain = _create_certificate_chain()
         [(cakey, cacert), (ikey, icert), (skey, scert)] = chain
 
-        serverContext = Context(TLSv1_METHOD)
+        serverContext = Context(SSLv23_METHOD)
         serverContext.use_privatekey(skey)
         serverContext.use_certificate(scert)
         serverContext.add_extra_chain_cert(icert)
@@ -2462,7 +2462,7 @@ class TestConnection(object):
         server.set_accept_state()
 
         # Create the client
-        clientContext = Context(TLSv1_METHOD)
+        clientContext = Context(SSLv23_METHOD)
         # cacert is self-signed so the client must trust it for verification
         # to succeed.
         clientContext.get_cert_store().add_cert(cacert)
@@ -2483,12 +2483,12 @@ class TestConnection(object):
         `Connection.get_verified_chain` returns `None` if the peer sends
         no certificate chain.
         """
-        ctx = Context(TLSv1_METHOD)
+        ctx = Context(SSLv23_METHOD)
         ctx.use_privatekey(load_privatekey(FILETYPE_PEM, server_key_pem))
         ctx.use_certificate(load_certificate(FILETYPE_PEM, server_cert_pem))
         server = Connection(ctx, None)
         server.set_accept_state()
-        client = Connection(Context(TLSv1_METHOD), None)
+        client = Connection(Context(SSLv23_METHOD), None)
         client.set_connect_state()
         interact_in_memory(client, server)
         assert None is server.get_verified_chain()
@@ -2498,7 +2498,7 @@ class TestConnection(object):
         `Connection.get_verified_chain` returns `None` when used with an object
         which has not been connected.
         """
-        ctx = Context(TLSv1_METHOD)
+        ctx = Context(SSLv23_METHOD)
         server = Connection(ctx, None)
         assert None is server.get_verified_chain()
 


### PR DESCRIPTION
Add X509StoreContext.get_verified_chain using X509_STORE_CTX_get1_chain.
Add Connection.get_verified_chain using SSL_get0_verified_chain if
available (ie OpenSSL 1.1+) and X509StoreContext.get_verified_chain
otherwise.

Motivation: [PyMongo](https://github.com/mongodb/mongo-python-driver/) is implementing OCSP support and we're using PyOpenSSL to do so (thanks!). As part of the client's OCSP callback we would ideally have access to the **verified** peer certificate chain to find the peer's issuer cert. This change allows us to do that by exposing the verified peer certificate chain.

References:
- https://www.openssl.org/docs/man1.1.0/man3/X509_STORE_CTX_get1_chain.html
- https://www.openssl.org/docs/man1.1.0/man3/SSL_get0_verified_chain.html
- The MongoDB server's polyfill implementation of SSL_get0_verified_chain for OpenSSL 1.0.1/1.0.2: https://github.com/mongodb/mongo/blob/r4.4.0/src/mongo/util/net/ssl_manager_openssl.cpp#L312-L327

Fixes #740.