### PR TITLE
Add .gitattributes to force .rst files to LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rst text eol=lf


### PR DESCRIPTION
setup.py runs a regex which assumes LF line endings
over the contents of CHANGELOG.rst.
When installing pyopenssl from source (`pip install git+...`)
on Windows, there's a good chance these files will be checked
out with CRLF line endings today, which leads to:

```
AttributeError: 'NoneType' object has no attribute 'group'
```

We could also address this by having the `read_file`
function in setup.py enforce LF line endings.
I think changing `codecs.open` to just `open`
would do it, since the default behavior of
universal newlines would be to translate to LF.