### PR TITLE
Fix `ruff` invocation

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -639,7 +639,7 @@ class X509Name:
 
         # Note: we really do not want str subclasses here, so we do not use
         # isinstance.
-        if type(name) is not str:  # noqa: E721
+        if type(name) is not str:
             raise TypeError(
                 f"attribute name must be string, not "
                 f"'{type(value).__name__:.200}'"

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps =
     ruff
 skip_install = true
 commands =
-    ruff .
+    ruff check .
     ruff format --check .
 
 [testenv:py311-mypy]


### PR DESCRIPTION
Ruff must now either be invoked as `ruff check` or `ruff format`.