### PR TITLE
Fix docs in `SSL.Context.get_alpn_proto_negotiated`

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2648,7 +2648,7 @@ class Connection:
         Get the protocol that was negotiated by ALPN.
 
         :returns: A bytestring of the protocol name.  If no protocol has been
-            negotiated yet, returns an empty string.
+            negotiated yet, returns an empty bytestring.
         """
         data = _ffi.new("unsigned char **")
         data_len = _ffi.new("unsigned int *")


### PR DESCRIPTION
I am working on better types in https://github.com/python/typeshed/blob/master/stubs/pyOpenSSL/OpenSSL/SSL.pyi
I've noticed that your current docs are not quite correct, because it stated "returns an empty string", while the actual code did: `return b""`. It was a bit confusing.