### PR TITLE
Migrate `.readthedocs.yml` to use `build.os`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,9 @@
 version: 2
 
 build:
-  image: "7.0"
-
-python:
-  version: "3"
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+  os: "ubuntu-22.04"
+  tools:
+    python: "3"
+  jobs:
+    post_install:
+      - pip install .[docs]


### PR DESCRIPTION
Since `build.image` is being [deprecated](https://blog.readthedocs.com/use-build-os-config/) , this changes the config to use the new format. CI is currently failing due to one of the scheduled brownouts of the deprecated feature:
> Monday, October 2, 2023: Do a third and final brownout (temporarily enforce this deprecation) for 48 hours: 00:01 PST to October 3, 2023 23:59 PST (midnight)

> Monday, October 16, 2023: Fully remove support for building documentation using “build.image” on the configuration file
