### PR TITLE
Switch to the new utils.deprecation spelling

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -3229,7 +3229,7 @@ utils.deprecated(
         "in cryptography."
     ),
     DeprecationWarning,
-    name = "load_pkcs7_data",
+    name="load_pkcs7_data",
 )
 
 
@@ -3328,5 +3328,5 @@ utils.deprecated(
         "in cryptography."
     ),
     DeprecationWarning,
-    name = "load_pkcs12",
+    name="load_pkcs12",
 )

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -3221,7 +3221,7 @@ def load_pkcs7_data(type: int, buffer: Union[str, bytes]) -> PKCS7:
     return pypkcs7
 
 
-load_pkcs7_data = utils.deprecated(
+utils.deprecated(
     load_pkcs7_data,
     __name__,
     (
@@ -3229,6 +3229,7 @@ load_pkcs7_data = utils.deprecated(
         "in cryptography."
     ),
     DeprecationWarning,
+    name = "load_pkcs7_data",
 )
 
 
@@ -3319,7 +3320,7 @@ def load_pkcs12(
     return pkcs12
 
 
-load_pkcs12 = utils.deprecated(
+utils.deprecated(
     load_pkcs12,
     __name__,
     (
@@ -3327,4 +3328,5 @@ load_pkcs12 = utils.deprecated(
         "in cryptography."
     ),
     DeprecationWarning,
+    name = "load_pkcs12",
 )


### PR DESCRIPTION
The new spelling was introduced in https://github.com/pyca/cryptography/pull/6923 and is more friendly to type checkers.

Version-wise, that PR appears to be in cryptography 37.0.0, which is now beyond the minimum version for pyOpenSSL.