### PR TITLE
Context.set_verify: allow omission of callback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Changes:
 - Added ``OpenSSL.SSL.Connection.get_verified_chain`` to retrieve the
   verified certificate chain of the peer.
   `#894 <https://github.com/pyca/pyopenssl/pull/894>`_.
+- Allow omission of the verification callback in ``Context.set_verify``.
+  `#933 <https://github.com/pyca/pyopenssl/pull/933>`_
 
 
 19.1.0 (2019-11-18)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,8 @@ Changes:
 - Added ``OpenSSL.SSL.Connection.get_verified_chain`` to retrieve the
   verified certificate chain of the peer.
   `#894 <https://github.com/pyca/pyopenssl/pull/894>`_.
-- Allow omission of the verification callback in ``Context.set_verify``.
+- Make verification callback optional in ``Context.set_verify``.
+  If omitted, OpenSSL's default verification is used.
   `#933 <https://github.com/pyca/pyopenssl/pull/933>`_
 
 

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1013,12 +1013,12 @@ class Context(object):
             :const:`VERIFY_PEER` is used, *mode* can be OR:ed with
             :const:`VERIFY_FAIL_IF_NO_PEER_CERT` and
             :const:`VERIFY_CLIENT_ONCE` to further control the behaviour.
-        :param callback: The optional Python callback to use. This should take
-            five arguments: A Connection object, an X509 object, and three
-            integer variables, which are in turn potential error number, error
-            depth and return code. *callback* should return True if
-            verification passes and False otherwise. If omitted, OpenSSL's
-            verification result (the return code) is passed through.
+        :param callback: The optional Python verification callback to use.
+            This should take five arguments: A Connection object, an X509
+            object, and three integer variables, which are in turn potential
+            error number, error depth and return code. *callback* should
+            return True if verification passes and False otherwise.
+            If omitted, OpenSSL's default verification is used.
         :return: None
 
         See SSL_CTX_set_verify(3SSL) for further details.

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1013,12 +1013,12 @@ class Context(object):
             :const:`VERIFY_PEER` is used, *mode* can be OR:ed with
             :const:`VERIFY_FAIL_IF_NO_PEER_CERT` and
             :const:`VERIFY_CLIENT_ONCE` to further control the behaviour.
-        :param callback: The optional Python callback to use. This should take five
-            arguments: A Connection object, an X509 object, and three integer
-            variables, which are in turn potential error number, error depth
-            and return code. *callback* should return True if verification
-            passes and False otherwise. If omitted, OpenSSL's verification result
-            (the return code) is passed through.
+        :param callback: The optional Python callback to use. This should take
+            five arguments: A Connection object, an X509 object, and three
+            integer variables, which are in turn potential error number, error
+            depth and return code. *callback* should return True if
+            verification passes and False otherwise. If omitted, OpenSSL's
+            verification result (the return code) is passed through.
         :return: None
 
         See SSL_CTX_set_verify(3SSL) for further details.


### PR DESCRIPTION
This PR allows it to call `set_verify` without specifying an explicit callback:

> If no verify_callback is specified, the default callback will be used. Its return value is identical to preverify_ok, so that any verification failure will lead to a termination of the TLS/SSL handshake with an alert message, if SSL_VERIFY_PEER is set.

This simplifies the most common case to `context.set_verify(SSL.VERIFY_PEER)`. Now that OpenSSL has builtin hostname validation, it's probably a good thing to discourage people from writing custom certificate verification.