### PR TITLE
add `Connection.use_(certificate|privatekey)`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ Changes:
 - Add ``OpenSSL.SSL.Connection.set_verify`` and ``OpenSSL.SSL.Connection.get_verify_mode``
   to override the context object's verification flags.
   `#1073 <https://github.com/pyca/pyopenssl/pull/1073>`_
+- Add ``OpenSSL.SSL.Connection.use_certificate`` and ``OpenSSL.SSL.Connection.use_privatekey``
+  to set a certificate per connection (and not just per context) `#1121 <https://github.com/pyca/pyopenssl/pull/1121>`_.
 
 22.0.0 (2022-01-29)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             # Fix cryptographyMinimum in tox.ini when changing this!
-            "cryptography>=37.0.2",
+            "cryptography>=38.0.0",
         ],
         extras_require={
             "test": ["flaky", "pretend", "pytest>=3.0.1"],

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -954,6 +954,7 @@ class Context:
         :param cert: The X509 object
         :return: None
         """
+        # Mirrored at Connection.use_certificate
         if not isinstance(cert, X509):
             raise TypeError("cert must be an X509 instance")
 
@@ -1015,6 +1016,7 @@ class Context:
         :param pkey: The PKey object
         :return: None
         """
+        # Mirrored at Connection.use_privatekey
         if not isinstance(pkey, PKey):
             raise TypeError("pkey must be a PKey instance")
 
@@ -1779,6 +1781,36 @@ class Connection:
         :return: The verify mode
         """
         return _lib.SSL_get_verify_mode(self._ssl)
+
+    def use_certificate(self, cert):
+        """
+        Load a certificate from a X509 object
+
+        :param cert: The X509 object
+        :return: None
+        """
+        # Mirrored from Context.use_certificate
+        if not isinstance(cert, X509):
+            raise TypeError("cert must be an X509 instance")
+
+        use_result = _lib.SSL_use_certificate(self._ssl, cert._x509)
+        if not use_result:
+            _raise_current_error()
+
+    def use_privatekey(self, pkey):
+        """
+        Load a private key from a PKey object
+
+        :param pkey: The PKey object
+        :return: None
+        """
+        # Mirrored from Context.use_privatekey
+        if not isinstance(pkey, PKey):
+            raise TypeError("pkey must be a PKey instance")
+
+        use_result = _lib.SSL_use_PrivateKey(self._ssl, pkey._pkey)
+        if not use_result:
+            self._context._raise_passphrase_exception()
 
     def set_ciphertext_mtu(self, mtu):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2152,6 +2152,7 @@ class TestContextConnection:
     """
     Unit test for methods that are exposed both by Connection and Context objects.
     """
+
     def test_use_privatekey(self, ctx_or_conn):
         """
         `use_privatekey` takes an `OpenSSL.crypto.PKey` instance.
@@ -2170,7 +2171,9 @@ class TestContextConnection:
         """
         key = PKey()
         key.generate_key(TYPE_RSA, 1024)
-        ctx_or_conn.use_certificate(load_certificate(FILETYPE_PEM, root_cert_pem))
+        ctx_or_conn.use_certificate(
+            load_certificate(FILETYPE_PEM, root_cert_pem)
+        )
         with pytest.raises(Error):
             ctx_or_conn.use_privatekey(key)
 
@@ -2183,7 +2186,9 @@ class TestContextConnection:
         # Hard to assert anything.  But we could set a privatekey then ask
         # OpenSSL if the cert and key agree using check_privatekey.  Then as
         # long as check_privatekey works right we're good...
-        ctx_or_conn.use_certificate(load_certificate(FILETYPE_PEM, root_cert_pem))
+        ctx_or_conn.use_certificate(
+            load_certificate(FILETYPE_PEM, root_cert_pem)
+        )
 
     def test_use_certificate_wrong_args(self, ctx_or_conn):
         """

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2150,7 +2150,8 @@ def ctx_or_conn(request) -> Union[Context, Connection]:
 
 class TestContextConnection:
     """
-    Unit test for methods that are exposed both by Connection and Context objects.
+    Unit test for methods that are exposed both by Connection and Context
+    objects.
     """
 
     def test_use_privatekey(self, ctx_or_conn):

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -625,6 +625,7 @@ class TestContext:
         """
         `Context.use_privatekey` takes an `OpenSSL.crypto.PKey` instance.
         """
+        # Mirrored at TestConnection.test_use_privatekey
         key = PKey()
         key.generate_key(TYPE_RSA, 1024)
         ctx = Context(SSLv23_METHOD)
@@ -709,6 +710,7 @@ class TestContext:
         `Context.use_certificate` sets the certificate which will be
         used to identify connections created using the context.
         """
+        # Mirrored at TestConnection.test_use_certificate
         # TODO
         # Hard to assert anything.  But we could set a privatekey then ask
         # OpenSSL if the cert and key agree using check_privatekey.  Then as
@@ -2205,6 +2207,31 @@ class TestConnection:
         """
         ctx = Context(SSLv23_METHOD)
         assert is_consistent_type(Connection, "Connection", ctx, None)
+
+    def test_use_privatekey(self):
+        """
+        `Connection.use_privatekey` takes an `OpenSSL.crypto.PKey` instance.
+        """
+        # Mirrored from TestContext.test_use_privatekey
+        key = PKey()
+        key.generate_key(TYPE_RSA, 1024)
+        ctx = Context(SSLv23_METHOD)
+        connection = Connection(ctx, None)
+        connection.use_privatekey(key)
+        with pytest.raises(TypeError):
+            connection.use_privatekey("")
+
+    def test_use_certificate(self):
+        """
+        `Connection.use_certificate` sets the certificate which will be
+        used to identify connections created using the context.
+        """
+        # Mirrored from TestContext.test_use_certificate
+        ctx = Context(SSLv23_METHOD)
+        connection = Connection(ctx, None)
+        connection.use_certificate(
+            load_certificate(FILETYPE_PEM, root_cert_pem)
+        )
 
     @pytest.mark.parametrize("bad_context", [object(), "context", None, 1])
     def test_wrong_args(self, bad_context):

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ extras =
 deps =
     coverage>=4.2
     cryptographyMain: git+https://github.com/pyca/cryptography.git
-    cryptographyMinimum: cryptography==37.0.2
+    cryptographyMinimum: cryptography==38.0.0
     randomorder: pytest-randomly
 setenv =
     # Do not allow the executing environment to pollute the test environment


### PR DESCRIPTION
(depends on cryptography 38)

Follow-up to https://github.com/pyca/cryptography/pull/7210.  :)
I've added comments to point out the duplication between Context and Connection. Let me know if you want those out, happy to adjust to whatever style you prefer.