### PR TITLE
src/OpenSSL/crypto.py: support SM2 sign with OpenSSL 1.1.1x

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -787,6 +787,15 @@ e3fJQJwX9+KsHRut6qNZDUbvRbtO1YIAwB4UJZjwAjEAtXCPURS5A4McZHnSwgTi
 Td8GMrwKz0557OxxtKN6uVVy4ACFMqEw0zN/KJI1vxc9
 -----END CERTIFICATE-----"""
 
+sm2_root_key_pem = b"""-----BEGIN EC PARAMETERS-----
+BggqgRzPVQGCLQ==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEII/sRQnfpXCVx5kjmRbPp7KGgwJlOCx0kBX2Tr2lXrM2oAoGCCqBHM9V
+AYItoUQDQgAEkZX7gPPNGa0uwJMjTCBgVxlTD2krqPL1rZg2z9HLg3wnH06IxQ8r
+3su/VOmyoYBLBYcEjI7GSzvBy6ynX1ZDwA==
+-----END EC PRIVATE KEY-----"""
+
 rsa_p_not_prime_pem = """
 -----BEGIN RSA PRIVATE KEY-----
 MBsCAQACAS0CAQcCAQACAQ8CAQMCAQACAQACAQA=
@@ -4396,6 +4405,20 @@ class TestSignVerify:
         cert = load_certificate(FILETYPE_PEM, ec_root_cert_pem)
         sig = sign(priv_key, content, "sha256")
         verify(cert, sig, content, "sha256")
+
+    def test_sign_sm2(self):
+        """
+        `sign` generates a SM2 cryptographic signature
+        """
+        content = (
+            b"It was a bright cold day in April, and the clocks were striking "
+            b"thirteen. Winston Smith, his chin nuzzled into his breast in an "
+            b"effort to escape the vile wind, slipped quickly through the "
+            b"glass doors of Victory Mansions, though not quickly enough to "
+            b"prevent a swirl of gritty dust from entering along with him."
+        )
+        priv_key = load_privatekey(FILETYPE_PEM, sm2_root_key_pem)
+        _ = sign(priv_key, content, "sm3")
 
     def test_sign_nulls(self):
         """


### PR DESCRIPTION
In openssl 1.1.1 docs/man3/EVP_PKEY_set1_RSA.pod
(https://github.com/openssl/openssl/blob/OpenSSL_1_1_1/doc/man3/EVP_PKEY_set1_RSA.pod) The EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2) API is possible to convert it to using SM2 algorithms After loading an ECC key.

Besides, pyca/cryptography support to export `The EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2) API` in https://github.com/pyca/cryptography/commit/c28bfb352ab1f390900ef92856a9570aadd5fe2c .

So in pyopenssl, we can support SM2 sign with OpenSSL 1.1.1x and pyca/cryptography.

Fixes: #1171 
Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>