### PR TITLE
Remove SSL_library_init call

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2618,8 +2618,3 @@ class Connection:
             self._ssl, _lib.TLSEXT_STATUSTYPE_ocsp
         )
         _openssl_assert(rc == 1)
-
-
-# This is similar to the initialization calls at the end of OpenSSL/crypto.py
-# but is exercised mostly by the Context initializer.
-_lib.SSL_library_init()


### PR DESCRIPTION
a) It's already called by initializing the Bindings in cryptography
b) I'm pretty sure it's not actually necessary at all