### PR TITLE
Don't try to serialize invalid objects in tests

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1668,6 +1668,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         """
         request = X509Req()
         pkey = load_privatekey(FILETYPE_PEM, root_key_pem)
+        request.set_pubkey(pkey)
         request.sign(pkey, GOOD_DIGEST)
         another_pkey = load_privatekey(FILETYPE_PEM, client_key_pem)
         with pytest.raises(Error):
@@ -1680,6 +1681,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         """
         request = X509Req()
         pkey = load_privatekey(FILETYPE_PEM, root_key_pem)
+        request.set_pubkey(pkey)
         request.sign(pkey, GOOD_DIGEST)
         assert request.verify(pkey)
 
@@ -3373,6 +3375,9 @@ class TestNetscapeSPKI(_PKeyInteractionTestsMixin):
         `NetscapeSPKI.b64_encode` encodes the certificate to a base64 blob.
         """
         nspki = NetscapeSPKI()
+        pkey = load_privatekey(FILETYPE_PEM, root_key_pem)
+        nspki.set_pubkey(pkey)
+        nspki.sign(pkey, GOOD_DIGEST)
         blob = nspki.b64_encode()
         assert isinstance(blob, bytes)
 


### PR DESCRIPTION
A default-constructed X509_REQ or NETSCAPE_SPKI contains empty values
for all its fields, notably the OIDs in public keys. This initial state
is incomplete and not yet a valid object. The ASN.1 structures make the
public key mandatory.  When serializing, OpenSSL would previously
silently omit the field, which doesn't actually produce a valid
structure.

As of https://github.com/openssl/openssl/pull/16027, OpenSSL will notice
this and return an error rather than serialize garbage. Sadly, that had
to be reverted on 1.1.1, but it is present in the 3.0 branch. With that
change, some of pyOpenSSL's tests fail.

The bug here is in pyOpenSSL: pyOpenSSL tests are trying to serialize
incomplete objects. Instead, fill in the public key.  While not
syntactically necessary (the empty string is a BIT STRING), also fill in
the signature for NetscapeSPKI, to better align with real code.

Tested by running pyOpenSSL tests against a copy of OpenSSL 1.1.1's dev
branch, prior to the changes getting reverted.