### PR TITLE
Expose `SSL_OP_LEGACY_SERVER_CONNECT` binding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Backward-incompatible changes:
 - Dropped support for Python 3.6.
 - The minimum ``cryptography`` version is now 41.0.0.
 - Removed ``OpenSSL.crypto.loads_pkcs7`` and ``OpenSSL.crypto.loads_pkcs12`` which had been deprecated for 3 years.
+- Added ``OpenSSL.SSL.OP_LEGACY_SERVER_CONNECT`` to allow legacy insecure renegotiation between OpenSSL and unpatched servers.
+  `#1234 <https://github.com/pyca/pyopenssl/pull/1234>`_.
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -217,6 +217,12 @@ try:
 except AttributeError:
     pass
 
+try:
+    OP_LEGACY_SERVER_CONNECT = _lib.SSL_OP_LEGACY_SERVER_CONNECT
+    __all__.append("OP_LEGACY_SERVER_CONNECT")
+except AttributeError:
+    pass
+
 OP_ALL = _lib.SSL_OP_ALL
 
 VERIFY_PEER = _lib.SSL_VERIFY_PEER


### PR DESCRIPTION
based on https://github.com/pyca/cryptography/pull/9303

refs https://github.com/mitmproxy/mitmproxy/pull/6281