### PR TITLE
Keep reference to SSL verify_call in Connection object

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1485,6 +1485,12 @@ class Connection(object):
         # avoid them getting freed.
         self._alpn_select_callback_args = None
 
+        # Reference the verify_callback of the Context. This ensures that if
+        # set_verify is called again after the SSL object has been created we
+        # do not point to a dangling reference
+        self._verify_helper = context._verify_helper
+        self._verify_callback = context._verify_callback
+
         self._reverse_mapping[self._ssl] = self
 
         if socket is None:


### PR DESCRIPTION
If a set_verify is used on a context before and after a Connection
the reference in the SSL* object still points to the old _verify_helper
object. Since this object has no longer any references to it, the
callback can result in a segfault.

This commit fixes the issues by ensuring that as long as the
Connection object/SSL* object lives a reference to the callback
function is held.

Note: I have not checked if other callback functions suffer the same problem