### PR TITLE
Fix CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     readme_renderer
 skip_install = true
 commands =
-    python setup.py check -r -s
+    python setup.py check -r
 
 [testenv:check-manifest]
 deps =


### PR DESCRIPTION
readme_renderer 35.0 warns if there are duplicate implicit target names.
This breaks with pyOpenSSL's readme (which has duplicate subsections, e.g. "Deprecations:").

I'm happy to also add a whole bunch of anchors if you prefer that. I didn't feel that's necessarily better. :)