### PR TITLE
Allow using an OpenSSL hashed directory for verification in X509Store

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,9 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
+- Added ``OpenSSL.crypto.X509Store.load_locations`` to set trusted
+  certificate file bundles and/or directories for verification.
+  `#943 <https://github.com/pyca/pyopenssl/pull/943>`_
 - Added ``Context.set_keylog_callback`` to log key material.
   `#910 <https://github.com/pyca/pyopenssl/pull/910>`_
 - Added ``OpenSSL.SSL.Connection.get_verified_chain`` to retrieve the


### PR DESCRIPTION
Add `X509Store.load_locations()` to set a CA bundle file and/or an OpenSSL-style hashed CA/CRL lookup directory. 
This exposes `X509_STORE_load_locations()` from OpenSSL, similar to what the already existing `SSL.Context.load_verify_locations()` does for `SSL_CTX_load_verify_locations()`.
