### PR TITLE
add attributes only conditionally

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -172,7 +172,7 @@ OP_NO_TLSv1_1 = _lib.SSL_OP_NO_TLSv1_1
 OP_NO_TLSv1_2 = _lib.SSL_OP_NO_TLSv1_2
 try:
     OP_NO_TLSv1_3 = _lib.SSL_OP_NO_TLSv1_3
-    __all__ += [ "OP_NO_TLSv1_3", ]
+    __all__ += ["OP_NO_TLSv1_3"]
 except AttributeError:
     pass
 
@@ -209,13 +209,13 @@ OP_NO_TICKET = _lib.SSL_OP_NO_TICKET
 
 try:
     OP_NO_RENEGOTIATION = _lib.SSL_OP_NO_RENEGOTIATION
-    __all__ += [ "OP_NO_RENEGOTIATION", ]
+    __all__ += ["OP_NO_RENEGOTIATION"]
 except AttributeError:
     pass
 
 try:
     OP_IGNORE_UNEXPECTED_EOF = _lib.SSL_OP_IGNORE_UNEXPECTED_EOF
-    __all__ += [ "OP_IGNORE_UNEXPECTED_EOF", ]
+    __all__ += ["OP_IGNORE_UNEXPECTED_EOF"]
 except AttributeError:
     pass
 

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -59,7 +59,7 @@ __all__ = [
     "OP_NO_TLSv1",
     "OP_NO_TLSv1_1",
     "OP_NO_TLSv1_2",
-    "OP_NO_TLSv1_3",
+    # "OP_NO_TLSv1_3", conditionally added below
     "MODE_RELEASE_BUFFERS",
     "OP_SINGLE_DH_USE",
     "OP_SINGLE_ECDH_USE",
@@ -84,8 +84,8 @@ __all__ = [
     "OP_NO_QUERY_MTU",
     "OP_COOKIE_EXCHANGE",
     "OP_NO_TICKET",
-    "OP_NO_RENEGOTIATION",
-    "OP_IGNORE_UNEXPECTED_EOF",
+    # "OP_NO_RENEGOTIATION", conditionally added below
+    # "OP_IGNORE_UNEXPECTED_EOF", conditionally added below
     "OP_ALL",
     "VERIFY_PEER",
     "VERIFY_FAIL_IF_NO_PEER_CERT",
@@ -172,6 +172,7 @@ OP_NO_TLSv1_1 = _lib.SSL_OP_NO_TLSv1_1
 OP_NO_TLSv1_2 = _lib.SSL_OP_NO_TLSv1_2
 try:
     OP_NO_TLSv1_3 = _lib.SSL_OP_NO_TLSv1_3
+    __all__ += [ "OP_NO_TLSv1_3", ]
 except AttributeError:
     pass
 
@@ -208,11 +209,13 @@ OP_NO_TICKET = _lib.SSL_OP_NO_TICKET
 
 try:
     OP_NO_RENEGOTIATION = _lib.SSL_OP_NO_RENEGOTIATION
+    __all__ += [ "OP_NO_RENEGOTIATION", ]
 except AttributeError:
     pass
 
 try:
     OP_IGNORE_UNEXPECTED_EOF = _lib.SSL_OP_IGNORE_UNEXPECTED_EOF
+    __all__ += [ "OP_IGNORE_UNEXPECTED_EOF", ]
 except AttributeError:
     pass
 


### PR DESCRIPTION
Fixes https://github.com/pyca/pyopenssl/pull/1127#issuecomment-1286231133

Before: :x: 

cryptography 0.38.01
openssl 1.1.1q
on openSUSE Tumbleweed

```
[   38s] + python3.8 -c 'from OpenSSL.SSL import *'
[   38s] Traceback (most recent call last):
[   38s]   File "<string>", line 1, in <module>
[   38s] AttributeError: module 'OpenSSL.SSL' has no attribute 'OP_IGNORE_UNEXPECTED_EOF'
```

After: :heavy_check_mark: 