### PR TITLE
Increase cryptography minimum in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ extras =
     test
 deps =
     coverage>=4.2
-    cryptographyMinimum: cryptography==38.0.0
+    cryptographyMinimum: cryptography==41.0.0
     randomorder: pytest-randomly
 setenv =
     # Do not allow the executing environment to pollute the test environment


### PR DESCRIPTION
Looks like https://github.com/pyca/pyopenssl/pull/1221 increased the minimum in `setup.py`, but not in `tox.ini`. This PR fixes that.