### PR TITLE
X509Name: Raise AttributeError correctly

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -620,7 +620,7 @@ class X509Name:
                 _raise_current_error()
             except Error:
                 pass
-            return super(X509Name, self).__getattr__(name)
+            raise AttributeError("No such attribute")
 
         entry_index = _lib.X509_NAME_get_index_by_NID(self._name, nid, -1)
         if entry_index == -1:


### PR DESCRIPTION
X509Name does only inherit from object, which has no `__getattr__()` method.
By accident this also raised an AttributeError but the error message
is confusing.

This commit now raises the AttributeError with a descriptive message.

Fixes #1085