### PR TITLE
Allow `set_tmp_ecdh` to take cryptography elliptic curves

### DIFF
--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -576,6 +576,20 @@ def get_elliptic_curves() -> set[_EllipticCurve]:
     return _EllipticCurve._get_elliptic_curves(_lib)
 
 
+_get_elliptic_curves_internal = get_elliptic_curves
+
+utils.deprecated(
+    get_elliptic_curves,
+    __name__,
+    (
+        "get_elliptic_curves is deprecated. You should use the APIs in "
+        "cryptography instead."
+    ),
+    DeprecationWarning,
+    name="get_elliptic_curves",
+)
+
+
 def get_elliptic_curve(name: str) -> _EllipticCurve:
     """
     Return a single curve object selected by name.
@@ -588,10 +602,22 @@ def get_elliptic_curve(name: str) -> _EllipticCurve:
 
     If the named curve is not supported then :py:class:`ValueError` is raised.
     """
-    for curve in get_elliptic_curves():
+    for curve in _get_elliptic_curves_internal():
         if curve.name == name:
             return curve
     raise ValueError("unknown curve name", name)
+
+
+utils.deprecated(
+    get_elliptic_curve,
+    __name__,
+    (
+        "get_elliptic_curve is deprecated. You should use the APIs in "
+        "cryptography instead."
+    ),
+    DeprecationWarning,
+    name="get_elliptic_curve",
+)
 
 
 @functools.total_ordering

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -37,7 +37,7 @@ from weakref import ref
 import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.x509.oid import NameOID
 from pretend import raiser
 
@@ -1685,6 +1685,14 @@ class TestContext:
                 continue
             # The only easily "assertable" thing is that it does not raise an
             # exception.
+            with pytest.deprecated_call():
+                context.set_tmp_ecdh(curve)
+
+        for name in dir(ec.EllipticCurveOID):
+            if name.startswith("_"):
+                continue
+            oid = getattr(ec.EllipticCurveOID, name)
+            curve = ec.get_curve_for_oid(oid)
             context.set_tmp_ecdh(curve)
 
     def test_set_session_cache_mode_wrong_args(self):


### PR DESCRIPTION
Deprecate `get_elliptic_curves` and `get_elliptic_curve`

Refs #1321