### PR TITLE
Deprecated passing X509 objects to use_certificate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Deprecations:
 
 - Deprecated ``OpenSSL.rand`` - callers should use ``os.urandom()`` instead.
 - Deprecated ``OpenSSL.crypto.get_elliptic_curves`` and ``OpenSSL.crypto.get_elliptic_curve``, as well as passing the reult of them to ``OpenSSL.SSL.Context.set_tmp_ecdh``, users should instead pass curves from ``cryptography``.
+- Deprecated passing ``X509`` objects to ``OpenSSL.SSL.Context.use_certificate`` and ``OpenSSL.SSL.Connection.use_certificate``, users should instead pass ``cryptography.x509.Certificate`` instances. This is in preperation for deprecating pyOpenSSL's ``X509`` entirely.
 
 Changes:
 ^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Deprecations:
 
 - Deprecated ``OpenSSL.rand`` - callers should use ``os.urandom()`` instead.
 - Deprecated ``OpenSSL.crypto.get_elliptic_curves`` and ``OpenSSL.crypto.get_elliptic_curve``, as well as passing the reult of them to ``OpenSSL.SSL.Context.set_tmp_ecdh``, users should instead pass curves from ``cryptography``.
-- Deprecated passing ``X509`` objects to ``OpenSSL.SSL.Context.use_certificate`` and ``OpenSSL.SSL.Connection.use_certificate``, users should instead pass ``cryptography.x509.Certificate`` instances. This is in preperation for deprecating pyOpenSSL's ``X509`` entirely.
+- Deprecated passing ``X509`` objects to ``OpenSSL.SSL.Context.use_certificate`` and ``OpenSSL.SSL.Connection.use_certificate``, users should instead pass ``cryptography.x509.Certificate`` instances. This is in preparation for deprecating pyOpenSSL's ``X509`` entirely.
 
 Changes:
 ^^^^^^^^

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -11,6 +11,7 @@ from sys import platform
 from typing import Any, Callable, List, Optional, Sequence, TypeVar
 from weakref import WeakValueDictionary
 
+from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from OpenSSL._util import (
@@ -1126,7 +1127,7 @@ class Context:
         if not use_result:
             _raise_current_error()
 
-    def use_certificate(self, cert: X509) -> None:
+    def use_certificate(self, cert: X509 | x509.Certificate) -> None:
         """
         Load a certificate from a X509 object
 
@@ -1135,7 +1136,16 @@ class Context:
         """
         # Mirrored at Connection.use_certificate
         if not isinstance(cert, X509):
-            raise TypeError("cert must be an X509 instance")
+            cert = X509.from_cryptography(cert)
+        else:
+            warnings.warn(
+                (
+                    "Passing pyOpenSSL X509 objects is deprecated. You "
+                    "should use a cryptography.x509.Certificate instead."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         use_result = _lib.SSL_CTX_use_certificate(self._context, cert._x509)
         if not use_result:
@@ -2017,7 +2027,7 @@ class Connection:
         """
         return _lib.SSL_get_verify_mode(self._ssl)
 
-    def use_certificate(self, cert: X509) -> None:
+    def use_certificate(self, cert: X509 | x509.Certificate) -> None:
         """
         Load a certificate from a X509 object
 
@@ -2026,7 +2036,16 @@ class Connection:
         """
         # Mirrored from Context.use_certificate
         if not isinstance(cert, X509):
-            raise TypeError("cert must be an X509 instance")
+            cert = X509.from_cryptography(cert)
+        else:
+            warnings.warn(
+                (
+                    "Passing pyOpenSSL X509 objects is deprecated. You "
+                    "should use a cryptography.x509.Certificate instead."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         use_result = _lib.SSL_use_certificate(self._ssl, cert._x509)
         if not use_result:

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2208,6 +2208,9 @@ class TestContextConnection:
         ctx_or_conn.use_certificate(
             load_certificate(FILETYPE_PEM, root_cert_pem)
         )
+        ctx_or_conn.use_certificate(
+            load_certificate(FILETYPE_PEM, root_cert_pem).to_cryptography()
+        )
 
     def test_use_certificate_wrong_args(self, ctx_or_conn):
         """


### PR DESCRIPTION
Added support for passing cryptography.x509.Certificate