### PR TITLE
Remove native, it's behavior is confusing

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -12,7 +12,6 @@ from OpenSSL._util import (
     ffi as _ffi,
     lib as _lib,
     make_assert as _make_assert,
-    native as _native,
     path_string as _path_string,
     text_to_bytes_and_warn as _text_to_bytes_and_warn,
     no_zero_allocator as _no_zero_allocator,
@@ -2125,7 +2124,7 @@ class Connection(object):
             result = _lib.SSL_get_cipher_list(self._ssl, i)
             if result == _ffi.NULL:
                 break
-            ciphers.append(_native(_ffi.string(result)))
+            ciphers.append(_ffi.string(result).decode("utf-8"))
         return ciphers
 
     def get_client_ca_list(self):

--- a/src/OpenSSL/_util.py
+++ b/src/OpenSSL/_util.py
@@ -26,7 +26,7 @@ def text(charp):
     """
     if not charp:
         return ""
-    return native(ffi.string(charp))
+    return ffi.string(charp).decode("utf-8")
 
 
 def exception_from_error_queue(exception_type):
@@ -69,23 +69,6 @@ def make_assert(error):
             exception_from_error_queue(error)
 
     return openssl_assert
-
-
-def native(s):
-    """
-    Convert :py:class:`bytes` or :py:class:`unicode` to the native
-    :py:class:`str` type, using UTF-8 encoding if conversion is necessary.
-
-    :raise UnicodeError: The input string is not UTF-8 decodeable.
-
-    :raise TypeError: The input is neither :py:class:`bytes` nor
-        :py:class:`unicode`.
-    """
-    if not isinstance(s, (bytes, str)):
-        raise TypeError("%r is neither bytes nor unicode" % s)
-    if isinstance(s, bytes):
-        return s.decode("utf-8")
-    return s
 
 
 def path_string(s):


### PR DESCRIPTION
Instead just decode stuff at the call-sites -- 100% of which were passing bytes