### PR TITLE
remove SSL_CTX_set_ecdh_auto call

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -724,12 +724,6 @@ class Context(object):
         _openssl_assert(context != _ffi.NULL)
         context = _ffi.gc(context, _lib.SSL_CTX_free)
 
-        # Set SSL_CTX_set_ecdh_auto so that the ECDH curve will be
-        # auto-selected. This function was added in 1.0.2 and made a noop in
-        # 1.1.0+ (where it is set automatically).
-        res = _lib.SSL_CTX_set_ecdh_auto(context, 1)
-        _openssl_assert(res == 1)
-
         self._context = context
         self._passphrase_helper = None
         self._passphrase_callback = None


### PR DESCRIPTION
Calls to SSL_CTX_set_ecdh_auto are a noop on 1.1.0+ and pyOpenSSL only supports 1.1.0+ now due to cryptography versions