### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - {VERSION: "3.10", TOXENV: "py310"}
           - {VERSION: "3.11", TOXENV: "py311"}
           - {VERSION: "3.12", TOXENV: "py312"}
+          - {VERSION: "3.13-dev", TOXENV: "py313"}
           - {VERSION: "pypy-3.9", TOXENV: "pypy3"}
           - {VERSION: "pypy-3.10", TOXENV: "pypy3"}
           - {VERSION: "3.11", TOXENV: "py311-useWheel", OS: "windows-2022" }
@@ -26,6 +27,7 @@ jobs:
           - {VERSION: "3.10", TOXENV: "py310-cryptographyMain"}
           - {VERSION: "3.11", TOXENV: "py311-cryptographyMain"}
           - {VERSION: "3.12", TOXENV: "py312-cryptographyMain"}
+          - {VERSION: "3.13-dev", TOXENV: "py313-cryptographyMain"}
           - {VERSION: "pypy-3.9", TOXENV: "pypy3-cryptographyMain"}
           - {VERSION: "pypy-3.10", TOXENV: "pypy3-cryptographyMain"}
           # -cryptographyMinimum
@@ -35,6 +37,7 @@ jobs:
           - {VERSION: "3.10", TOXENV: "py310-cryptographyMinimum"}
           - {VERSION: "3.11", TOXENV: "py311-cryptographyMinimum"}
           - {VERSION: "3.12", TOXENV: "py312-cryptographyMinimum"}
+          - {VERSION: "3.13-dev", TOXENV: "py313-cryptographyMinimum"}
           - {VERSION: "pypy-3.10", TOXENV: "pypy3-cryptographyMinimum"}
           # Cryptography wheels
           - {VERSION: "3.9", TOXENV: "py39-cryptographyMinimum-useWheel"}

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",
             "Topic :: Security :: Cryptography",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{py3,37,38,39,310,311,312}{,-cryptographyMinimum}{,-useWheel}{,-randomorder},py311-twistedTrunk,check-manifest,lint,py311-mypy,docs,coverage-report
+envlist = py{py3,37,38,39,310,311,312,313}{,-cryptographyMinimum}{,-useWheel}{,-randomorder},py311-twistedTrunk,check-manifest,lint,py311-mypy,docs,coverage-report
 
 [testenv]
 allowlist_externals =


### PR DESCRIPTION
The final Python 3.13 release candidate is out now! :rocket:

The Release Manager has issued a [call to action](https://discuss.python.org/t/python-3-13-0rc2-3-12-6-3-11-10-3-10-15-3-9-20-and-3-8-20-are-now-available/63161?u=hugovk]):

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.13 compatibilities during this phase, and where necessary publish Python 3.13 wheels on PyPI to be ready for the final release of 3.13.0. Any binary wheels built against Python 3.13.0rc2 will work with future versions of Python 3.13. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).