### PR TITLE
setup.cfg: Replace dashes with underscores

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ license_file = LICENSE
 # This is currently *not* actively tested.
 [bdist_rpm]
 release = 1
-build-requires = openssl-devel python-devel python-sphinx
+build_requires = openssl-devel python-devel python-sphinx
 group = Development/Libraries
 build_script = rpm/build_script
-doc-files = doc/_build/html
+doc_files = doc/_build/html


### PR DESCRIPTION
Setuptools v54.1.0 introduces a warning that the use of dash-separated options in 'setup.cfg' will not be supported in a future version. https://github.com/pypa/setuptools/commit/a2e9ae4cb
Get ahead of the issue by replacing the dashes with underscores. Without this, we see 'UserWarning' messages like the following on new enough versions of setuptools:

> UserWarning: Usage of dash-separated 'build-requires' will not be supported in future versions. Please use the underscore name 'build_requires' instead
> UserWarning: Usage of dash-separated 'doc-files' will not be supported in future versions. Please use the underscore name 'doc_files' instead