### PR TITLE
Fix CRL nextUpdate handling.

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -179,7 +179,7 @@ def _set_asn1_time(boundary: Any, when: bytes) -> None:
 
 def _new_asn1_time(when: bytes) -> Any:
     """
-    Behaves like _set_asn1_time bit returns a new ASN1_TIME object.
+    Behaves like _set_asn1_time but returns a new ASN1_TIME object.
 
     @param when: A string representation of the desired time value.
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -168,10 +168,9 @@ def _set_asn1_time(boundary: Any, when: bytes) -> None:
     """
     if not isinstance(when, bytes):
         raise TypeError("when must be a byte string")
-    if boundary == _ffi.NULL:
-        # ASN1_TIME_set_string validates the string without writing anything
-        # when the destination is NULL.
-        raise ValueError("boundary must not be NULL")
+    # ASN1_TIME_set_string validates the string without writing anything
+    # when the destination is NULL.
+    _openssl_assert(boundary != _ffi.NULL)
 
     set_result = _lib.ASN1_TIME_set_string(boundary, when)
     if set_result == 0:

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3850,7 +3850,9 @@ class TestCRL:
             crl.add_revoked(revoked)
         crl.set_version(1)
         crl.set_lastUpdate(b"20140601000000Z")
-        crl.set_nextUpdate(b"20180601000000Z")
+        # The year 5000 is far into the future so that this CRL isn't
+        # considered to have expired.
+        crl.set_nextUpdate(b"50000601000000Z")
         crl.sign(issuer_cert, issuer_key, digest=b"sha512")
         return crl
 


### PR DESCRIPTION
When setting the nextUpdate field of a CRL, this code grabbed the nextUpdate ASN1_TIME field from the CRL and set its time. But nextUpdate is optional in a CRL so that field is usually NULL. But OpenSSL's ASN1_TIME_set_string succeeds when the destination argument is NULL, so it was silently a no-op.

Given that, the call in a test to set the nextUpdate field suddenly starts working and sets the time to 2018, thus causing the CRL to be considered expired and breaking the test. So this change also changes the expiry year far into the future.

Additionally, the other CRL and Revoked setters violate const in the API.

Fixes #1168.