### PR TITLE
Allow Connection.get_certificate to return a cryptography certificate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
+* ``OpenSSL.SSL.Connection.get_certificate`` now takes an ``as_cryptography`` keyword-argument. When ``True`` is passed then a ``cryptography.x509.Certificate`` is returned, instead of an ``OpenSSL.crypto.X509``. In the future, passing ``False`` (the default) will be deprecated.
+
 
 24.2.1 (2024-07-20)
 -------------------

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -2696,16 +2696,43 @@ class Connection:
         """
         return self._socket.shutdown(*args, **kwargs)  # type: ignore[return-value, union-attr]
 
-    def get_certificate(self) -> X509 | None:
+    @typing.overload
+    def get_certificate(
+        self, *, as_cryptography: typing.Literal[True]
+    ) -> x509.Certificate | None:
+        pass
+
+    @typing.overload
+    def get_certificate(
+        self, *, as_cryptography: typing.Literal[False] = False
+    ) -> X509 | None:
+        pass
+
+    @typing.overload
+    def get_certificate(
+        self, *, as_cryptography: bool = False
+    ) -> X509 | x509.Certificate | None:
+        pass
+
+    def get_certificate(
+        self, *, as_cryptography: bool = False
+    ) -> X509 | x509.Certificate | None:
         """
         Retrieve the local certificate (if any)
+
+        :param bool as_cryptography: Controls whether a
+            ``cryptography.x509.Certificate`` or an ``OpenSSL.crypto.X509``
+            object should be returned.
 
         :return: The local certificate
         """
         cert = _lib.SSL_get_certificate(self._ssl)
         if cert != _ffi.NULL:
             _lib.X509_up_ref(cert)
-            return X509._from_raw_x509_ptr(cert)
+            pycert = X509._from_raw_x509_ptr(cert)
+            if as_cryptography:
+                return pycert.to_cryptography()
+            return pycert
         return None
 
     def get_peer_certificate(self) -> X509 | None:

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2556,6 +2556,13 @@ class TestConnection:
         assert cert is not None
         assert "Server Certificate" == cert.get_subject().CN
 
+        cryptography_cert = client.get_certificate(as_cryptography=True)
+        assert cryptography_cert is not None
+        assert (
+            cryptography_cert.subject.rfc4514_string()
+            == "CN=Server Certificate"
+        )
+
     def test_get_certificate_none(self):
         """
         `Connection.get_certificate` returns the local certificate.


### PR DESCRIPTION
refs https://github.com/pyca/pyopenssl/issues/1321