### PR TITLE
add `Connection.set_verify`, fix #255

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
     strategy:
       matrix:
         TEST:
+          - {CONTAINER: "ubuntu-bionic", TOXENV: "py36"}
           # cryptographyMain used since there's no wheel
           - {CONTAINER: "ubuntu-rolling", TOXENV: "py310-cryptographyMain"}
     name: "${{ matrix.TEST.TOXENV }} on ${{ matrix.TEST.CONTAINER }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
     strategy:
       matrix:
         TEST:
-          - {CONTAINER: "ubuntu-bionic", TOXENV: "py36"}
           # cryptographyMain used since there's no wheel
           - {CONTAINER: "ubuntu-rolling", TOXENV: "py310-cryptographyMain"}
     name: "${{ matrix.TEST.TOXENV }} on ${{ matrix.TEST.CONTAINER }}"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
+- Add ``OpenSSL.SSL.Connection.set_verify`` and ``OpenSSL.SSL.Connection.get_verify_mode``
+  to override the context object's verification flags.
+  `#1073 <https://github.com/pyca/pyopenssl/pull/1073>`_
+
 22.0.0 (2022-01-29)
 -------------------
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2647,9 +2647,10 @@ class TestConnection:
 
     def test_set_verify_callback_reference(self):
         """
-        The callback for certificate verification should only be forgotten if the context and all connections
-        created by it do not use it anymore.
+        The callback for certificate verification should only be forgotten if
+        the context and all connections created by it do not use it anymore.
         """
+
         def callback(conn, cert, errnum, depth, ok):  # pragma: no cover
             return ok
 


### PR DESCRIPTION
This PR adds `Connection.set_verify` and `Connection.get_verify_mode` to fix #255. Compared to #844 (a previous attempt which went stale) things got a bit simpler as `Connection` now already has its own `_verify_helper` and `_verify_callback` attributes.

I'm happy to add more tests if you feel that would be useful, I did not copy and adapt all the `Context.set_verify` tests as that felt more like a maintenance burden than anything else. Line coverage is at 100% anyhow.

<s>CI will fail as we depend on the yet-unreleased cryptography bindings. :)</s>