### PR TITLE
Fix generated test X.509 certificates.

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1729,6 +1729,9 @@ WpOdIpB8KksUTCzV591Nr1wd
 
     def _extcert(self, pkey, extensions):
         cert = X509()
+        # Certificates with extensions must be X.509v3, which is encoded with a
+        # version of two.
+        cert.set_version(2)
         cert.set_pubkey(pkey)
         cert.get_subject().commonName = "Unit Tests"
         cert.get_issuer().commonName = "Unit Tests"

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -199,6 +199,7 @@ def _create_certificate_chain():
     cakey = PKey()
     cakey.generate_key(TYPE_RSA, 1024)
     cacert = X509()
+    cacert.set_version(2)
     cacert.get_subject().commonName = "Authority Certificate"
     cacert.set_issuer(cacert.get_subject())
     cacert.set_pubkey(cakey)
@@ -212,6 +213,7 @@ def _create_certificate_chain():
     ikey = PKey()
     ikey.generate_key(TYPE_RSA, 1024)
     icert = X509()
+    icert.set_version(2)
     icert.get_subject().commonName = "Intermediate Certificate"
     icert.set_issuer(cacert.get_subject())
     icert.set_pubkey(ikey)
@@ -225,6 +227,7 @@ def _create_certificate_chain():
     skey = PKey()
     skey.generate_key(TYPE_RSA, 1024)
     scert = X509()
+    scert.set_version(2)
     scert.get_subject().commonName = "Server Certificate"
     scert.set_issuer(icert.get_subject())
     scert.set_pubkey(skey)


### PR DESCRIPTION
From RFC 5280, section 4.1.2.9:

>   [Extensions] MUST only appear if the version is 3 (Section 4.1.2.1).
>   If present, this field is a SEQUENCE of one or more certificate
>   extensions.  The format and content of certificate extensions in the
>   Internet PKI are defined in Section 4.2.

X509 objects default to v1, so the test certs need a set_version(2) call. (Note v3 is encoded as 2.)