### PR TITLE
Fix Travis CI build config validation issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+os: linux
 dist: xenial
-sudo: true
 language: python
 
 cache:
@@ -10,7 +10,7 @@ env:
   global:
     - LC_ALL=en_US.UTF-8
 
-matrix:
+jobs:
   include:
   - language: generic
     os: osx


### PR DESCRIPTION
* `sudo` key is deprecated
* `os` key is missing
* `matrix` is an alias for `jobs`

![Screenshot 2020-07-12 at 08 06 17](https://user-images.githubusercontent.com/3709715/87240154-56eebd80-c417-11ea-855e-87a85316ada2.png)