### PR TITLE
Stop using flaky lib, use pytest-rerunfailures instead

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
             "cryptography>=41.0.5,<43",
         ],
         extras_require={
-            "test": ["flaky", "pretend", "pytest>=3.0.1"],
+            "test": ["pytest-rerunfailures", "pretend", "pytest>=3.0.1"],
             "docs": [
                 "sphinx!=5.2.0,!=5.2.0.post0,!=7.2.5",
                 "sphinx_rtd_theme",

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -10,7 +10,6 @@ import warnings
 from datetime import datetime, timedelta, timezone
 from subprocess import PIPE, Popen
 
-import flaky
 import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -1864,7 +1863,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         with pytest.raises(TypeError):
             cert.gmtime_adj_notBefore(None)
 
-    @flaky.flaky
+    @pytest.mark.flaky(reruns=2)
     def test_gmtime_adj_notBefore(self):
         """
         `X509.gmtime_adj_notBefore` changes the not-before timestamp to be the
@@ -1890,7 +1889,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         with pytest.raises(TypeError):
             cert.gmtime_adj_notAfter(None)
 
-    @flaky.flaky
+    @pytest.mark.flaky(reruns=2)
     def test_gmtime_adj_notAfter(self):
         """
         `X509.gmtime_adj_notAfter` changes the not-after timestamp

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -4,6 +4,7 @@
 """
 Unit tests for :py:mod:`OpenSSL.crypto`.
 """
+
 import base64
 import sys
 import warnings

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -34,7 +34,6 @@ from sys import getfilesystemencoding, platform
 from typing import Union
 from weakref import ref
 
-import flaky
 import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -510,7 +509,7 @@ class TestContext:
         with pytest.raises(TypeError):
             context.set_cipher_list(object())
 
-    @flaky.flaky
+    @pytest.mark.flaky(reruns=2)
     def test_set_cipher_list_no_cipher_match(self, context):
         """
         `Context.set_cipher_list` raises `OpenSSL.SSL.Error` with a

--- a/tests/util.py
+++ b/tests/util.py
@@ -6,7 +6,6 @@ Helpers for the OpenSSL test suite, largely copied from
 U{Twisted<http://twistedmatrix.com/>}.
 """
 
-
 # This is the UTF-8 encoding of the SNOWMAN unicode code point.
 NON_ASCII = b"\xe2\x98\x83".decode("utf-8")
 


### PR DESCRIPTION
flaky is not compatible with the latest pytest release and appears unmaintained, while pytest-rerunfailures is maintained by the pytest team