### PR TITLE
Fix error module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             # Fix cryptographyMinimum in tox.ini when changing this!
-            "cryptography>=35.0",
+            "cryptography>=35.0,<37.0.0",
         ],
         extras_require={
             "test": ["flaky", "pretend", "pytest>=3.0.1"],


### PR DESCRIPTION
Release today:
 - https://pypi.org/project/cryptography/37.0.0

And it is raising the following error:
 - `module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'`

So current pyopenssl version is only compatible with cryptography<37.0.0