### PR TITLE
allow X509_ALGOR to be opaque

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Backward-incompatible changes:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Dropped support for Python 3.6.
-- The minimum ``cryptography`` version is now 41.0.0.
+- The minimum ``cryptography`` version is now 41.0.5.
 - Removed ``OpenSSL.crypto.loads_pkcs7`` and ``OpenSSL.crypto.loads_pkcs12`` which had been deprecated for 3 years.
 - Added ``OpenSSL.SSL.OP_LEGACY_SERVER_CONNECT`` to allow legacy insecure renegotiation between OpenSSL and unpatched servers.
   `#1234 <https://github.com/pyca/pyopenssl/pull/1234>`_.

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
         packages=find_packages(where="src"),
         package_dir={"": "src"},
         install_requires=[
-            "cryptography>=41.0.0,<42",
+            "cryptography>=41.0.5,<42",
         ],
         extras_require={
             "test": ["flaky", "pretend", "pytest>=3.0.1"],

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -1322,8 +1322,10 @@ class X509:
 
         .. versionadded:: 0.13
         """
-        algor = _lib.X509_get0_tbs_sigalg(self._x509)
-        nid = _lib.OBJ_obj2nid(algor.algorithm)
+        sig_alg = _lib.X509_get0_tbs_sigalg(self._x509)
+        alg = _ffi.new("ASN1_OBJECT **")
+        _lib.X509_ALGOR_get0(alg, _ffi.NULL, _ffi.NULL, sig_alg)
+        nid = _lib.OBJ_obj2nid(alg[0])
         if nid == _lib.NID_undef:
             raise ValueError("Undefined signature algorithm")
         return _ffi.string(_lib.OBJ_nid2ln(nid))

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ extras =
     test
 deps =
     coverage>=4.2
-    cryptographyMinimum: cryptography==41.0.0
+    cryptographyMinimum: cryptography==41.0.5
     randomorder: pytest-randomly
 setenv =
     # Do not allow the executing environment to pollute the test environment


### PR DESCRIPTION
this needs 41.0.5 since there's a new binding