### PR TITLE
Allow Connection.get_peer_certificate to return a cryptography certificate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-* ``OpenSSL.SSL.Connection.get_certificate`` now takes an ``as_cryptography`` keyword-argument. When ``True`` is passed then a ``cryptography.x509.Certificate`` is returned, instead of an ``OpenSSL.crypto.X509``. In the future, passing ``False`` (the default) will be deprecated.
+* ``OpenSSL.SSL.Connection.get_certificate`` and ``OpenSSL.SSL.Connection.get_peer_certificate`` now take an ``as_cryptography`` keyword-argument. When ``True`` is passed then a ``cryptography.x509.Certificate`` is returned, instead of an ``OpenSSL.crypto.X509``. In the future, passing ``False`` (the default) will be deprecated.
 
 
 24.2.1 (2024-07-20)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1073,6 +1073,14 @@ class TestContext:
         cert = clientSSL.get_peer_certificate()
         assert cert.get_subject().CN == "Testing Root CA"
 
+        cryptography_cert = clientSSL.get_peer_certificate(
+            as_cryptography=True
+        )
+        assert (
+            cryptography_cert.subject.rfc4514_string()
+            == "CN=Testing Root CA,O=Testing,L=Chicago,ST=IL,C=US"
+        )
+
     def _load_verify_cafile(self, cafile):
         """
         Verify that if path to a file containing a certificate is passed to


### PR DESCRIPTION
refs https://github.com/pyca/pyopenssl/issues/1321