### PR TITLE
Add `NO_OVERLAPPING_PROTOCOLS` to `__all__`

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -117,6 +117,7 @@ __all__ = [
     "WantX509LookupError",
     "ZeroReturnError",
     "SysCallError",
+    "NO_OVERLAPPING_PROTOCOLS",
     "SSLeay_version",
     "Session",
     "Context",


### PR DESCRIPTION
Minor nit, just noticed this while fixing up types-pyOpenSSL. :)