### PR TITLE
Update bdist_rpm option build_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ license_file = LICENSE
 # This is currently *not* actively tested.
 [bdist_rpm]
 release = 1
-build-requires = openssl-devel python-devel python-sphinx
+build_requires = openssl-devel python-devel python-sphinx
 group = Development/Libraries
 build_script = rpm/build_script
 doc-files = doc/_build/html


### PR DESCRIPTION
Hi, I saw a warning message note that `build-requires` should be `build_requires` when I tried to install local pyopenssl
```bash
$ pip install -e .
...
```


ref:
https://www.pyopenssl.org/en/stable/install.html. 
https://docs.python.org/3/distutils/builtdist.html#creating-rpm-packages. 