### PR TITLE
Don't test that invalid RSA keys can be imported

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1230,8 +1230,8 @@ class TestPKey:
         """
         `PKey.check` raises `OpenSSL.crypto.Error` if provided with broken key
         """
-        pkey = load_privatekey(FILETYPE_PEM, rsa_p_not_prime_pem)
         with pytest.raises(Error):
+            pkey = load_privatekey(FILETYPE_PEM, rsa_p_not_prime_pem)
             pkey.check()
 
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1206,10 +1206,11 @@ class TestPKey:
 
     def test_inconsistent_key(self):
         """
-        `PKey.check` returns `Error` if the key is not consistent.
+        Either `load_privatekey` or `PKey.check` returns `Error` if the key is
+        not consistent.
         """
-        key = load_privatekey(FILETYPE_PEM, inconsistentPrivateKeyPEM)
         with pytest.raises(Error):
+            key = load_privatekey(FILETYPE_PEM, inconsistentPrivateKeyPEM)
             key.check()
 
     def test_check_public_key(self):
@@ -1228,7 +1229,8 @@ class TestPKey:
 
     def test_check_pr_897(self):
         """
-        `PKey.check` raises `OpenSSL.crypto.Error` if provided with broken key
+        Either `load_privatekey` or `PKey.check` raises `OpenSSL.crypto.Error`
+        if provided with broken key
         """
         with pytest.raises(Error):
             pkey = load_privatekey(FILETYPE_PEM, rsa_p_not_prime_pem)


### PR DESCRIPTION
test_check_pr_897 asserts that an invalid key is correctly detected as invalid. However, in doing so, it also asserts that the invalid key is considered *valid* at parse time.

Ideally, the underlying cryptography library would just call RSA_check_key during parsing, but it would then fail this test. Make the test more tolerant by allow either parsing or checking to throw an error.