### PR TITLE
Remove py2 tag from wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,6 @@ minversion = 3.0.1
 strict = true
 testpaths = tests
 
-[bdist_wheel]
-# We are a pure-Python project so a single wheel is enough.
-universal = 1
-
 [metadata]
 # Ensure LICENSE is included in wheels.
 license_file = LICENSE


### PR DESCRIPTION
Universal wheels are for supporting Python 2 and 3, and adds the unnecessary `py2` tag to the wheel metadata and filename:

* `pyOpenSSL-22.0.0-py2.py3-none-any.whl`

https://pypi.org/project/pyOpenSSL/22.0.0/#files

https://wheel.readthedocs.io/en/stable/user_guide.html#building-wheels