### PR TITLE
Make `X509StoreContextError`'s message friendlier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Backward-incompatible changes:
 
 - Remove support for SSLv2 and SSLv3.
 - The minimum ``cryptography`` version is now 37.0.2.
+- The ``OpenSSL.crypto.X509StoreContextError`` exception has been refactored,
+  changing its internal attributes.
+  `#1133 <https://github.com/pyca/pyopenssl/pull/1133>`_
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1776,7 +1776,9 @@ class X509StoreContextError(Exception):
     :type certificate: :class:`X509`
     """
 
-    def __init__(self, message: str, errors: List[Any], certificate: X509) -> None:
+    def __init__(
+        self, message: str, errors: List[Any], certificate: X509
+    ) -> None:
         super(X509StoreContextError, self).__init__(message)
         self.errors = errors
         self.certificate = certificate

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1776,8 +1776,9 @@ class X509StoreContextError(Exception):
     :type certificate: :class:`X509`
     """
 
-    def __init__(self, message: Any, certificate: X509) -> None:
+    def __init__(self, message: str, errors: List[Any], certificate: X509) -> None:
         super(X509StoreContextError, self).__init__(message)
+        self.errors = errors
         self.certificate = certificate
 
 
@@ -1878,21 +1879,22 @@ class X509StoreContext:
         When a call to native OpenSSL X509_verify_cert fails, additional
         information about the failure can be obtained from the store context.
         """
+        message = _ffi.string(
+            _lib.X509_verify_cert_error_string(
+                _lib.X509_STORE_CTX_get_error(self._store_ctx)
+            )
+        ).decode("utf-8")
         errors = [
             _lib.X509_STORE_CTX_get_error(self._store_ctx),
             _lib.X509_STORE_CTX_get_error_depth(self._store_ctx),
-            _ffi.string(
-                _lib.X509_verify_cert_error_string(
-                    _lib.X509_STORE_CTX_get_error(self._store_ctx)
-                )
-            ).decode("utf-8"),
+            message,
         ]
         # A context error should always be associated with a certificate, so we
         # expect this call to never return :class:`None`.
         _x509 = _lib.X509_STORE_CTX_get_current_cert(self._store_ctx)
         _cert = _lib.X509_dup(_x509)
         pycert = X509._from_raw_x509_ptr(_cert)
-        return X509StoreContextError(errors, pycert)
+        return X509StoreContextError(message, errors, pycert)
 
     def set_store(self, store: X509Store) -> None:
         """

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3874,7 +3874,7 @@ class TestCRL:
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         with pytest.raises(X509StoreContextError) as err:
             store_ctx.verify_certificate()
-        assert err.value.args[0][2] == "certificate revoked"
+        assert str(err.value) == "certificate revoked"
 
     def test_verify_with_missing_crl(self):
         """
@@ -3894,7 +3894,7 @@ class TestCRL:
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         with pytest.raises(X509StoreContextError) as err:
             store_ctx.verify_certificate()
-        assert err.value.args[0][2] == "unable to get certificate CRL"
+        assert str(err.value) == "unable to get certificate CRL"
         assert err.value.certificate.get_subject().CN == "intermediate-service"
 
     def test_convert_from_cryptography(self):
@@ -4106,7 +4106,7 @@ class TestX509StoreContext:
             store_ctx.verify_certificate()
 
         # OpenSSL 1.1.x and 3.0.x have different error messages
-        assert exc.value.args[0][2] in [
+        assert str(exc.value) in [
             "self signed certificate",
             "self-signed certificate",
         ]
@@ -4124,7 +4124,7 @@ class TestX509StoreContext:
         with pytest.raises(X509StoreContextError) as exc:
             store_ctx.verify_certificate()
 
-        assert exc.value.args[0][2] == "unable to get issuer certificate"
+        assert str(exc.value) == "unable to get issuer certificate"
         assert exc.value.certificate.get_subject().CN == "intermediate"
 
     def test_invalid_chain_no_intermediate(self):
@@ -4139,7 +4139,7 @@ class TestX509StoreContext:
         with pytest.raises(X509StoreContextError) as exc:
             store_ctx.verify_certificate()
 
-        assert exc.value.args[0][2] == "unable to get local issuer certificate"
+        assert str(exc.value) == "unable to get local issuer certificate"
         assert exc.value.certificate.get_subject().CN == "intermediate-service"
 
     def test_modification_pre_verify(self):
@@ -4157,7 +4157,7 @@ class TestX509StoreContext:
         with pytest.raises(X509StoreContextError) as exc:
             store_ctx.verify_certificate()
 
-        assert exc.value.args[0][2] == "unable to get issuer certificate"
+        assert str(exc.value) == "unable to get issuer certificate"
         assert exc.value.certificate.get_subject().CN == "intermediate"
 
         store_ctx.set_store(store_good)
@@ -4182,7 +4182,7 @@ class TestX509StoreContext:
         with pytest.raises(X509StoreContextError) as exc:
             store_ctx.verify_certificate()
 
-        assert exc.value.args[0][2] == "certificate has expired"
+        assert str(exc.value) == "certificate has expired"
 
     def test_get_verified_chain(self):
         """
@@ -4216,7 +4216,7 @@ class TestX509StoreContext:
         with pytest.raises(X509StoreContextError) as exc:
             store_ctx.get_verified_chain()
 
-        assert exc.value.args[0][2] == "unable to get issuer certificate"
+        assert str(exc.value) == "unable to get issuer certificate"
         assert exc.value.certificate.get_subject().CN == "intermediate"
 
     @pytest.fixture
@@ -4281,7 +4281,7 @@ class TestX509StoreContext:
         with pytest.raises(X509StoreContextError) as exc:
             store_ctx.verify_certificate()
 
-        assert exc.value.args[0][2] == "unable to get local issuer certificate"
+        assert str(exc.value) == "unable to get local issuer certificate"
 
 
 class TestSignVerify:


### PR DESCRIPTION
The `message` is now a string, rather than a list of errors. The list of errors is separately preserved.

Closes #1132.