### PR TITLE
Don’t inherit from object

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -293,7 +293,7 @@ class SysCallError(Error):
     pass
 
 
-class _CallbackExceptionHelper(object):
+class _CallbackExceptionHelper:
     """
     A base class for wrapper classes that allow for intelligent exception
     handling in OpenSSL callbacks.
@@ -657,7 +657,7 @@ _requires_keylog = _make_requires(
 )
 
 
-class Session(object):
+class Session:
     """
     A class representing an SSL session.  A session defines certain connection
     parameters which may be re-used to speed up the setup of subsequent
@@ -669,7 +669,7 @@ class Session(object):
     pass
 
 
-class Context(object):
+class Context:
     """
     :class:`OpenSSL.SSL.Context` instances define the parameters for setting
     up new SSL connections.
@@ -1588,7 +1588,7 @@ class Context(object):
         )
 
 
-class Connection(object):
+class Connection:
     _reverse_mapping = WeakValueDictionary()
 
     def __init__(self, context, socket=None):

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -200,7 +200,7 @@ def _get_asn1_time(timestamp):
             return string_result
 
 
-class _X509NameInvalidator(object):
+class _X509NameInvalidator:
     def __init__(self):
         self._names = []
 
@@ -213,7 +213,7 @@ class _X509NameInvalidator(object):
             del name._name
 
 
-class PKey(object):
+class PKey:
     """
     A class representing an DSA or RSA public key or key pair.
     """
@@ -392,7 +392,7 @@ class PKey(object):
         return _lib.EVP_PKEY_bits(self._pkey)
 
 
-class _EllipticCurve(object):
+class _EllipticCurve:
     """
     A representation of a supported elliptic curve.
 
@@ -528,7 +528,7 @@ def get_elliptic_curve(name):
     raise ValueError("unknown curve name", name)
 
 
-class X509Name(object):
+class X509Name:
     """
     An X.509 Distinguished Name.
 
@@ -728,7 +728,7 @@ class X509Name(object):
         return result
 
 
-class X509Extension(object):
+class X509Extension:
     """
     An X.509 v3 certificate extension.
     """
@@ -880,7 +880,7 @@ class X509Extension(object):
         return _ffi.buffer(char_result, result_length)[:]
 
 
-class X509Req(object):
+class X509Req:
     """
     An X.509 certificate signing requests.
     """
@@ -1092,7 +1092,7 @@ class X509Req(object):
         return result
 
 
-class X509(object):
+class X509:
     """
     An X.509 certificate.
     """
@@ -1567,7 +1567,7 @@ class X509(object):
         return ext
 
 
-class X509StoreFlags(object):
+class X509StoreFlags:
     """
     Flags for X509 verification, used to change the behavior of
     :class:`X509Store`.
@@ -1590,7 +1590,7 @@ class X509StoreFlags(object):
     CHECK_SS_SIGNATURE = _lib.X509_V_FLAG_CHECK_SS_SIGNATURE
 
 
-class X509Store(object):
+class X509Store:
     """
     An X.509 store.
 
@@ -1756,7 +1756,7 @@ class X509StoreContextError(Exception):
         self.certificate = certificate
 
 
-class X509StoreContext(object):
+class X509StoreContext:
     """
     An X.509 store context.
 
@@ -2081,7 +2081,7 @@ def dump_privatekey(type, pkey, cipher=None, passphrase=None):
     return _bio_to_string(bio)
 
 
-class Revoked(object):
+class Revoked:
     """
     A certificate revocation.
     """
@@ -2254,7 +2254,7 @@ class Revoked(object):
         return _get_asn1_time(dt)
 
 
-class CRL(object):
+class CRL:
     """
     A certificate revocation list.
     """
@@ -2476,7 +2476,7 @@ class CRL(object):
         return dump_crl(type, self)
 
 
-class PKCS7(object):
+class PKCS7:
     def type_is_signed(self):
         """
         Check if this NID_pkcs7_signed object
@@ -2520,7 +2520,7 @@ class PKCS7(object):
         return _ffi.string(string_type)
 
 
-class PKCS12(object):
+class PKCS12:
     """
     A PKCS #12 archive.
     """
@@ -2701,7 +2701,7 @@ class PKCS12(object):
         return _bio_to_string(bio)
 
 
-class NetscapeSPKI(object):
+class NetscapeSPKI:
     """
     A Netscape SPKI object.
     """
@@ -2791,7 +2791,7 @@ class NetscapeSPKI(object):
         _openssl_assert(set_result == 1)
 
 
-class _PassphraseHelper(object):
+class _PassphraseHelper:
     def __init__(self, type, passphrase, more_args=False, truncate=False):
         if type != FILETYPE_PEM and passphrase is not None:
             raise ValueError(

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -809,7 +809,7 @@ def x509_data():
     yield pkey, x509
 
 
-class TestX509Ext(object):
+class TestX509Ext:
     """
     Tests for `OpenSSL.crypto.X509Extension`.
     """
@@ -1008,7 +1008,7 @@ class TestX509Ext(object):
             )
 
 
-class TestPKey(object):
+class TestPKey:
     """
     Tests for `OpenSSL.crypto.PKey`.
     """
@@ -1222,7 +1222,7 @@ def x509_name(**attrs):
     return name
 
 
-class TestX509Name(object):
+class TestX509Name:
     """
     Unit tests for `OpenSSL.crypto.X509Name`.
     """
@@ -2224,7 +2224,7 @@ tgI5
         assert crypto_cert.version.value == cert.get_version()
 
 
-class TestX509Store(object):
+class TestX509Store:
     """
     Test for `OpenSSL.crypto.X509Store`.
     """
@@ -2295,7 +2295,7 @@ class TestX509Store(object):
     def test_load_locations_parameters(
         self, cafile, capath, call_cafile, call_capath, monkeypatch
     ):
-        class LibMock(object):
+        class LibMock:
             def load_locations(self, store, cafile, capath):
                 self.cafile = cafile
                 self.capath = capath
@@ -2326,7 +2326,7 @@ class TestX509Store(object):
             store.load_locations(cafile=str(invalid_ca_file))
 
 
-class TestPKCS12(object):
+class TestPKCS12:
     """
     Test for `OpenSSL.crypto.PKCS12` and `OpenSSL.crypto.load_pkcs12`.
     """
@@ -2802,7 +2802,7 @@ def _runopenssl(pem, *args):
     return output
 
 
-class TestLoadPublicKey(object):
+class TestLoadPublicKey:
     """
     Tests for :func:`load_publickey`.
     """
@@ -2842,7 +2842,7 @@ class TestLoadPublicKey(object):
         assert dumped_pem == cleartextPublicKeyPEM
 
 
-class TestFunction(object):
+class TestFunction:
     """
     Tests for free-functions in the `OpenSSL.crypto` module.
     """
@@ -3263,7 +3263,7 @@ class TestFunction(object):
             load_pkcs7_data(object(), b"foo")
 
 
-class TestLoadCertificate(object):
+class TestLoadCertificate:
     """
     Tests for `load_certificate_request`.
     """
@@ -3287,7 +3287,7 @@ class TestLoadCertificate(object):
             load_certificate(FILETYPE_ASN1, b"lol")
 
 
-class TestPKCS7(object):
+class TestPKCS7:
     """
     Tests for `PKCS7`.
     """
@@ -3387,7 +3387,7 @@ class TestNetscapeSPKI(_PKeyInteractionTestsMixin):
         assert isinstance(blob, bytes)
 
 
-class TestRevoked(object):
+class TestRevoked:
     """
     Tests for `OpenSSL.crypto.Revoked`.
     """
@@ -3497,7 +3497,7 @@ class TestRevoked(object):
             revoked.set_reason(b"blue")
 
 
-class TestCRL(object):
+class TestCRL:
     """
     Tests for `OpenSSL.crypto.CRL`.
     """
@@ -3858,7 +3858,7 @@ class TestCRL(object):
         assert isinstance(crypto_crl, x509.CertificateRevocationList)
 
 
-class TestX509StoreContext(object):
+class TestX509StoreContext:
     """
     Tests for `OpenSSL.crypto.X509StoreContext`.
     """
@@ -4226,7 +4226,7 @@ class TestX509StoreContext(object):
         assert exc.value.args[0][2] == "unable to get local issuer certificate"
 
 
-class TestSignVerify(object):
+class TestSignVerify:
     """
     Tests for `OpenSSL.crypto.sign` and `OpenSSL.crypto.verify`.
     """
@@ -4348,7 +4348,7 @@ class TestSignVerify(object):
         sign(priv_key, content, "sha256")
 
 
-class TestEllipticCurve(object):
+class TestEllipticCurve:
     """
     Tests for `_EllipticCurve`, `get_elliptic_curve`, and
     `get_elliptic_curves`.
@@ -4399,7 +4399,7 @@ class TestEllipticCurve(object):
         curve._to_EC_KEY()
 
 
-class EllipticCurveFactory(object):
+class EllipticCurveFactory:
     """
     A helper to get the names of two curves.
     """
@@ -4434,7 +4434,7 @@ class TestEllipticCurveEquality(EqualityTestsMixin):
         return get_elliptic_curve(self.curve_factory.another_curve_name)
 
 
-class TestEllipticCurveHash(object):
+class TestEllipticCurveHash:
     """
     Tests for `_EllipticCurve`'s implementation of hashing (thus use as
     an item in a `dict` or `set`).

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -10,7 +10,7 @@ import pytest
 from OpenSSL import rand
 
 
-class TestRand(object):
+class TestRand:
     @pytest.mark.parametrize("args", [(b"foo", None), (None, 3)])
     def test_add_wrong_args(self, args):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -410,7 +410,7 @@ def handshake_in_memory(client_conn, server_conn):
     interact_in_memory(client_conn, server_conn)
 
 
-class TestVersion(object):
+class TestVersion:
     """
     Tests for version information exposed by `OpenSSL.SSL.SSLeay_version` and
     `OpenSSL.SSL.OPENSSL_VERSION_NUMBER`.
@@ -491,7 +491,7 @@ def context():
     return Context(SSLv23_METHOD)
 
 
-class TestContext(object):
+class TestContext:
     """
     Unit tests for `OpenSSL.SSL.Context`.
     """
@@ -1364,7 +1364,7 @@ class TestContext(object):
         )
         serverConnection = Connection(serverContext, None)
 
-        class VerifyCallback(object):
+        class VerifyCallback:
             def callback(self, connection, *args):
                 self.connection = connection
                 return 1
@@ -1776,7 +1776,7 @@ class TestContext(object):
         assert context.set_tlsext_use_srtp(b"SRTP_AES128_CM_SHA1_80") is None
 
 
-class TestServerNameCallback(object):
+class TestServerNameCallback:
     """
     Tests for `Context.set_tlsext_servername_callback` and its
     interaction with `Connection`.
@@ -1885,7 +1885,7 @@ class TestServerNameCallback(object):
         assert args == [(server, b"foo1.example.com")]
 
 
-class TestApplicationLayerProtoNegotiation(object):
+class TestApplicationLayerProtoNegotiation:
     """
     Tests for ALPN in PyOpenSSL.
     """
@@ -2165,7 +2165,7 @@ class TestApplicationLayerProtoNegotiation(object):
         assert select_args == [(server, [b"http/1.1", b"spdy/2"])]
 
 
-class TestSession(object):
+class TestSession:
     """
     Unit tests for :py:obj:`OpenSSL.SSL.Session`.
     """
@@ -2179,7 +2179,7 @@ class TestSession(object):
         assert isinstance(new_session, Session)
 
 
-class TestConnection(object):
+class TestConnection:
     """
     Unit tests for `OpenSSL.SSL.Connection`.
     """
@@ -2979,7 +2979,7 @@ class TestConnection(object):
         assert 2 == len(data)
 
 
-class TestConnectionGetCipherList(object):
+class TestConnectionGetCipherList:
     """
     Tests for `Connection.get_cipher_list`.
     """
@@ -3005,7 +3005,7 @@ class VeryLarge(bytes):
         return 2**31
 
 
-class TestConnectionSend(object):
+class TestConnectionSend:
     """
     Tests for `Connection.send`.
     """
@@ -3091,7 +3091,7 @@ def _make_memoryview(size):
     return memoryview(bytearray(size))
 
 
-class TestConnectionRecvInto(object):
+class TestConnectionRecvInto:
     """
     Tests for `Connection.recv_into`.
     """
@@ -3214,7 +3214,7 @@ class TestConnectionRecvInto(object):
         self._doesnt_overfill_test(_make_memoryview)
 
 
-class TestConnectionSendall(object):
+class TestConnectionSendall:
     """
     Tests for `Connection.sendall`.
     """
@@ -3296,7 +3296,7 @@ class TestConnectionSendall(object):
             assert err.value.args[0] == EPIPE
 
 
-class TestConnectionRenegotiate(object):
+class TestConnectionRenegotiate:
     """
     Tests for SSL renegotiation APIs.
     """
@@ -3340,7 +3340,7 @@ class TestConnectionRenegotiate(object):
             pass
 
 
-class TestError(object):
+class TestError:
     """
     Unit tests for `OpenSSL.SSL.Error`.
     """
@@ -3353,7 +3353,7 @@ class TestError(object):
         assert Error.__name__ == "Error"
 
 
-class TestConstants(object):
+class TestConstants:
     """
     Tests for the values of constants exposed in `OpenSSL.SSL`.
 
@@ -3470,7 +3470,7 @@ class TestConstants(object):
         assert 0x300 == SESS_CACHE_NO_INTERNAL
 
 
-class TestMemoryBIO(object):
+class TestMemoryBIO:
     """
     Tests for `OpenSSL.SSL.Connection` using a memory BIO.
     """
@@ -3894,7 +3894,7 @@ class TestMemoryBIO(object):
         self._check_client_ca_list(set_replaces_add_ca)
 
 
-class TestInfoConstants(object):
+class TestInfoConstants:
     """
     Tests for assorted constants exposed for use in info callbacks.
     """
@@ -3937,7 +3937,7 @@ class TestInfoConstants(object):
             assert const is None or isinstance(const, int)
 
 
-class TestRequires(object):
+class TestRequires:
     """
     Tests for the decorator factory used to conditionally raise
     NotImplementedError when older OpenSSLs are used.
@@ -3976,7 +3976,7 @@ class TestRequires(object):
         assert "Error text" in str(e.value)
 
 
-class TestOCSP(object):
+class TestOCSP:
     """
     Tests for PyOpenSSL's OCSP stapling support.
     """
@@ -4222,7 +4222,7 @@ class TestOCSP(object):
             handshake_in_memory(client, server)
 
 
-class TestDTLS(object):
+class TestDTLS:
     # The way you would expect DTLSv1_listen to work is:
     #
     # - it reads packets in a loop

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,7 +3,7 @@ import pytest
 from OpenSSL._util import exception_from_error_queue, lib
 
 
-class TestErrors(object):
+class TestErrors:
     """
     Tests for handling of certain OpenSSL error cases.
     """

--- a/tests/util.py
+++ b/tests/util.py
@@ -30,7 +30,7 @@ def is_consistent_type(theType, name, *constructionArgs):
     return True
 
 
-class EqualityTestsMixin(object):
+class EqualityTestsMixin:
     """
     A mixin defining tests for the standard implementation of C{==} and C{!=}.
     """
@@ -126,7 +126,7 @@ class EqualityTestsMixin(object):
         operand if it is of an unrelated type.
         """
 
-        class Delegate(object):
+        class Delegate:
             def __eq__(self, other):
                 # Do something crazy and obvious.
                 return [self]
@@ -141,7 +141,7 @@ class EqualityTestsMixin(object):
         operand if it is of an unrelated type.
         """
 
-        class Delegate(object):
+        class Delegate:
             def __ne__(self, other):
                 # Do something crazy and obvious.
                 return [self]


### PR DESCRIPTION
In python3 all classes inherit by default from object

Now that support for python2 was dropped this is not needed anymore