### PR TITLE
X509Name: Use functools.totalordering for comparisons

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -642,17 +642,17 @@ class X509Name:
             _lib.OPENSSL_free(result_buffer[0])
         return result
 
-    def _cmp(self, other):
+    def __eq__(self, other):
         if not isinstance(other, X509Name):
             return NotImplemented
 
-        return _lib.X509_NAME_cmp(self._name, other._name)
-
-    def __eq__(self, other):
-        return self._cmp(other) == 0
+        return _lib.X509_NAME_cmp(self._name, other._name) == 0
 
     def __lt__(self, other):
-        return self._cmp(other) < 0
+        if not isinstance(other, X509Name):
+            return NotImplemented
+
+        return _lib.X509_NAME_cmp(self._name, other._name) < 0
 
     def __repr__(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1398,6 +1398,19 @@ class TestX509Name:
         # other X509Name.
         assert_greater_than(x509_name(CN="def"), x509_name(CN="abc"))
 
+        def assert_raises(a, b):
+            with pytest.raises(TypeError):
+                a < b
+            with pytest.raises(TypeError):
+                a <= b
+            with pytest.raises(TypeError):
+                a > b
+            with pytest.raises(TypeError):
+                a >= b
+
+        # Only X509Name objects can be compared with lesser than / greater than
+        assert_raises(x509_name(), object())
+
     def test_hash(self):
         """
         `X509Name.hash` returns an integer hash based on the value of the name.


### PR DESCRIPTION
- Reduce the magic
- Make it more readable
- Make it easier to add type annotations in the future