### PR TITLE
docs: include test dependencies when developing pyOpenSSL

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -7,7 +7,7 @@ To install pyOpenSSL::
 
 If you are installing in order to *develop* on pyOpenSSL, move to the root directory of a pyOpenSSL checkout, and run::
 
-  $ pip install -e .
+  $ pip install -e .[test]
 
 
 .. warning::


### PR DESCRIPTION
If someone is running `pip install -e` to develop on pyOpenSSL, presumably they want to be able to run the tests too.