### PR TITLE
Changed load_crl doc comment return to CRL

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -3081,7 +3081,7 @@ def load_crl(type, buffer):
     :param type: The file type (one of FILETYPE_PEM, FILETYPE_ASN1)
     :param buffer: The buffer the CRL is stored in
 
-    :return: The PKey object
+    :return: The CRL object
     """
     if isinstance(buffer, str):
         buffer = buffer.encode("ascii")


### PR DESCRIPTION
The documentation claimed `OpenSSL.crypto.load_crl` returned "The PKey object" rather than "The CRL object".