### PR TITLE
Fix problem caused by SSL_WANT_READ or SSL_WANT_WRITE errors.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
         packages=find_packages(where="src"),
         package_dir={"": "src"},
         install_requires=[
-            "cryptography>=41.0.3,<42",
+            "cryptography>=42.0.0",
         ],
         extras_require={
             "test": ["flaky", "pretend", "pytest>=3.0.1"],

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
         packages=find_packages(where="src"),
         package_dir={"": "src"},
         install_requires=[
-            "cryptography>=41.0.0,<42",
+            "cryptography>=41.0.3,<42",
         ],
         extras_require={
             "test": ["flaky", "pretend", "pytest>=3.0.1"],

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -850,7 +850,10 @@ class Context:
         self._cookie_generate_helper = None
         self._cookie_verify_helper = None
 
-        self.set_mode(_lib.SSL_MODE_ENABLE_PARTIAL_WRITE | _lib.SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER)
+        self.set_mode(
+            _lib.SSL_MODE_ENABLE_PARTIAL_WRITE
+            | _lib.SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER
+        )
         if version is not None:
             self.set_min_proto_version(version)
             self.set_max_proto_version(version)

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -850,7 +850,7 @@ class Context:
         self._cookie_generate_helper = None
         self._cookie_verify_helper = None
 
-        self.set_mode(_lib.SSL_MODE_ENABLE_PARTIAL_WRITE)
+        self.set_mode(_lib.SSL_MODE_ENABLE_PARTIAL_WRITE | _lib.SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER)
         if version is not None:
             self.set_min_proto_version(version)
             self.set_max_proto_version(version)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1738,7 +1738,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         certificate = X509()
         assert isinstance(certificate, X509)
         assert type(certificate).__name__ == "X509"
-        assert type(certificate) == X509
+        assert type(certificate) is X509
 
     def test_set_version_wrong_args(self):
         """
@@ -3146,7 +3146,7 @@ class TestRevoked:
         """
         revoked = Revoked()
         assert isinstance(revoked, Revoked)
-        assert type(revoked) == Revoked
+        assert type(revoked) is Revoked
         assert revoked.get_serial() == b"00"
         assert revoked.get_rev_date() is None
         assert revoked.get_reason() is None
@@ -3441,8 +3441,8 @@ class TestCRL:
 
         revs = crl.get_revoked()
         assert len(revs) == 2
-        assert type(revs[0]) == Revoked
-        assert type(revs[1]) == Revoked
+        assert type(revs[0]) is Revoked
+        assert type(revs[1]) is Revoked
         assert revs[0].get_serial() == b"03AB"
         assert revs[1].get_serial() == b"0100"
         assert revs[0].get_rev_date() == now

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -191,7 +191,7 @@ def join_bytes_or_unicode(prefix, suffix):
     The return type is the same as the type of ``prefix``.
     """
     # If the types are the same, nothing special is necessary.
-    if type(prefix) == type(suffix):
+    if type(prefix) is type(suffix):
         return join(prefix, suffix)
 
     # Otherwise, coerce suffix to the type of prefix.

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ extras =
     test
 deps =
     coverage>=4.2
-    cryptographyMinimum: cryptography==40.0.3
+    cryptographyMinimum: cryptography==41.0.3
     randomorder: pytest-randomly
 setenv =
     # Do not allow the executing environment to pollute the test environment

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ extras =
     test
 deps =
     coverage>=4.2
-    cryptographyMinimum: cryptography==38.0.0
+    cryptographyMinimum: cryptography==40.0.3
     randomorder: pytest-randomly
 setenv =
     # Do not allow the executing environment to pollute the test environment


### PR DESCRIPTION

When SSL_WANT_READ or SSL_WANT_WRITE are encountered, it's typical to retry the call but this must be repeated with the exact same arguments. Without this change, openSSL requires that the address of the buffer passed is the same. However, buffers in python can change location in some circumstances which cause the retry to fail.  By adding the setting SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER, the requirement for the same buffer address is forgiven and the retry has a better chance of success.  See https://github.com/cherrypy/cheroot/issues/245 for discussion.