### PR TITLE
Add support for `cryptography` CRLs to `X509Store`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,10 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
+- Changed ``OpenSSL.crypto.X509Store.add_crl`` to also accept
+  ``cryptography``'s ``X509.CertificateRevocationList`` arguments in addition
+  to the now deprecated ``OpenSSL.crypto.CRL`` arguments.
+
 23.2.0 (2023-05-30)
 -------------------
 

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1720,7 +1720,7 @@ class X509Store:
         res = _lib.X509_STORE_add_cert(self._store, cert._x509)
         _openssl_assert(res == 1)
 
-    def add_crl(self, crl: "CRL") -> None:
+    def add_crl(self, crl: "_CRLInternal") -> None:
         """
         Add a certificate revocation list to this store.
 
@@ -2404,7 +2404,7 @@ class CRL:
     @classmethod
     def from_cryptography(
         cls, crypto_crl: x509.CertificateRevocationList
-    ) -> "CRL":
+    ) -> "_CRLInternal":
         """
         Construct based on a ``cryptography`` *crypto_crl*.
 
@@ -2445,7 +2445,7 @@ class CRL:
             return tuple(results)
         return None
 
-    def add_revoked(self, revoked: Revoked) -> None:
+    def add_revoked(self, revoked: _RevokedInternal) -> None:
         """
         Add a revoked (by value not reference) to the CRL structure
 
@@ -3222,7 +3222,7 @@ utils.deprecated(
 )
 
 
-def dump_crl(type: int, crl: CRL) -> bytes:
+def dump_crl(type: int, crl: _CRLInternal) -> bytes:
     """
     Dump a certificate revocation list to a buffer.
 
@@ -3264,7 +3264,7 @@ utils.deprecated(
 )
 
 
-def load_crl(type: int, buffer: Union[str, bytes]) -> CRL:
+def load_crl(type: int, buffer: Union[str, bytes]) -> _CRLInternal:
     """
     Load Certificate Revocation List (CRL) data from a string *buffer*.
     *buffer* encoded with the type *type*.


### PR DESCRIPTION
As a follow up to deprecating CRL APIs (https://github.com/pyca/pyopenssl/issues/1249), there is one remaining function that won't be deprecated but accepts the `CRL` type: `X509Store.add_crl(crl: CRL)`. In order to [give users an alternative](https://github.com/pyca/pyopenssl/issues/1249#issuecomment-1726834527) once `CRL` is deprecated, this PR adds support to `add_crl()` so that it also accepts `cryptography`'s `X509.CertificateRevocationList`.

This PR also adds tests for the new code path, by parametrizing existing tests that use `add_crl` so that the CRL being passed as a parameter is either PyOpenSSL's or cryptography's. For example:
```python
    @pytest.mark.parametrize(
        "create_crl",
        [
            pytest.param(
                _make_test_crl,
                id="pyOpenSSL CRL",
            ),
            pytest.param(
                _make_test_crl_cryptography,
                id="cryptography CRL",
            ),
        ],
    )
    def test_verify_with_revoked(self, create_crl):
            #...
            root_crl = create_crl(self.root_cert, self.root_key, certs=[self.intermediate_cert])
            #...
 ```