### PR TITLE
Deprecate passing `PKey` instances to `use_privatekey`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Deprecations:
 - Deprecated ``OpenSSL.rand`` - callers should use ``os.urandom()`` instead.
 - Deprecated ``OpenSSL.crypto.get_elliptic_curves`` and ``OpenSSL.crypto.get_elliptic_curve``, as well as passing the reult of them to ``OpenSSL.SSL.Context.set_tmp_ecdh``, users should instead pass curves from ``cryptography``.
 - Deprecated passing ``X509`` objects to ``OpenSSL.SSL.Context.use_certificate``, ``OpenSSL.SSL.Connection.use_certificate``, ``OpenSSL.SSL.Context.add_extra_chain_cert``, and ``OpenSSL.SSL.Context.add_client_ca``, users should instead pass ``cryptography.x509.Certificate`` instances. This is in preparation for deprecating pyOpenSSL's ``X509`` entirely.
+- Deprecated passing ``PKey`` objects to ``OpenSSL.SSL.Context.use_privatekey`` and ``OpenSSL.SSL.Connection.use_privatekey``, users should instead pass ``cryptography`` priate key instances. This is in preparation for deprecating pyOpenSSL's ``PKey`` entirely.
 
 Changes:
 ^^^^^^^^

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -46,6 +46,7 @@ from OpenSSL.crypto import (
     X509Store,
     _EllipticCurve,
     _PassphraseHelper,
+    _PrivateKey,
 )
 
 __all__ = [
@@ -1204,7 +1205,7 @@ class Context:
         if not use_result:
             self._raise_passphrase_exception()
 
-    def use_privatekey(self, pkey: PKey) -> None:
+    def use_privatekey(self, pkey: _PrivateKey | PKey) -> None:
         """
         Load a private key from a PKey object
 
@@ -1213,7 +1214,16 @@ class Context:
         """
         # Mirrored at Connection.use_privatekey
         if not isinstance(pkey, PKey):
-            raise TypeError("pkey must be a PKey instance")
+            pkey = PKey.from_cryptography_key(pkey)
+        else:
+            warnings.warn(
+                (
+                    "Passing pyOpenSSL PKey objects is deprecated. You "
+                    "should use a cryptography private key instead."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         use_result = _lib.SSL_CTX_use_PrivateKey(self._context, pkey._pkey)
         if not use_result:
@@ -2070,7 +2080,7 @@ class Connection:
         if not use_result:
             _raise_current_error()
 
-    def use_privatekey(self, pkey: PKey) -> None:
+    def use_privatekey(self, pkey: _PrivateKey | PKey) -> None:
         """
         Load a private key from a PKey object
 
@@ -2079,7 +2089,16 @@ class Connection:
         """
         # Mirrored from Context.use_privatekey
         if not isinstance(pkey, PKey):
-            raise TypeError("pkey must be a PKey instance")
+            pkey = PKey.from_cryptography_key(pkey)
+        else:
+            warnings.warn(
+                (
+                    "Passing pyOpenSSL PKey objects is deprecated. You "
+                    "should use a cryptography private key instead."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         use_result = _lib.SSL_use_PrivateKey(self._ssl, pkey._pkey)
         if not use_result:

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -84,18 +84,21 @@ __all__ = [
 ]
 
 
-_Key = Union[
+_PrivateKey = Union[
     dsa.DSAPrivateKey,
-    dsa.DSAPublicKey,
     ec.EllipticCurvePrivateKey,
-    ec.EllipticCurvePublicKey,
     ed25519.Ed25519PrivateKey,
-    ed25519.Ed25519PublicKey,
     ed448.Ed448PrivateKey,
-    ed448.Ed448PublicKey,
     rsa.RSAPrivateKey,
+]
+_PublicKey = Union[
+    dsa.DSAPublicKey,
+    ec.EllipticCurvePublicKey,
+    ed25519.Ed25519PublicKey,
+    ed448.Ed448PublicKey,
     rsa.RSAPublicKey,
 ]
+_Key = Union[_PrivateKey, _PublicKey]
 StrOrBytesPath = Union[str, bytes, PathLike]
 PassphraseCallableT = Union[bytes, Callable[..., bytes]]
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -727,6 +727,11 @@ class TestContext:
         context.use_certificate(cert)
         assert None is context.check_privatekey()
 
+        context = Context(SSLv23_METHOD)
+        context.use_privatekey(key.to_cryptography_key())
+        context.use_certificate(cert)
+        assert None is context.check_privatekey()
+
     def test_check_privatekey_invalid(self):
         """
         `Context.check_privatekey` raises `Error` if the `Context` instance
@@ -737,6 +742,12 @@ class TestContext:
         cert = load_certificate(FILETYPE_PEM, server_cert_pem)
         context = Context(SSLv23_METHOD)
         context.use_privatekey(key)
+        context.use_certificate(cert)
+        with pytest.raises(Error):
+            context.check_privatekey()
+
+        context = Context(SSLv23_METHOD)
+        context.use_privatekey(key.to_cryptography_key())
         context.use_certificate(cert)
         with pytest.raises(Error):
             context.check_privatekey()
@@ -2162,6 +2173,8 @@ class TestContextConnection:
         ctx_or_conn.use_privatekey(key)
         with pytest.raises(TypeError):
             ctx_or_conn.use_privatekey("")
+
+        ctx_or_conn.use_privatekey(key.to_cryptography_key())
 
     def test_use_privatekey_wrong_key(self, ctx_or_conn):
         """


### PR DESCRIPTION
Allow passing cryptography keys instead.

Refs #1321