### PR TITLE
Fix X.509 version handling.

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1148,7 +1148,7 @@ class X509:
         if not isinstance(version, int):
             raise TypeError("version must be an integer")
 
-        _lib.X509_set_version(self._x509, version)
+        _openssl_assert(_lib.X509_set_version(self._x509, version) == 1)
 
     def get_version(self):
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -618,9 +618,10 @@ vrzEeLDRiiPl92dyyWmu
 -----END X509 CRL-----
 """
 
+# The signature on this CRL is invalid.
 crlDataUnsupportedExtension = b"""\
 -----BEGIN X509 CRL-----
-MIIGRzCCBS8CAQIwDQYJKoZIhvcNAQELBQAwJzELMAkGA1UEBhMCVVMxGDAWBgNV
+MIIGRzCCBS8CAQEwDQYJKoZIhvcNAQELBQAwJzELMAkGA1UEBhMCVVMxGDAWBgNV
 BAMMD2NyeXB0b2dyYXBoeS5pbxgPMjAxNTAxMDEwMDAwMDBaGA8yMDE2MDEwMTAw
 MDAwMFowggTOMBQCAQAYDzIwMTUwMTAxMDAwMDAwWjByAgEBGA8yMDE1MDEwMTAw
 MDAwMFowXDAYBgNVHRgEERgPMjAxNTAxMDEwMDAwMDBaMDQGA1UdHQQtMCukKTAn
@@ -1598,14 +1599,20 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         """
         `X509Req.set_version` sets the X.509 version of the certificate
         request. `X509Req.get_version` returns the X.509 version of the
-        certificate request. The initial value of the version is 0.
+        certificate request. The only defined version is 0. Others may or
+        may not be supported depending on backend.
         """
         request = X509Req()
         assert request.get_version() == 0
-        request.set_version(1)
-        assert request.get_version() == 1
-        request.set_version(3)
-        assert request.get_version() == 3
+        request.set_version(0)
+        assert request.get_version() == 0
+        try:
+            request.set_version(1)
+            assert request.get_version() == 1
+            request.set_version(3)
+            assert request.get_version() == 3
+        except Error:
+            pass
 
     def test_version_wrong_args(self):
         """
@@ -1793,8 +1800,8 @@ class TestX509(_PKeyInteractionTestsMixin):
         `X509.get_version` retrieves it.
         """
         cert = X509()
-        cert.set_version(1234)
-        assert cert.get_version() == 1234
+        cert.set_version(2)
+        assert cert.get_version() == 2
 
     def test_serial_number(self):
         """


### PR DESCRIPTION
Certificate versions go up to v3 (numeric value 2), CRLs go up to v2
(numeric value 1), and CSRs go up to v1 (numeric value 0). This CL fixes
the following issues:

- Add a missing check to the return value of X509_set_version

- Fix crlDataUnsupportedExtension which had an invalid CRL version.

- Switch TestX509.test_version to test valid versions, so it doesn't
  prevent OpenSSL or an OpenSSL derivative from checking for invalid
  versions.

- Make TestX509Req.test_version tolerate set_version(1) failing on CSRs.
  Since there's nothing useful to test otherwise, I've made the test
  work for either possible backend behavior.