### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
         author_email=find_meta("email"),
         url=URI,
         project_urls={
-            'Source': 'https://github.com/pyca/pyopenssl',
+            "Source": "https://github.com/pyca/pyopenssl",
         },
         license=find_meta("license"),
         classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,9 @@ if __name__ == "__main__":
         author=find_meta("author"),
         author_email=find_meta("email"),
         url=URI,
+        project_urls={
+            'Source': 'https://github.com/pyca/pyopenssl',
+        },
         license=find_meta("license"),
         classifiers=[
             "Development Status :: 6 - Mature",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.