### PR TITLE
Expose secure renegotiation flag from TLS connection

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2730,6 +2730,23 @@ class Connection:
 
         return _ffi.buffer(data[0], data_len[0])[:]
 
+    def get_secure_renegotiation_support(self):
+        """
+        Retrieve the secure renegotiation flag of the current connection.
+
+        :returns: A boolean representing the support of secure renegotiation (rfc5746)
+            for the current connection. True means that secure renegotiation is advertised
+            and supported by server. False means that secure renegotiation is not supported
+            or that client renegotiation is not supported at all.
+        :rtype: :class:`bool`
+        """
+        support = _lib.SSL_get_secure_renegotiation_support(self._ssl)
+
+        if support == 1:
+            return True
+        else:
+            return False
+
     def request_ocsp(self):
         """
         Called to request that the server sends stapled OCSP data, if

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -3029,6 +3029,23 @@ class TestConnection:
 
         assert server_protocol_version == client_protocol_version
 
+    def test_get_secure_renegotiation_support(self):
+        """
+        `Connection.get_secure_renegotiation_support()` returns a boolean
+        stating secure renegotiation support of the current connection.
+        """
+        server, client = loopback(
+            lambda s: loopback_server_factory(s, TLSv1_2_METHOD),
+            lambda s: loopback_client_factory(s, TLSv1_2_METHOD),
+        )
+        client_secure_renegotiation_support = client.get_secure_renegotiation_support()
+        server_secure_renegotiation_support = server.get_secure_renegotiation_support()
+
+        assert isinstance(server_secure_renegotiation_support, bool)
+        assert isinstance(client_secure_renegotiation_support, bool)
+
+        assert client_secure_renegotiation_support == server_secure_renegotiation_support
+
     def test_wantReadError(self):
         """
         `Connection.bio_read` raises `OpenSSL.SSL.WantReadError` if there are


### PR DESCRIPTION
Hello,

This is a pull request to add support for the SSL_get_secure_renegotiation_support function from OpenSSL.

Some simple test is added.


Best regards