### PR TITLE
Add Connection.get_selected_srtp_profile (#1278)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ Changes:
   to the now deprecated ``OpenSSL.crypto.CRL`` arguments.
 - Fixed ``test_set_default_verify_paths`` test so that it is skipped if no
   network connection is available.
+- Added ``OpenSSL.SSL.Connection.get_selected_srtp_profile`` to determine which SRTP profile was negotiated.
+  `#1279 <https://github.com/pyca/pyopenssl/pull/1279>`_.
 
 23.2.0 (2023-05-30)
 -------------------

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2858,6 +2858,19 @@ class Connection:
 
         return _ffi.buffer(data[0], data_len[0])[:]
 
+    def get_selected_srtp_profile(self):
+        """
+        Get the SRTP protocol which was negotiated.
+
+        :returns: A bytestring of the SRTP profile name. If no profile has been
+            negotiated yet, returns an empty bytestring.
+        """
+        profile = _lib.SSL_get_selected_srtp_profile(self._ssl)
+        if not profile:
+            return b""
+
+        return _ffi.string(profile.name)
+
     def request_ocsp(self):
         """
         Called to request that the server sends stapled OCSP data, if


### PR DESCRIPTION
If an SRTP profile was negotiated as part of the handshake, make it possible to retrieve the name of the profile. This is needed to determine which profiles were offered using `Context.set_tlsext_use_srtp` was actually selected.