### PR TITLE
Fix typo in debug command output

### DIFF
--- a/src/OpenSSL/debug.py
+++ b/src/OpenSSL/debug.py
@@ -16,7 +16,7 @@ cryptography: {cryptography}
 cffi: {cffi}
 cryptography's compiled against OpenSSL: {crypto_openssl_compile}
 cryptography's linked OpenSSL: {crypto_openssl_link}
-Pythons's OpenSSL: {python_openssl}
+Python's OpenSSL: {python_openssl}
 Python executable: {python}
 Python version: {python_version}
 Platform: {platform}


### PR DESCRIPTION
Hi,

Love the software! I noticed a small typo in the output from the ``python -m OpenSSL.debug`` command.