### PR TITLE
Add support for DTLS timeouts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
+- Add ``OpenSSL.SSL.Connection.DTLSv1_get_timeout`` and ``OpenSSL.SSL.Connection.DTLSv1_handle_timeout``
+  to support DTLS timeouts `#1180 <https://github.com/pyca/pyopenssl/pull/1180>`_.
+
 23.0.0 (2023-01-01)
 -------------------
 

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2159,6 +2159,37 @@ class Connection:
         if result < 0:
             self._raise_ssl_error(self._ssl, result)
 
+    def DTLSv1_get_timeout(self):
+        """
+        Determine when the DTLS SSL object next needs to perform internal
+        processing due to the passage of time.
+
+        When the returned number of seconds have passed, the
+        :meth:`DTLSv1_handle_timeout` method needs to be called.
+
+        :return: The time left in seconds before the next timeout or `None`
+            if no timeout is currently active.
+        """
+        ptv_sec = _ffi.new("time_t *")
+        ptv_usec = _ffi.new("long *")
+        if _lib.Cryptography_DTLSv1_get_timeout(self._ssl, ptv_sec, ptv_usec):
+            return ptv_sec[0] + (ptv_usec[0] / 1000000)
+        else:
+            return None
+
+    def DTLSv1_handle_timeout(self):
+        """
+        Handles any timeout events which have become pending on a DTLS SSL
+        object.
+
+        :return: `True` if there was a pending timeout, `False` otherwise.
+        """
+        result = _lib.DTLSv1_handle_timeout(self._ssl)
+        if result < 0:
+            self._raise_ssl_error(self._ssl, result)
+        else:
+            return bool(result)
+
     def bio_shutdown(self):
         """
         If the Connection was created with a memory BIO, this method can be


### PR DESCRIPTION
When performing a DTLS handshake, the DTLS state machine may need to be updated based on the passage of time, for instance in response to packet loss.

OpenSSL supports this by means of the `DTLSv1_get_timeout` and `DTLSv1_handle_timeout` methods, both of which are included in cryptography's bindings. This change adds Python wrappers for these methods in the `Connection` class.