### PR TITLE
Add SSL.Context.set_keylog_callback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Added ``Context.set_keylog_callback`` to log key material.
+  `#910 <https://github.com/pyca/pyopenssl/pull/910>`_
 
 
 19.1.0 (2019-11-18)

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1358,19 +1358,16 @@ class Context(object):
             debugging output.
         :return: None
         """
+
         @wraps(callback)
         def wrapper(ssl, line):
             line = _ffi.string(line)
             callback(Connection._reverse_mapping[ssl], line)
 
         self._keylog_callback = _ffi.callback(
-            "void (*)(const SSL *, const char *)",
-            wrapper
+            "void (*)(const SSL *, const char *)", wrapper
         )
-        _lib.SSL_CTX_set_keylog_callback(
-            self._context,
-            self._keylog_callback
-        )
+        _lib.SSL_CTX_set_keylog_callback(self._context, self._keylog_callback)
 
     def get_app_data(self):
         """

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -697,7 +697,7 @@ _requires_alpn = _make_requires(
 
 
 _requires_keylog = _make_requires(
-    getattr(_lib,"Cryptography_HAS_KEYLOG", None), "Key logging not available"
+    getattr(_lib, "Cryptography_HAS_KEYLOG", None), "Key logging not available"
 )
 
 
@@ -1348,20 +1348,29 @@ class Context(object):
     def set_keylog_callback(self, callback):
         """
         Set the TLS key logging callback to *callback*. This function will be
-        called whenever TLS key material is generated or received,
-        in order to allow applications to store this keying material for debugging purposes.
+        called whenever TLS key material is generated or received, in order
+        to allow applications to store this keying material for debugging
+        purposes.
 
         :param callback: The Python callback to use.  This should take two
-            arguments: a Connection object and a bytestring that contains the key material
-            in the format used by NSS for its SSLKEYLOGFILE debugging output.
+            arguments: a Connection object and a bytestring that contains
+            the key material in the format used by NSS for its SSLKEYLOGFILE
+            debugging output.
         :return: None
         """
         @wraps(callback)
         def wrapper(ssl, line):
             line = _ffi.string(line)
             callback(Connection._reverse_mapping[ssl], line)
-        self._keylog_callback = _ffi.callback("void (*)(const SSL *, const char *)", wrapper)
-        _lib.SSL_CTX_set_keylog_callback(self._context, self._keylog_callback)
+
+        self._keylog_callback = _ffi.callback(
+            "void (*)(const SSL *, const char *)",
+            wrapper
+        )
+        _lib.SSL_CTX_set_keylog_callback(
+            self._context,
+            self._keylog_callback
+        )
 
     def get_app_data(self):
         """

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -696,6 +696,11 @@ _requires_alpn = _make_requires(
 )
 
 
+_requires_keylog = _make_requires(
+    _lib.Cryptography_HAS_KEYLOG, "Key logging not available"
+)
+
+
 class Session(object):
     """
     A class representing an SSL session.  A session defines certain connection
@@ -760,6 +765,7 @@ class Context(object):
         self._verify_helper = None
         self._verify_callback = None
         self._info_callback = None
+        self._keylog_callback = None
         self._tlsext_servername_callback = None
         self._app_data = None
         self._npn_advertise_helper = None
@@ -1337,6 +1343,25 @@ class Context(object):
             "void (*)(const SSL *, int, int)", wrapper
         )
         _lib.SSL_CTX_set_info_callback(self._context, self._info_callback)
+
+    @_requires_keylog
+    def set_keylog_callback(self, callback):
+        """
+        Set the TLS key logging callback to *callback*. This function will be
+        called whenever TLS key material is generated or received,
+        in order to allow applications to store this keying material for debugging purposes.
+
+        :param callback: The Python callback to use.  This should take two
+            arguments: a Connection object and a bytestring that contains the key material
+            in the format used by NSS for its SSLKEYLOGFILE debugging output.
+        :return: None
+        """
+        @wraps(callback)
+        def wrapper(ssl, line):
+            line = _ffi.string(line)
+            callback(Connection._reverse_mapping[ssl], line)
+        self._keylog_callback = _ffi.callback("void (*)(const SSL *, const char *)", wrapper)
+        _lib.SSL_CTX_set_keylog_callback(self._context, self._keylog_callback)
 
     def get_app_data(self):
         """

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -697,7 +697,7 @@ _requires_alpn = _make_requires(
 
 
 _requires_keylog = _make_requires(
-    _lib.Cryptography_HAS_KEYLOG, "Key logging not available"
+    getattr(_lib,"Cryptography_HAS_KEYLOG", None), "Key logging not available"
 )
 
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1003,7 +1003,7 @@ class TestContext(object):
 
     @pytest.mark.skipif(
         not getattr(_lib, "Cryptography_HAS_KEYLOG", None),
-        reason="SSL_CTX_set_keylog_callback unavailable"
+        reason="SSL_CTX_set_keylog_callback unavailable",
     )
     def test_set_keylog_callback(self):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1001,6 +1001,33 @@ class TestContext(object):
             [] == notConnections
         ), "Some info callback arguments were not Connection instances."
 
+    @pytest.mark.skipif(
+        not _lib.Cryptography_HAS_KEYLOG,
+        reason="SSL_CTX_set_keylog_callback unavailable - OpenSSL version may be too old"
+    )
+    def test_set_keylog_callback(self):
+        """
+        `Context.set_keylog_callback` accepts a callable which will be
+        invoked when key material is generated or received.
+        """
+        called = []
+
+        def keylog(conn, line):
+            called.append((conn, line))
+
+        server_context = Context(TLSv1_METHOD)
+        server_context.set_keylog_callback(keylog)
+        server_context.use_certificate(load_certificate(FILETYPE_PEM, cleartextCertificatePEM))
+        server_context.use_privatekey(load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM))
+
+        client_context = Context(TLSv1_METHOD)
+
+        self._handshake_test(server_context, client_context)
+
+        assert called
+        assert all(isinstance(conn, Connection) for conn, line in called)
+        assert all(b"CLIENT_RANDOM" in line for conn, line in called)
+
     def _load_verify_locations_test(self, *args):
         """
         Create a client context which will verify the peer certificate and call

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1002,7 +1002,7 @@ class TestContext(object):
         ), "Some info callback arguments were not Connection instances."
 
     @pytest.mark.skipif(
-        not _lib.Cryptography_HAS_KEYLOG,
+        not getattr(_lib, "Cryptography_HAS_KEYLOG", None),
         reason="SSL_CTX_set_keylog_callback unavailable - OpenSSL version may be too old"
     )
     def test_set_keylog_callback(self):

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1003,7 +1003,7 @@ class TestContext(object):
 
     @pytest.mark.skipif(
         not getattr(_lib, "Cryptography_HAS_KEYLOG", None),
-        reason="SSL_CTX_set_keylog_callback unavailable - OpenSSL version may be too old"
+        reason="SSL_CTX_set_keylog_callback unavailable"
     )
     def test_set_keylog_callback(self):
         """
@@ -1017,8 +1017,12 @@ class TestContext(object):
 
         server_context = Context(TLSv1_METHOD)
         server_context.set_keylog_callback(keylog)
-        server_context.use_certificate(load_certificate(FILETYPE_PEM, cleartextCertificatePEM))
-        server_context.use_privatekey(load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM))
+        server_context.use_certificate(
+            load_certificate(FILETYPE_PEM, cleartextCertificatePEM)
+        )
+        server_context.use_privatekey(
+            load_privatekey(FILETYPE_PEM, cleartextPrivateKeyPEM)
+        )
 
         client_context = Context(TLSv1_METHOD)
 


### PR DESCRIPTION
This builds on the bindings added in https://github.com/pyca/cryptography/pull/5187. :)

The PR should be ready, but this depends on the next minor cryptography release.