### PR TITLE
Remove call to init_static_locks

### DIFF
--- a/src/OpenSSL/_util.py
+++ b/src/OpenSSL/_util.py
@@ -5,7 +5,6 @@ from cryptography.hazmat.bindings.openssl.binding import Binding
 
 
 binding = Binding()
-binding.init_static_locks()
 ffi = binding.ffi
 lib = binding.lib
 


### PR DESCRIPTION
It has been a no-op (when called from an _instance_ of Binding) since 3.3