### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - {VERSION: "3.9", TOXENV: "py39"}
           - {VERSION: "3.10", TOXENV: "py310"}
           - {VERSION: "3.11", TOXENV: "py311"}
+          - {VERSION: "3.12-dev", TOXENV: "py312"}
           - {VERSION: "pypy-3.8", TOXENV: "pypy3"}
           - {VERSION: "pypy-3.9", TOXENV: "pypy3"}
           - {VERSION: "3.11", TOXENV: "py311-useWheel", OS: "windows-2022" }
@@ -24,6 +25,7 @@ jobs:
           - {VERSION: "3.9", TOXENV: "py39-cryptographyMain"}
           - {VERSION: "3.10", TOXENV: "py310-cryptographyMain"}
           - {VERSION: "3.11", TOXENV: "py311-cryptographyMain"}
+          - {VERSION: "3.12-dev", TOXENV: "py312-cryptographyMain"}
           - {VERSION: "pypy-3.8", TOXENV: "pypy3-cryptographyMain"}
           - {VERSION: "pypy-3.9", TOXENV: "pypy3-cryptographyMain"}
           # -cryptographyMinimum
@@ -32,6 +34,7 @@ jobs:
           - {VERSION: "3.9", TOXENV: "py39-cryptographyMinimum"}
           - {VERSION: "3.10", TOXENV: "py310-cryptographyMinimum"}
           - {VERSION: "3.11", TOXENV: "py311-cryptographyMinimum"}
+          - {VERSION: "3.12-dev", TOXENV: "py312-cryptographyMinimum"}
           - {VERSION: "pypy-3.8", TOXENV: "pypy3-cryptographyMinimum"}
           # Cryptography wheels
           - {VERSION: "3.9", TOXENV: "py39-cryptographyMinimum-useWheel"}

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",
             "Topic :: Security :: Cryptography",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{py,py3,37,38,39,310,311}{,-cryptographyMinimum}{,-useWheel}{,-randomorder},py311-twistedTrunk,check-manifest,lint,py311-mypy,docs,coverage-report
+envlist = py{py3,37,38,39,310,311,312}{,-cryptographyMinimum}{,-useWheel}{,-randomorder},py311-twistedTrunk,check-manifest,lint,py311-mypy,docs,coverage-report
 
 [testenv]
 allowlist_externals =


### PR DESCRIPTION
Rebased branch of https://github.com/pyca/pyopenssl/pull/1245

The [Python 3.12 release candidate is out!](https://discuss.python.org/t/python-3-12-0-release-candidate-1-released/31137?u=hugovk) 🚀

> Call to action
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

See also https://dev.to/hugovk/help-test-python-312-beta-1508/
