### PR TITLE
Fix failing test when running offline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ Changes:
 - Changed ``OpenSSL.crypto.X509Store.add_crl`` to also accept
   ``cryptography``'s ``X509.CertificateRevocationList`` arguments in addition
   to the now deprecated ``OpenSSL.crypto.CRL`` arguments.
+- Fixed ``test_set_default_verify_paths`` test so that it is skipped if no
+  network connection is available.
 
 23.2.0 (2023-05-30)
 -------------------

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -27,6 +27,7 @@ from socket import (
     AF_INET6,
     MSG_PEEK,
     SHUT_RDWR,
+    gaierror,
     socket,
 )
 from sys import getfilesystemencoding, platform
@@ -1269,7 +1270,10 @@ class TestContext:
         )
 
         client = socket_any_family()
-        client.connect(("encrypted.google.com", 443))
+        try:
+            client.connect(("encrypted.google.com", 443))
+        except gaierror:
+            pytest.skip("cannot connect to encrypted.google.com")
         clientSSL = Connection(context, client)
         clientSSL.set_connect_state()
         clientSSL.set_tlsext_host_name(b"encrypted.google.com")


### PR DESCRIPTION
The `test_set_default_verify_paths` test fails if tests are run offline, due to not being able to connect to `encrypted.google.com`. This PR adds a change to skip that test if the connection cannot be made.

This fixes https://github.com/pyca/pyopenssl/issues/68

cc @mhils @reaperhulk 