### PR TITLE
add `utcnow()` helper function to avoid `datetime.utcnow()` (closes #1228)

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1437,7 +1437,9 @@ class X509:
         time_string = time_bytes.decode("utf-8")
         not_after = datetime.datetime.strptime(time_string, "%Y%m%d%H%M%SZ")
 
-        return not_after < datetime.datetime.utcnow()
+        UTC = datetime.timezone.utc
+        utcnow = datetime.datetime.now(UTC).replace(tzinfo=None)
+        return not_after < utcnow
 
     def _get_boundary_time(self, which: Any) -> Optional[bytes]:
         return _get_asn1_time(which(self._x509))

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -7,7 +7,7 @@ Unit tests for :py:mod:`OpenSSL.crypto`.
 import base64
 import sys
 import warnings
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from subprocess import PIPE, Popen
 
 from cryptography import x509
@@ -66,6 +66,10 @@ from .util import (
 
 def normalize_privatekey_pem(pem):
     return dump_privatekey(FILETYPE_PEM, load_privatekey(FILETYPE_PEM, pem))
+
+
+def utcnow():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 GOOD_CIPHER = "blowfish"
@@ -1865,14 +1869,14 @@ class TestX509(_PKeyInteractionTestsMixin):
         current time plus the number of seconds passed in.
         """
         cert = load_certificate(FILETYPE_PEM, self.pemData)
-        not_before_min = datetime.utcnow().replace(microsecond=0) + timedelta(
+        not_before_min = utcnow().replace(microsecond=0) + timedelta(
             seconds=100
         )
         cert.gmtime_adj_notBefore(100)
         not_before = datetime.strptime(
             cert.get_notBefore().decode(), "%Y%m%d%H%M%SZ"
         )
-        not_before_max = datetime.utcnow() + timedelta(seconds=100)
+        not_before_max = utcnow() + timedelta(seconds=100)
         assert not_before_min <= not_before <= not_before_max
 
     def test_gmtime_adj_notAfter_wrong_args(self):
@@ -1891,14 +1895,14 @@ class TestX509(_PKeyInteractionTestsMixin):
         to be the current time plus the number of seconds passed in.
         """
         cert = load_certificate(FILETYPE_PEM, self.pemData)
-        not_after_min = datetime.utcnow().replace(microsecond=0) + timedelta(
+        not_after_min = utcnow().replace(microsecond=0) + timedelta(
             seconds=100
         )
         cert.gmtime_adj_notAfter(100)
         not_after = datetime.strptime(
             cert.get_notAfter().decode(), "%Y%m%d%H%M%SZ"
         )
-        not_after_max = datetime.utcnow() + timedelta(seconds=100)
+        not_after_max = utcnow() + timedelta(seconds=100)
         assert not_after_min <= not_after <= not_after_max
 
     def test_has_expired(self):


### PR DESCRIPTION
Using datetime.utcnow() triggers a deprecation warning in Python 3.12. This leads to test failures in projects using PyOpenSSL (e.g. josepy).

I considered two possible approaches to solve this issue:

- compare tz-aware datetime instances (basically use `datetime.strptime(time_string, "%Y%m%d%H%M%S%z")`)
- strip `tzinfo` from a tz-aware "utcnow" (`datetime.now(timezone.utc).replace(tzinfo=None)`.

In the end I went with the second option because `self.get_notAfter()` returns the "ASN.1 TIME" format which I think is supposed to always have a "Z" at the end. If we use `%z` as a format string for `.strptime()` we would accept also other formats.
