### PR TITLE
Annotate a zillion test functions with -> None

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -879,7 +879,7 @@ class TestX509Ext:
     Tests for `OpenSSL.crypto.X509Extension`.
     """
 
-    def test_str(self):
+    def test_str(self) -> None:
         """
         The string representation of `X509Extension` instances as
         returned by `str` includes stuff.
@@ -891,7 +891,7 @@ class TestX509Ext:
             == "CA:FALSE"
         )
 
-    def test_type(self):
+    def test_type(self) -> None:
         """
         `X509Extension` can be used to create instances of that type.
         """
@@ -903,7 +903,7 @@ class TestX509Ext:
             b"CA:true",
         )
 
-    def test_construction(self):
+    def test_construction(self) -> None:
         """
         `X509Extension` accepts an extension type name, a critical flag,
         and an extension value and returns an `X509Extension` instance.
@@ -931,7 +931,7 @@ class TestX509Ext:
             ),
         ],
     )
-    def test_invalid_extension(self, type_name, critical, value):
+    def test_invalid_extension(self, type_name, critical, value) -> None:
         """
         `X509Extension` raises something if it is passed a bad
         extension name or value.
@@ -940,7 +940,7 @@ class TestX509Ext:
             X509Extension(type_name, critical, value)
 
     @pytest.mark.parametrize("critical_flag", [True, False])
-    def test_get_critical(self, critical_flag):
+    def test_get_critical(self, critical_flag) -> None:
         """
         `X509ExtensionType.get_critical` returns the value of the
         extension's critical flag.
@@ -952,7 +952,7 @@ class TestX509Ext:
         "short_name, value",
         [(b"basicConstraints", b"CA:true"), (b"nsComment", b"foo bar")],
     )
-    def test_get_short_name(self, short_name, value):
+    def test_get_short_name(self, short_name, value) -> None:
         """
         `X509ExtensionType.get_short_name` returns a string giving the
         short type name of the extension.
@@ -960,7 +960,7 @@ class TestX509Ext:
         ext = X509Extension(short_name, True, value)
         assert ext.get_short_name() == short_name
 
-    def test_get_data(self):
+    def test_get_data(self) -> None:
         """
         `X509Extension.get_data` returns a string giving the data of
         the extension.
@@ -969,7 +969,7 @@ class TestX509Ext:
         # Expect to get back the DER encoded form of CA:true.
         assert ext.get_data() == b"0\x03\x01\x01\xff"
 
-    def test_unused_subject(self, x509_data):
+    def test_unused_subject(self, x509_data) -> None:
         """
         The `subject` parameter to `X509Extension` may be provided for an
         extension which does not use it and is ignored in this case.
@@ -985,7 +985,7 @@ class TestX509Ext:
         assert b"X509v3 Basic Constraints:" in text
         assert b"CA:TRUE" in text
 
-    def test_subject(self, x509_data):
+    def test_subject(self, x509_data) -> None:
         """
         If an extension requires a subject, the `subject` parameter to
         `X509Extension` provides its value.
@@ -999,7 +999,7 @@ class TestX509Ext:
         text = dump_certificate(FILETYPE_TEXT, x509)
         assert b"X509v3 Subject Key Identifier:" in text
 
-    def test_missing_subject(self):
+    def test_missing_subject(self) -> None:
         """
         If an extension requires a subject and the `subject` parameter
         is given no value, something happens.
@@ -1008,7 +1008,7 @@ class TestX509Ext:
             X509Extension(b"subjectKeyIdentifier", False, b"hash")
 
     @pytest.mark.parametrize("bad_obj", [True, object(), "hello", []])
-    def test_invalid_subject(self, bad_obj):
+    def test_invalid_subject(self, bad_obj) -> None:
         """
         If the `subject` parameter is given a value which is not an
         `X509` instance, `TypeError` is raised.
@@ -1018,7 +1018,7 @@ class TestX509Ext:
                 "basicConstraints", False, "CA:TRUE", subject=bad_obj
             )
 
-    def test_unused_issuer(self, x509_data):
+    def test_unused_issuer(self, x509_data) -> None:
         """
         The `issuer` parameter to `X509Extension` may be provided for an
         extension which does not use it and is ignored in this case.
@@ -1033,7 +1033,7 @@ class TestX509Ext:
         assert b"X509v3 Basic Constraints:" in text
         assert b"CA:TRUE" in text
 
-    def test_issuer(self, x509_data):
+    def test_issuer(self, x509_data) -> None:
         """
         If an extension requires an issuer, the `issuer` parameter to
         `X509Extension` provides its value.
@@ -1048,7 +1048,7 @@ class TestX509Ext:
         assert b"X509v3 Authority Key Identifier:" in text
         assert b"DirName:/CN=Yoda root CA" in text
 
-    def test_missing_issuer(self):
+    def test_missing_issuer(self) -> None:
         """
         If an extension requires an issue and the `issuer` parameter is
         given no value, something happens.
@@ -1059,7 +1059,7 @@ class TestX509Ext:
             )
 
     @pytest.mark.parametrize("bad_obj", [True, object(), "hello", []])
-    def test_invalid_issuer(self, bad_obj):
+    def test_invalid_issuer(self, bad_obj) -> None:
         """
         If the `issuer` parameter is given a value which is not an
         `X509` instance, `TypeError` is raised.
@@ -1146,7 +1146,7 @@ class TestPKey:
         assert pkey._only_public is True
         assert pkey._initialized is True
 
-    def test_convert_from_cryptography_public_key(self):
+    def test_convert_from_cryptography_public_key(self) -> None:
         """
         PKey.from_cryptography_key creates a proper public PKey.
         """
@@ -1158,7 +1158,7 @@ class TestPKey:
         assert pkey._only_public is True
         assert pkey._initialized is True
 
-    def test_convert_from_cryptography_unsupported_type(self):
+    def test_convert_from_cryptography_unsupported_type(self) -> None:
         """
         PKey.from_cryptography_key raises TypeError with an unsupported type.
         """
@@ -1166,7 +1166,7 @@ class TestPKey:
         with pytest.raises(TypeError):
             PKey.from_cryptography_key(key)
 
-    def test_convert_public_pkey_to_cryptography_key(self):
+    def test_convert_public_pkey_to_cryptography_key(self) -> None:
         """
         PKey.to_cryptography_key creates a proper cryptography public key.
         """
@@ -1176,20 +1176,20 @@ class TestPKey:
         assert isinstance(key, rsa.RSAPublicKey)
         assert pkey.bits() == key.key_size
 
-    def test_type(self):
+    def test_type(self) -> None:
         """
         `PKey` can be used to create instances of that type.
         """
         assert is_consistent_type(PKey, "PKey")
 
-    def test_construction(self):
+    def test_construction(self) -> None:
         """
         `PKey` takes no arguments and returns a new `PKey` instance.
         """
         key = PKey()
         assert isinstance(key, PKey)
 
-    def test_pregeneration(self):
+    def test_pregeneration(self) -> None:
         """
         `PKey.bits` and `PKey.type` return `0` before the key is generated.
         `PKey.check` raises `TypeError` before the key is generated.
@@ -1200,7 +1200,7 @@ class TestPKey:
         with pytest.raises(TypeError):
             key.check()
 
-    def test_failed_generation(self):
+    def test_failed_generation(self) -> None:
         """
         `PKey.generate_key` takes two arguments, the first giving the key type
         as one of `TYPE_RSA` or `TYPE_DSA` and the second giving the number of
@@ -1241,7 +1241,7 @@ class TestPKey:
         # with pytest.raises(Error):
         #     key.generate_key(TYPE_DSA, -7)
 
-    def test_rsa_generation(self):
+    def test_rsa_generation(self) -> None:
         """
         `PKey.generate_key` generates an RSA key when passed `TYPE_RSA` as a
         type and a reasonable number of bits.
@@ -1253,7 +1253,7 @@ class TestPKey:
         assert key.bits() == bits
         assert key.check()
 
-    def test_dsa_generation(self):
+    def test_dsa_generation(self) -> None:
         """
         `PKey.generate_key` generates a DSA key when passed `TYPE_DSA` as a
         type and a reasonable number of bits.
@@ -1269,7 +1269,7 @@ class TestPKey:
         with pytest.raises(TypeError):
             key.check()
 
-    def test_regeneration(self):
+    def test_regeneration(self) -> None:
         """
         `PKey.generate_key` can be called multiple times on the same key to
         generate new keys.
@@ -1280,7 +1280,7 @@ class TestPKey:
             assert key.type() == type
             assert key.bits() == bits
 
-    def test_inconsistent_key(self):
+    def test_inconsistent_key(self) -> None:
         """
         Either `load_privatekey` or `PKey.check` returns `Error` if the key is
         not consistent.
@@ -1289,7 +1289,7 @@ class TestPKey:
             key = load_privatekey(FILETYPE_PEM, inconsistentPrivateKeyPEM)
             key.check()
 
-    def test_check_public_key(self):
+    def test_check_public_key(self) -> None:
         """
         `PKey.check` raises `TypeError` if only the public part of the key
         is available.
@@ -1303,7 +1303,7 @@ class TestPKey:
         with pytest.raises(TypeError):
             pub.check()
 
-    def test_check_pr_897(self):
+    def test_check_pr_897(self) -> None:
         """
         Either `load_privatekey` or `PKey.check` raises `OpenSSL.crypto.Error`
         if provided with broken key
@@ -1336,14 +1336,14 @@ class TestX509Name:
     Unit tests for `OpenSSL.crypto.X509Name`.
     """
 
-    def test_type(self):
+    def test_type(self) -> None:
         """
         The type of X509Name objects is `X509Name`.
         """
         name = x509_name()
         assert isinstance(name, X509Name)
 
-    def test_only_string_attributes(self):
+    def test_only_string_attributes(self) -> None:
         """
         Attempting to set a non-`str` attribute name on an `X509Name` instance
         causes `TypeError` to be raised.
@@ -1364,7 +1364,7 @@ class TestX509Name:
         with pytest.raises(TypeError):
             setattr(name, 30, "hello")
 
-    def test_set_invalid_attribute(self):
+    def test_set_invalid_attribute(self) -> None:
         """
         Attempting to set any attribute name on an `X509Name` instance for
         which no corresponding NID is defined causes `AttributeError` to be
@@ -1374,7 +1374,7 @@ class TestX509Name:
         with pytest.raises(AttributeError):
             setattr(name, "no such thing", None)
 
-    def test_attributes(self):
+    def test_attributes(self) -> None:
         """
         `X509Name` instances have attributes for each standard (?)
         X509Name field.
@@ -1401,7 +1401,7 @@ class TestX509Name:
         with pytest.raises(AttributeError):
             name.foobar
 
-    def test_copy(self):
+    def test_copy(self) -> None:
         """
         `X509Name` creates a new `X509Name` instance with all the same
         attributes as an existing `X509Name` instance when called with one.
@@ -1420,7 +1420,7 @@ class TestX509Name:
         name.emailAddress = "quux@example.com"
         assert copy.emailAddress == "bar@example.com"
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         """
         `repr` passed an `X509Name` instance should return a string containing
         a description of the type and the NIDs which have been set on it.
@@ -1428,7 +1428,7 @@ class TestX509Name:
         name = x509_name(commonName="foo", emailAddress="bar")
         assert repr(name) == "<X509Name object '/emailAddress=bar/CN=foo'>"
 
-    def test_comparison(self):
+    def test_comparison(self) -> None:
         """
         `X509Name` instances should compare based on their NIDs.
         """
@@ -1520,7 +1520,7 @@ class TestX509Name:
         # Only X509Name objects can be compared with lesser than / greater than
         assert_raises(x509_name(), object())
 
-    def test_hash(self):
+    def test_hash(self) -> None:
         """
         `X509Name.hash` returns an integer hash based on the value of the name.
         """
@@ -1530,7 +1530,7 @@ class TestX509Name:
         a.CN = "bar"
         assert a.hash() != b.hash()
 
-    def test_der(self):
+    def test_der(self) -> None:
         """
         `X509Name.der` returns the DER encoded form of the name.
         """
@@ -1540,7 +1540,7 @@ class TestX509Name:
             b"1\x0c0\n\x06\x03U\x04\x03\x0c\x03foo"
         )
 
-    def test_get_components(self):
+    def test_get_components(self) -> None:
         """
         `X509Name.get_components` returns a `list` of two-tuples of `str`
         giving the NIDs and associated values which make up the name.
@@ -1552,7 +1552,7 @@ class TestX509Name:
         a.organizationalUnitName = "bar"
         assert a.get_components() == [(b"CN", b"foo"), (b"OU", b"bar")]
 
-    def test_load_nul_byte_attribute(self):
+    def test_load_nul_byte_attribute(self) -> None:
         """
         An `X509Name` from an `X509` instance loaded from a file can have a
         NUL byte in the value of one of its attributes.
@@ -1561,7 +1561,7 @@ class TestX509Name:
         subject = cert.get_subject()
         assert "null.python.org\x00example.org" == subject.commonName
 
-    def test_load_nul_byte_components(self):
+    def test_load_nul_byte_components(self) -> None:
         """
         An `X509Name` from an `X509` instance loaded from a file can have a
         NUL byte in the value of its components
@@ -1572,7 +1572,7 @@ class TestX509Name:
         ccn = [value for name, value in components if name == b"CN"]
         assert ccn[0] == b"null.python.org\x00example.org"
 
-    def test_set_attribute_failure(self):
+    def test_set_attribute_failure(self) -> None:
         """
         If the value of an attribute cannot be set for some reason then
         `Error` is raised.
@@ -1594,7 +1594,7 @@ class _PKeyInteractionTestsMixin:
         """
         raise NotImplementedError()
 
-    def test_sign_with_ungenerated(self):
+    def test_sign_with_ungenerated(self) -> None:
         """
         `X509Req.sign` raises `ValueError` when passed a `PKey` with no parts.
         """
@@ -1603,7 +1603,7 @@ class _PKeyInteractionTestsMixin:
         with pytest.raises(ValueError):
             request.sign(key, GOOD_DIGEST)
 
-    def test_sign_with_public_key(self):
+    def test_sign_with_public_key(self) -> None:
         """
         `X509Req.sign` raises `ValueError` when passed a `PKey` with no private
         part as the signing key.
@@ -1616,7 +1616,7 @@ class _PKeyInteractionTestsMixin:
         with pytest.raises(ValueError):
             request.sign(pub, GOOD_DIGEST)
 
-    def test_sign_with_unknown_digest(self):
+    def test_sign_with_unknown_digest(self) -> None:
         """
         `X509Req.sign` raises `ValueError` when passed a digest name which is
         not known.
@@ -1627,7 +1627,7 @@ class _PKeyInteractionTestsMixin:
         with pytest.raises(ValueError):
             request.sign(key, BAD_DIGEST)
 
-    def test_sign(self):
+    def test_sign(self) -> None:
         """
         `X509Req.sign` succeeds when passed a private key object and a
         valid digest function. `X509Req.verify` can be used to check
@@ -1660,20 +1660,20 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         """
         return X509Req()
 
-    def test_type(self):
+    def test_type(self) -> None:
         """
         `X509Req` can be used to create instances of that type.
         """
         assert is_consistent_type(X509Req, "X509Req")
 
-    def test_construction(self):
+    def test_construction(self) -> None:
         """
         `X509Req` takes no arguments and returns an `X509Req` instance.
         """
         request = X509Req()
         assert isinstance(request, X509Req)
 
-    def test_version(self):
+    def test_version(self) -> None:
         """
         `X509Req.set_version` sets the X.509 version of the certificate
         request. `X509Req.get_version` returns the X.509 version of the
@@ -1684,7 +1684,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         request.set_version(0)
         assert request.get_version() == 0
 
-    def test_version_wrong_args(self):
+    def test_version_wrong_args(self) -> None:
         """
         `X509Req.set_version` raises `TypeError` if called with a non-`int`
         argument.
@@ -1695,7 +1695,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         with pytest.raises(ValueError):
             request.set_version(2)
 
-    def test_get_subject(self):
+    def test_get_subject(self) -> None:
         """
         `X509Req.get_subject` returns an `X509Name` for the subject of the
         request and which is valid even after the request object is
@@ -1710,7 +1710,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         subject.commonName = "bar"
         assert subject.commonName == "bar"
 
-    def test_add_extensions(self):
+    def test_add_extensions(self) -> None:
         """
         `X509Req.add_extensions` accepts a `list` of `X509Extension` instances
         and adds them to the X509 request.
@@ -1725,7 +1725,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         assert exts[0].get_critical() == 1
         assert exts[0].get_data() == b"0\x00"
 
-    def test_get_extensions(self):
+    def test_get_extensions(self) -> None:
         """
         `X509Req.get_extensions` returns a `list` of extensions added to this
         X509 request.
@@ -1751,7 +1751,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         exts = request.get_extensions()
         assert len(exts) == 2
 
-    def test_undef_oid(self):
+    def test_undef_oid(self) -> None:
         assert (
             X509Extension(
                 b"1.2.3.4.5.6.7", False, b"DER:05:00"
@@ -1759,7 +1759,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
             == b"UNDEF"
         )
 
-    def test_add_extensions_wrong_args(self):
+    def test_add_extensions_wrong_args(self) -> None:
         """
         `X509Req.add_extensions` raises `TypeError` if called with a
         non-`list`.  Or it raises `ValueError` if called with a `list`
@@ -1771,7 +1771,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         with pytest.raises(ValueError):
             request.add_extensions([object()])
 
-    def test_verify_wrong_args(self):
+    def test_verify_wrong_args(self) -> None:
         """
         `X509Req.verify` raises `TypeError` if passed anything other than a
         `PKey` instance as its single argument.
@@ -1780,7 +1780,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         with pytest.raises(TypeError):
             request.verify(object())
 
-    def test_verify_uninitialized_key(self):
+    def test_verify_uninitialized_key(self) -> None:
         """
         `X509Req.verify` raises `OpenSSL.crypto.Error` if called with a
         `OpenSSL.crypto.PKey` which contains no key data.
@@ -1790,7 +1790,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         with pytest.raises(Error):
             request.verify(pkey)
 
-    def test_verify_wrong_key(self):
+    def test_verify_wrong_key(self) -> None:
         """
         `X509Req.verify` raises `OpenSSL.crypto.Error` if called with a
         `OpenSSL.crypto.PKey` which does not represent the public part of the
@@ -1804,7 +1804,7 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         with pytest.raises(Error):
             request.verify(another_pkey)
 
-    def test_verify_success(self):
+    def test_verify_success(self) -> None:
         """
         `X509Req.verify` returns `True` if called with a `OpenSSL.crypto.PKey`
         which represents the public part of the key which signed the request.
@@ -1815,16 +1815,16 @@ class TestX509Req(_PKeyInteractionTestsMixin):
         request.sign(pkey, GOOD_DIGEST)
         assert request.verify(pkey)
 
-    def test_convert_from_cryptography(self):
+    def test_convert_from_cryptography(self) -> None:
         crypto_req = x509.load_pem_x509_csr(cleartextCertificateRequestPEM)
         req = X509Req.from_cryptography(crypto_req)
         assert isinstance(req, X509Req)
 
-    def test_convert_from_cryptography_unsupported_type(self):
+    def test_convert_from_cryptography_unsupported_type(self) -> None:
         with pytest.raises(TypeError):
             X509Req.from_cryptography(object())
 
-    def test_convert_to_cryptography_key(self):
+    def test_convert_to_cryptography_key(self) -> None:
         req = load_certificate_request(
             FILETYPE_PEM, cleartextCertificateRequestPEM
         )
@@ -1850,13 +1850,13 @@ class TestX509(_PKeyInteractionTestsMixin):
         certificate.gmtime_adj_notAfter(24 * 60 * 60)
         return certificate
 
-    def test_type(self):
+    def test_type(self) -> None:
         """
         `X509` can be used to create instances of that type.
         """
         assert is_consistent_type(X509, "X509")
 
-    def test_construction(self):
+    def test_construction(self) -> None:
         """
         `X509` takes no arguments and returns an instance of `X509`.
         """
@@ -1865,7 +1865,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         assert type(certificate).__name__ == "X509"
         assert type(certificate) is X509
 
-    def test_set_version_wrong_args(self):
+    def test_set_version_wrong_args(self) -> None:
         """
         `X509.set_version` raises `TypeError` if invoked with an argument
         not of type `int`.
@@ -1874,7 +1874,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         with pytest.raises(TypeError):
             cert.set_version(None)
 
-    def test_version(self):
+    def test_version(self) -> None:
         """
         `X509.set_version` sets the certificate version number.
         `X509.get_version` retrieves it.
@@ -1883,7 +1883,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         cert.set_version(2)
         assert cert.get_version() == 2
 
-    def test_serial_number(self):
+    def test_serial_number(self) -> None:
         """
         The serial number of an `X509` can be retrieved and
         modified with `X509.get_serial_number` and
@@ -1944,7 +1944,7 @@ class TestX509(_PKeyInteractionTestsMixin):
 
     # XXX ASN1_TIME (not GENERALIZEDTIME)
 
-    def test_set_notBefore(self):
+    def test_set_notBefore(self) -> None:
         """
         `X509.set_notBefore` takes a string in the format of an
         ASN1 GENERALIZEDTIME and sets the beginning of the certificate's
@@ -1952,7 +1952,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         """
         self._setBoundTest("Before")
 
-    def test_set_notAfter(self):
+    def test_set_notAfter(self) -> None:
         """
         `X509.set_notAfter` takes a string in the format of an ASN1
         GENERALIZEDTIME and sets the end of the certificate's validity period
@@ -1960,7 +1960,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         """
         self._setBoundTest("After")
 
-    def test_get_notBefore(self):
+    def test_get_notBefore(self) -> None:
         """
         `X509.get_notBefore` returns a string in the format of an
         ASN1 GENERALIZEDTIME even for certificates which store it as UTCTIME
@@ -1969,7 +1969,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         cert = load_certificate(FILETYPE_PEM, old_root_cert_pem)
         assert cert.get_notBefore() == b"20090325123658Z"
 
-    def test_get_notAfter(self):
+    def test_get_notAfter(self) -> None:
         """
         `X509.get_notAfter` returns a string in the format of an
         ASN1 GENERALIZEDTIME even for certificates which store it as UTCTIME
@@ -1978,7 +1978,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         cert = load_certificate(FILETYPE_PEM, old_root_cert_pem)
         assert cert.get_notAfter() == b"20170611123658Z"
 
-    def test_gmtime_adj_notBefore_wrong_args(self):
+    def test_gmtime_adj_notBefore_wrong_args(self) -> None:
         """
         `X509.gmtime_adj_notBefore` raises `TypeError` if called with a
         non-`int` argument.
@@ -1988,7 +1988,7 @@ class TestX509(_PKeyInteractionTestsMixin):
             cert.gmtime_adj_notBefore(None)
 
     @pytest.mark.flaky(reruns=2)
-    def test_gmtime_adj_notBefore(self):
+    def test_gmtime_adj_notBefore(self) -> None:
         """
         `X509.gmtime_adj_notBefore` changes the not-before timestamp to be the
         current time plus the number of seconds passed in.
@@ -2004,7 +2004,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         not_before_max = utcnow() + timedelta(seconds=100)
         assert not_before_min <= not_before <= not_before_max
 
-    def test_gmtime_adj_notAfter_wrong_args(self):
+    def test_gmtime_adj_notAfter_wrong_args(self) -> None:
         """
         `X509.gmtime_adj_notAfter` raises `TypeError` if called with a
         non-`int` argument.
@@ -2014,7 +2014,7 @@ class TestX509(_PKeyInteractionTestsMixin):
             cert.gmtime_adj_notAfter(None)
 
     @pytest.mark.flaky(reruns=2)
-    def test_gmtime_adj_notAfter(self):
+    def test_gmtime_adj_notAfter(self) -> None:
         """
         `X509.gmtime_adj_notAfter` changes the not-after timestamp
         to be the current time plus the number of seconds passed in.
@@ -2030,7 +2030,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         not_after_max = utcnow() + timedelta(seconds=100)
         assert not_after_min <= not_after <= not_after_max
 
-    def test_has_expired(self):
+    def test_has_expired(self) -> None:
         """
         `X509.has_expired` returns `True` if the certificate's not-after time
         is in the past.
@@ -2039,7 +2039,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         cert.gmtime_adj_notAfter(-1)
         assert cert.has_expired()
 
-    def test_has_not_expired(self):
+    def test_has_not_expired(self) -> None:
         """
         `X509.has_expired` returns `False` if the certificate's not-after time
         is in the future.
@@ -2048,7 +2048,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         cert.gmtime_adj_notAfter(2)
         assert not cert.has_expired()
 
-    def test_has_expired_exception(self):
+    def test_has_expired_exception(self) -> None:
         """
         `X509.has_expired` throws ValueError if not-after time is not set
         """
@@ -2056,7 +2056,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         with pytest.raises(ValueError):
             cert.has_expired()
 
-    def test_root_has_not_expired(self):
+    def test_root_has_not_expired(self) -> None:
         """
         `X509.has_expired` returns `False` if the certificate's not-after time
         is in the future.
@@ -2064,7 +2064,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         cert = load_certificate(FILETYPE_PEM, root_cert_pem)
         assert not cert.has_expired()
 
-    def test_digest(self):
+    def test_digest(self) -> None:
         """
         `X509.digest` returns a string giving ":"-separated hex-encoded
         words of the digest of the certificate.
@@ -2099,7 +2099,7 @@ class TestX509(_PKeyInteractionTestsMixin):
 
         return X509.from_cryptography(builder.sign(key, hashes.SHA256()))
 
-    def test_extension_count(self):
+    def test_extension_count(self) -> None:
         """
         `X509.get_extension_count` returns the number of extensions
         that are present in the certificate.
@@ -2133,7 +2133,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         c = self._extcert(pkey, [ca, key, san])
         assert c.get_extension_count() == 3
 
-    def test_get_extension(self):
+    def test_get_extension(self) -> None:
         """
         `X509.get_extension` takes an integer and returns an
         `X509Extension` corresponding to the extension at that index.
@@ -2179,7 +2179,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         with pytest.raises(TypeError):
             cert.get_extension("hello")
 
-    def test_nullbyte_subjectAltName(self):
+    def test_nullbyte_subjectAltName(self) -> None:
         """
         The fields of a `subjectAltName` extension on an X509 may contain NUL
         bytes and this value is reflected in the string representation of the
@@ -2197,7 +2197,7 @@ class TestX509(_PKeyInteractionTestsMixin):
             == str(ext).encode("ascii").strip()
         )
 
-    def test_invalid_digest_algorithm(self):
+    def test_invalid_digest_algorithm(self) -> None:
         """
         `X509.digest` raises `ValueError` if called with an unrecognized hash
         algorithm.
@@ -2206,7 +2206,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         with pytest.raises(ValueError):
             cert.digest(BAD_DIGEST)
 
-    def test_get_subject(self):
+    def test_get_subject(self) -> None:
         """
         `X509.get_subject` returns an `X509Name` instance.
         """
@@ -2221,7 +2221,7 @@ class TestX509(_PKeyInteractionTestsMixin):
             (b"CN", b"Testing Root CA"),
         ]
 
-    def test_set_subject_wrong_args(self):
+    def test_set_subject_wrong_args(self) -> None:
         """
         `X509.set_subject` raises a `TypeError` if called with an argument not
         of type `X509Name`.
@@ -2230,7 +2230,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         with pytest.raises(TypeError):
             cert.set_subject(None)
 
-    def test_set_subject(self):
+    def test_set_subject(self) -> None:
         """
         `X509.set_subject` changes the subject of the certificate to the one
         passed in.
@@ -2245,7 +2245,7 @@ class TestX509(_PKeyInteractionTestsMixin):
             (b"OU", b"Unit Tests"),
         ]
 
-    def test_get_issuer(self):
+    def test_get_issuer(self) -> None:
         """
         `X509.get_issuer` returns an `X509Name` instance.
         """
@@ -2261,7 +2261,7 @@ class TestX509(_PKeyInteractionTestsMixin):
             (b"CN", b"Testing Root CA"),
         ]
 
-    def test_set_issuer_wrong_args(self):
+    def test_set_issuer_wrong_args(self) -> None:
         """
         `X509.set_issuer` raises a `TypeError` if called with an argument not
         of type `X509Name`.
@@ -2270,7 +2270,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         with pytest.raises(TypeError):
             cert.set_issuer(None)
 
-    def test_set_issuer(self):
+    def test_set_issuer(self) -> None:
         """
         `X509.set_issuer` changes the issuer of the certificate to the
         one passed in.
@@ -2285,7 +2285,7 @@ class TestX509(_PKeyInteractionTestsMixin):
             (b"OU", b"Unit Tests"),
         ]
 
-    def test_get_pubkey_uninitialized(self):
+    def test_get_pubkey_uninitialized(self) -> None:
         """
         When called on a certificate with no public key, `X509.get_pubkey`
         raises `OpenSSL.crypto.Error`.
@@ -2294,7 +2294,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         with pytest.raises(Error):
             cert.get_pubkey()
 
-    def test_set_pubkey_wrong_type(self):
+    def test_set_pubkey_wrong_type(self) -> None:
         """
         `X509.set_pubkey` raises `TypeError` when given an object of the
         wrong type.
@@ -2303,7 +2303,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         with pytest.raises(TypeError):
             cert.set_pubkey(object())
 
-    def test_subject_name_hash(self):
+    def test_subject_name_hash(self) -> None:
         """
         `X509.subject_name_hash` returns the hash of the certificate's
         subject name.
@@ -2312,7 +2312,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         # SHA1
         assert cert.subject_name_hash() == 3278919224
 
-    def test_get_signature_algorithm(self):
+    def test_get_signature_algorithm(self) -> None:
         """
         `X509.get_signature_algorithm` returns a string which means
         the algorithm used to sign the certificate.
@@ -2320,7 +2320,7 @@ class TestX509(_PKeyInteractionTestsMixin):
         cert = load_certificate(FILETYPE_PEM, self.pemData)
         assert b"sha256WithRSAEncryption" == cert.get_signature_algorithm()
 
-    def test_get_undefined_signature_algorithm(self):
+    def test_get_undefined_signature_algorithm(self) -> None:
         """
         `X509.get_signature_algorithm` raises `ValueError` if the signature
         algorithm is undefined or unknown.
@@ -2352,7 +2352,7 @@ tgI5
         with pytest.raises(ValueError):
             cert.get_signature_algorithm()
 
-    def test_sign_bad_pubkey_type(self):
+    def test_sign_bad_pubkey_type(self) -> None:
         """
         `X509.sign` raises `TypeError` when called with the wrong type.
         """
@@ -2360,18 +2360,18 @@ tgI5
         with pytest.raises(TypeError):
             cert.sign(object(), b"sha256")
 
-    def test_convert_from_cryptography(self):
+    def test_convert_from_cryptography(self) -> None:
         crypto_cert = x509.load_pem_x509_certificate(intermediate_cert_pem)
         cert = X509.from_cryptography(crypto_cert)
 
         assert isinstance(cert, X509)
         assert cert.get_version() == crypto_cert.version.value
 
-    def test_convert_from_cryptography_unsupported_type(self):
+    def test_convert_from_cryptography_unsupported_type(self) -> None:
         with pytest.raises(TypeError):
             X509.from_cryptography(object())
 
-    def test_convert_to_cryptography_key(self):
+    def test_convert_to_cryptography_key(self) -> None:
         cert = load_certificate(FILETYPE_PEM, intermediate_cert_pem)
         crypto_cert = cert.to_cryptography()
 
@@ -2384,13 +2384,13 @@ class TestX509Store:
     Test for `OpenSSL.crypto.X509Store`.
     """
 
-    def test_type(self):
+    def test_type(self) -> None:
         """
         `X509Store` is a type object.
         """
         assert is_consistent_type(X509Store, "X509Store")
 
-    def test_add_cert(self):
+    def test_add_cert(self) -> None:
         """
         `X509Store.add_cert` adds a `X509` instance to the certificate store.
         """
@@ -2399,7 +2399,7 @@ class TestX509Store:
         store.add_cert(cert)
 
     @pytest.mark.parametrize("cert", [None, 1.0, "cert", object()])
-    def test_add_cert_wrong_args(self, cert):
+    def test_add_cert_wrong_args(self, cert) -> None:
         """
         `X509Store.add_cert` raises `TypeError` if passed a non-X509 object
         as its first argument.
@@ -2408,7 +2408,7 @@ class TestX509Store:
         with pytest.raises(TypeError):
             store.add_cert(cert)
 
-    def test_add_cert_accepts_duplicate(self):
+    def test_add_cert_accepts_duplicate(self) -> None:
         """
         `X509Store.add_cert` doesn't raise `OpenSSL.crypto.Error` if an attempt
         is made to add the same certificate to the store more than once.
@@ -2467,12 +2467,12 @@ class TestX509Store:
         assert call_cafile == lib_mock.cafile
         assert call_capath == lib_mock.capath
 
-    def test_load_locations_fails_when_all_args_are_none(self):
+    def test_load_locations_fails_when_all_args_are_none(self) -> None:
         store = X509Store()
         with pytest.raises(Error):
             store.load_locations(None, None)
 
-    def test_load_locations_raises_error_on_failure(self, tmpdir):
+    def test_load_locations_raises_error_on_failure(self, tmpdir) -> None:
         invalid_ca_file = tmpdir.join("invalid.pem")
         invalid_ca_file.write("This is not a certificate")
 
@@ -2500,7 +2500,7 @@ class TestLoadPublicKey:
     Tests for :func:`load_publickey`.
     """
 
-    def test_loading_works(self):
+    def test_loading_works(self) -> None:
         """
         load_publickey loads public keys and sets correct attributes.
         """
@@ -2510,21 +2510,21 @@ class TestLoadPublicKey:
         assert 2048 == key.bits()
         assert TYPE_RSA == key.type()
 
-    def test_invalid_type(self):
+    def test_invalid_type(self) -> None:
         """
         load_publickey doesn't support FILETYPE_TEXT.
         """
         with pytest.raises(ValueError):
             load_publickey(FILETYPE_TEXT, cleartextPublicKeyPEM)
 
-    def test_invalid_key_format(self):
+    def test_invalid_key_format(self) -> None:
         """
         load_publickey explodes on incorrect keys.
         """
         with pytest.raises(Error):
             load_publickey(FILETYPE_ASN1, cleartextPublicKeyPEM)
 
-    def test_tolerates_unicode_strings(self):
+    def test_tolerates_unicode_strings(self) -> None:
         """
         load_publickey works with text strings, not just bytes.
         """
@@ -2540,14 +2540,14 @@ class TestFunction:
     Tests for free-functions in the `OpenSSL.crypto` module.
     """
 
-    def test_load_privatekey_invalid_format(self):
+    def test_load_privatekey_invalid_format(self) -> None:
         """
         `load_privatekey` raises `ValueError` if passed an unknown filetype.
         """
         with pytest.raises(ValueError):
             load_privatekey(100, root_key_pem)
 
-    def test_load_privatekey_invalid_passphrase_type(self):
+    def test_load_privatekey_invalid_passphrase_type(self) -> None:
         """
         `load_privatekey` raises `TypeError` if passed a passphrase that is
         neither a `str` nor a callable.
@@ -2557,7 +2557,7 @@ class TestFunction:
                 FILETYPE_PEM, encryptedPrivateKeyPEMPassphrase, object()
             )
 
-    def test_load_privatekey_wrongPassphrase(self):
+    def test_load_privatekey_wrongPassphrase(self) -> None:
         """
         `load_privatekey` raises `OpenSSL.crypto.Error` when it is passed an
         encrypted PEM and an incorrect passphrase.
@@ -2566,7 +2566,7 @@ class TestFunction:
             load_privatekey(FILETYPE_PEM, encryptedPrivateKeyPEM, b"quack")
         assert err.value.args[0] != []
 
-    def test_load_privatekey_passphraseWrongType(self):
+    def test_load_privatekey_passphraseWrongType(self) -> None:
         """
         `load_privatekey` raises `ValueError` when it is passeda passphrase
         with a private key encoded in a format, that doesn't support
@@ -2577,7 +2577,7 @@ class TestFunction:
         with pytest.raises(ValueError):
             load_privatekey(FILETYPE_ASN1, blob, "secret")
 
-    def test_load_privatekey_passphrase(self):
+    def test_load_privatekey_passphrase(self) -> None:
         """
         `load_privatekey` can create a `PKey` object from an encrypted PEM
         string if given the passphrase.
@@ -2589,7 +2589,7 @@ class TestFunction:
         )
         assert isinstance(key, PKey)
 
-    def test_load_privatekey_passphrase_exception(self):
+    def test_load_privatekey_passphrase_exception(self) -> None:
         """
         If the passphrase callback raises an exception, that exception is
         raised by `load_privatekey`.
@@ -2601,7 +2601,7 @@ class TestFunction:
         with pytest.raises(ArithmeticError):
             load_privatekey(FILETYPE_PEM, encryptedPrivateKeyPEM, cb)
 
-    def test_load_privatekey_wrongPassphraseCallback(self):
+    def test_load_privatekey_wrongPassphraseCallback(self) -> None:
         """
         `load_privatekey` raises `OpenSSL.crypto.Error` when it
         is passed an encrypted PEM and a passphrase callback which returns an
@@ -2618,7 +2618,7 @@ class TestFunction:
         assert called
         assert err.value.args[0] != []
 
-    def test_load_privatekey_passphraseCallback(self):
+    def test_load_privatekey_passphraseCallback(self) -> None:
         """
         `load_privatekey` can create a `PKey` object from an encrypted PEM
         string if given a passphrase callback which returns the correct
@@ -2634,7 +2634,7 @@ class TestFunction:
         assert isinstance(key, PKey)
         assert called == [False]
 
-    def test_load_privatekey_passphrase_wrong_return_type(self):
+    def test_load_privatekey_passphrase_wrong_return_type(self) -> None:
         """
         `load_privatekey` raises `ValueError` if the passphrase callback
         returns something other than a byte string.
@@ -2644,7 +2644,7 @@ class TestFunction:
                 FILETYPE_PEM, encryptedPrivateKeyPEM, lambda *args: 3
             )
 
-    def test_dump_privatekey_wrong_args(self):
+    def test_dump_privatekey_wrong_args(self) -> None:
         """
         `dump_privatekey` raises `TypeError` if called with a `cipher`
         argument but no `passphrase` argument.
@@ -2654,7 +2654,7 @@ class TestFunction:
         with pytest.raises(TypeError):
             dump_privatekey(FILETYPE_PEM, key, cipher=GOOD_CIPHER)
 
-    def test_dump_privatekey_not_rsa_key(self):
+    def test_dump_privatekey_not_rsa_key(self) -> None:
         """
         `dump_privatekey` raises `TypeError` if called with a key that is
         not RSA.
@@ -2664,11 +2664,11 @@ class TestFunction:
         with pytest.raises(TypeError):
             dump_privatekey(FILETYPE_TEXT, key)
 
-    def test_dump_privatekey_invalid_pkey(self):
+    def test_dump_privatekey_invalid_pkey(self) -> None:
         with pytest.raises(TypeError):
             dump_privatekey(FILETYPE_TEXT, object())
 
-    def test_dump_privatekey_unknown_cipher(self):
+    def test_dump_privatekey_unknown_cipher(self) -> None:
         """
         `dump_privatekey` raises `ValueError` if called with an unrecognized
         cipher name.
@@ -2678,7 +2678,7 @@ class TestFunction:
         with pytest.raises(ValueError):
             dump_privatekey(FILETYPE_PEM, key, BAD_CIPHER, "passphrase")
 
-    def test_dump_privatekey_invalid_passphrase_type(self):
+    def test_dump_privatekey_invalid_passphrase_type(self) -> None:
         """
         `dump_privatekey` raises `TypeError` if called with a passphrase which
         is neither a `str` nor a callable.
@@ -2688,7 +2688,7 @@ class TestFunction:
         with pytest.raises(TypeError):
             dump_privatekey(FILETYPE_PEM, key, GOOD_CIPHER, object())
 
-    def test_dump_privatekey_invalid_filetype(self):
+    def test_dump_privatekey_invalid_filetype(self) -> None:
         """
         `dump_privatekey` raises `ValueError` if called with an unrecognized
         filetype.
@@ -2698,7 +2698,7 @@ class TestFunction:
         with pytest.raises(ValueError):
             dump_privatekey(100, key)
 
-    def test_load_privatekey_passphrase_callback_length(self):
+    def test_load_privatekey_passphrase_callback_length(self) -> None:
         """
         `crypto.load_privatekey` should raise an error when the passphrase
         provided by the callback is too long, not silently truncate it.
@@ -2710,7 +2710,7 @@ class TestFunction:
         with pytest.raises(ValueError):
             load_privatekey(FILETYPE_PEM, encryptedPrivateKeyPEM, cb)
 
-    def test_dump_privatekey_passphrase(self):
+    def test_dump_privatekey_passphrase(self) -> None:
         """
         `dump_privatekey` writes an encrypted PEM when given a passphrase.
         """
@@ -2723,7 +2723,7 @@ class TestFunction:
         assert loadedKey.type() == key.type()
         assert loadedKey.bits() == key.bits()
 
-    def test_dump_privatekey_passphrase_wrong_type(self):
+    def test_dump_privatekey_passphrase_wrong_type(self) -> None:
         """
         `dump_privatekey` raises `ValueError` when it is passed a passphrase
         with a private key encoded in a format, that doesn't support
@@ -2733,7 +2733,7 @@ class TestFunction:
         with pytest.raises(ValueError):
             dump_privatekey(FILETYPE_ASN1, key, GOOD_CIPHER, "secret")
 
-    def test_dump_certificate(self):
+    def test_dump_certificate(self) -> None:
         """
         `dump_certificate` writes PEM, DER, and text.
         """
@@ -2750,7 +2750,7 @@ class TestFunction:
         dumped_text = dump_certificate(FILETYPE_TEXT, cert)
         assert len(dumped_text) > 500
 
-    def test_dump_certificate_bad_type(self):
+    def test_dump_certificate_bad_type(self) -> None:
         """
         `dump_certificate` raises a `ValueError` if it's called with
         a bad type.
@@ -2759,7 +2759,7 @@ class TestFunction:
         with pytest.raises(ValueError):
             dump_certificate(object(), cert)
 
-    def test_dump_privatekey_pem(self):
+    def test_dump_privatekey_pem(self) -> None:
         """
         `dump_privatekey` writes a PEM
         """
@@ -2768,7 +2768,7 @@ class TestFunction:
         dumped_pem = dump_privatekey(FILETYPE_PEM, key)
         assert dumped_pem == normalized_root_key_pem
 
-    def test_dump_privatekey_asn1(self):
+    def test_dump_privatekey_asn1(self) -> None:
         """
         `dump_privatekey` writes a DER
         """
@@ -2777,7 +2777,7 @@ class TestFunction:
         dumped_der = dump_privatekey(FILETYPE_ASN1, key)
         assert dumped_der == root_key_der
 
-    def test_load_privatekey_asn1(self):
+    def test_load_privatekey_asn1(self) -> None:
         """
         `dump_privatekey` writes a DER
         """
@@ -2785,7 +2785,7 @@ class TestFunction:
         assert key.bits() == 3072
         assert key.type() == TYPE_RSA
 
-    def test_dump_privatekey_text(self):
+    def test_dump_privatekey_text(self) -> None:
         """
         `dump_privatekey` writes a text
         """
@@ -2793,7 +2793,7 @@ class TestFunction:
         dumped_text = dump_privatekey(FILETYPE_TEXT, key)
         assert len(dumped_text) > 500
 
-    def test_dump_publickey_pem(self):
+    def test_dump_publickey_pem(self) -> None:
         """
         dump_publickey writes a PEM.
         """
@@ -2801,7 +2801,7 @@ class TestFunction:
         dumped_pem = dump_publickey(FILETYPE_PEM, key)
         assert dumped_pem == cleartextPublicKeyPEM
 
-    def test_dump_publickey_asn1(self):
+    def test_dump_publickey_asn1(self) -> None:
         """
         dump_publickey writes a DER.
         """
@@ -2811,7 +2811,7 @@ class TestFunction:
         dumped_pem2 = dump_publickey(FILETYPE_PEM, key2)
         assert dumped_pem2 == cleartextPublicKeyPEM
 
-    def test_dump_publickey_invalid_type(self):
+    def test_dump_publickey_invalid_type(self) -> None:
         """
         dump_publickey doesn't support FILETYPE_TEXT.
         """
@@ -2820,7 +2820,7 @@ class TestFunction:
         with pytest.raises(ValueError):
             dump_publickey(FILETYPE_TEXT, key)
 
-    def test_dump_certificate_request(self):
+    def test_dump_certificate_request(self) -> None:
         """
         `dump_certificate_request` writes a PEM, DER, and text.
         """
@@ -2840,7 +2840,7 @@ class TestFunction:
         with pytest.raises(ValueError):
             dump_certificate_request(100, req)
 
-    def test_dump_privatekey_passphrase_callback(self):
+    def test_dump_privatekey_passphrase_callback(self) -> None:
         """
         `dump_privatekey` writes an encrypted PEM when given a callback
         which returns the correct passphrase.
@@ -2861,7 +2861,7 @@ class TestFunction:
         assert loadedKey.type() == key.type()
         assert loadedKey.bits() == key.bits()
 
-    def test_dump_privatekey_passphrase_exception(self):
+    def test_dump_privatekey_passphrase_exception(self) -> None:
         """
         `dump_privatekey` should not overwrite the exception raised
         by the passphrase callback.
@@ -2874,7 +2874,7 @@ class TestFunction:
         with pytest.raises(ArithmeticError):
             dump_privatekey(FILETYPE_PEM, key, GOOD_CIPHER, cb)
 
-    def test_dump_privatekey_passphraseCallbackLength(self):
+    def test_dump_privatekey_passphraseCallbackLength(self) -> None:
         """
         `crypto.dump_privatekey` should raise an error when the passphrase
         provided by the callback is too long, not silently truncate it.
@@ -2887,7 +2887,7 @@ class TestFunction:
         with pytest.raises(ValueError):
             dump_privatekey(FILETYPE_PEM, key, GOOD_CIPHER, cb)
 
-    def test_dump_privatekey_truncated(self):
+    def test_dump_privatekey_truncated(self) -> None:
         """
         `crypto.dump_privatekey` should not truncate a passphrase that contains
         a null byte.
@@ -2907,7 +2907,7 @@ class TestFunction:
                 FILETYPE_PEM, encrypted_key_pem, truncated_passphrase
             )
 
-    def test_load_privatekey_truncated(self):
+    def test_load_privatekey_truncated(self) -> None:
         """
         `crypto.load_privatekey` should not truncate a passphrase that contains
         a null byte.
@@ -2931,7 +2931,7 @@ class TestLoadCertificate:
     Tests for `load_certificate_request`.
     """
 
-    def test_bad_file_type(self):
+    def test_bad_file_type(self) -> None:
         """
         If the file type passed to `load_certificate_request` is neither
         `FILETYPE_PEM` nor `FILETYPE_ASN1` then `ValueError` is raised.
@@ -2941,7 +2941,7 @@ class TestLoadCertificate:
         with pytest.raises(ValueError):
             load_certificate(object(), b"")
 
-    def test_bad_certificate(self):
+    def test_bad_certificate(self) -> None:
         """
         If the bytes passed to `load_certificate` are not a valid certificate,
         an exception is raised.
@@ -3004,7 +3004,7 @@ class TestCRL:
         )
         return crl
 
-    def test_verify_with_revoked(self):
+    def test_verify_with_revoked(self) -> None:
         """
         `verify_certificate` raises error when an intermediate certificate is
         revoked.
@@ -3028,7 +3028,7 @@ class TestCRL:
             store_ctx.verify_certificate()
         assert str(err.value) == "certificate revoked"
 
-    def test_verify_with_missing_crl(self):
+    def test_verify_with_missing_crl(self) -> None:
         """
         `verify_certificate` raises error when an intermediate certificate's
         CRL is missing.
@@ -3061,7 +3061,7 @@ class TestX509StoreContext:
         FILETYPE_PEM, intermediate_server_cert_pem
     )
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         """
         `verify_certificate` returns ``None`` when called with a certificate
         and valid chain.
@@ -3072,7 +3072,7 @@ class TestX509StoreContext:
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         assert store_ctx.verify_certificate() is None
 
-    def test_reuse(self):
+    def test_reuse(self) -> None:
         """
         `verify_certificate` can be called multiple times with the same
         ``X509StoreContext`` instance to produce the same result.
@@ -3107,13 +3107,15 @@ class TestX509StoreContext:
             ),
         ],
     )
-    def test_verify_success_with_chain(self, root_cert, chain, verified_cert):
+    def test_verify_success_with_chain(
+        self, root_cert, chain, verified_cert
+    ) -> None:
         store = X509Store()
         store.add_cert(root_cert)
         store_ctx = X509StoreContext(store, verified_cert, chain=chain)
         assert store_ctx.verify_certificate() is None
 
-    def test_valid_untrusted_chain_reuse(self):
+    def test_valid_untrusted_chain_reuse(self) -> None:
         """
         `verify_certificate` using an untrusted chain can be called multiple
         times with the same ``X509StoreContext`` instance to produce the same
@@ -3129,7 +3131,7 @@ class TestX509StoreContext:
         assert store_ctx.verify_certificate() is None
         assert store_ctx.verify_certificate() is None
 
-    def test_chain_reference(self):
+    def test_chain_reference(self) -> None:
         """
         ``X509StoreContext`` properly keeps references to the untrusted chain
         certificates.
@@ -3174,7 +3176,9 @@ class TestX509StoreContext:
             ),
         ],
     )
-    def test_verify_fail_with_chain(self, root_cert, chain, verified_cert):
+    def test_verify_fail_with_chain(
+        self, root_cert, chain, verified_cert
+    ) -> None:
         store = X509Store()
         if root_cert:
             store.add_cert(root_cert)
@@ -3199,7 +3203,7 @@ class TestX509StoreContext:
             ),
         ],
     )
-    def test_untrusted_chain_wrong_args(self, chain, expected_error):
+    def test_untrusted_chain_wrong_args(self, chain, expected_error) -> None:
         """
         Creating ``X509StoreContext`` with wrong chain raises an exception.
         """
@@ -3209,7 +3213,9 @@ class TestX509StoreContext:
         with pytest.raises(expected_error):
             X509StoreContext(store, self.intermediate_server_cert, chain=chain)
 
-    def test_failure_building_untrusted_chain_raises(self, monkeypatch):
+    def test_failure_building_untrusted_chain_raises(
+        self, monkeypatch
+    ) -> None:
         """
         Creating ``X509StoreContext`` raises ``OpenSSL.crypto.Error`` when
         the underlying lib fails to add the certificate to the stack.
@@ -3223,7 +3229,7 @@ class TestX509StoreContext:
         with pytest.raises(Error):
             X509StoreContext(store, self.intermediate_server_cert, chain=chain)
 
-    def test_trusted_self_signed(self):
+    def test_trusted_self_signed(self) -> None:
         """
         `verify_certificate` returns ``None`` when called with a self-signed
         certificate and itself in the chain.
@@ -3233,7 +3239,7 @@ class TestX509StoreContext:
         store_ctx = X509StoreContext(store, self.root_cert)
         assert store_ctx.verify_certificate() is None
 
-    def test_untrusted_self_signed(self):
+    def test_untrusted_self_signed(self) -> None:
         """
         `verify_certificate` raises error when a self-signed certificate is
         verified without itself in the chain.
@@ -3250,7 +3256,7 @@ class TestX509StoreContext:
         ]
         assert exc.value.certificate.get_subject().CN == "Testing Root CA"
 
-    def test_invalid_chain_no_root(self):
+    def test_invalid_chain_no_root(self) -> None:
         """
         `verify_certificate` raises error when a root certificate is missing
         from the chain.
@@ -3265,7 +3271,7 @@ class TestX509StoreContext:
         assert str(exc.value) == "unable to get issuer certificate"
         assert exc.value.certificate.get_subject().CN == "intermediate"
 
-    def test_invalid_chain_no_intermediate(self):
+    def test_invalid_chain_no_intermediate(self) -> None:
         """
         `verify_certificate` raises error when an intermediate certificate is
         missing from the chain.
@@ -3280,7 +3286,7 @@ class TestX509StoreContext:
         assert str(exc.value) == "unable to get local issuer certificate"
         assert exc.value.certificate.get_subject().CN == "intermediate-service"
 
-    def test_modification_pre_verify(self):
+    def test_modification_pre_verify(self) -> None:
         """
         `verify_certificate` can use a store context modified after
         instantiation.
@@ -3301,7 +3307,7 @@ class TestX509StoreContext:
         store_ctx.set_store(store_good)
         assert store_ctx.verify_certificate() is None
 
-    def test_verify_with_time(self):
+    def test_verify_with_time(self) -> None:
         """
         `verify_certificate` raises error when the verification time is
         set at notAfter.
@@ -3322,7 +3328,7 @@ class TestX509StoreContext:
 
         assert str(exc.value) == "certificate has expired"
 
-    def test_get_verified_chain(self):
+    def test_get_verified_chain(self) -> None:
         """
         `get_verified_chain` returns the verified chain.
         """
@@ -3343,7 +3349,7 @@ class TestX509StoreContext:
         assert chain[1].get_subject() == self.intermediate_cert.get_subject()
         assert chain[2].get_subject() == self.root_cert.get_subject()
 
-    def test_get_verified_chain_invalid_chain_no_root(self):
+    def test_get_verified_chain_invalid_chain_no_root(self) -> None:
         """
         `get_verified_chain` raises error when cert verification fails.
         """
@@ -3376,14 +3382,14 @@ class TestX509StoreContext:
         )
         return cafile
 
-    def test_verify_with_ca_file_location(self, root_ca_file):
+    def test_verify_with_ca_file_location(self, root_ca_file) -> None:
         store = X509Store()
         store.load_locations(str(root_ca_file))
 
         store_ctx = X509StoreContext(store, self.intermediate_cert)
         store_ctx.verify_certificate()
 
-    def test_verify_with_ca_path_location(self, root_ca_file):
+    def test_verify_with_ca_path_location(self, root_ca_file) -> None:
         store = X509Store()
         store.load_locations(None, str(root_ca_file.dirname))
 
@@ -3411,7 +3417,7 @@ class TestX509StoreContext:
         store_ctx = X509StoreContext(store, self.intermediate_server_cert)
         store_ctx.verify_certificate()
 
-    def test_verify_failure_with_empty_ca_directory(self, tmpdir):
+    def test_verify_failure_with_empty_ca_directory(self, tmpdir) -> None:
         store = X509Store()
         store.load_locations(None, str(tmpdir))
 
@@ -3421,7 +3427,7 @@ class TestX509StoreContext:
 
         assert str(exc.value) == "unable to get local issuer certificate"
 
-    def test_verify_with_partial_chain(self):
+    def test_verify_with_partial_chain(self) -> None:
         store = X509Store()
         store.add_cert(self.intermediate_cert)
 
@@ -3441,13 +3447,13 @@ class TestEllipticCurve:
     `get_elliptic_curves`.
     """
 
-    def test_set(self):
+    def test_set(self) -> None:
         """
         `get_elliptic_curves` returns a `set`.
         """
         assert isinstance(get_elliptic_curves(), set)
 
-    def test_a_curve(self):
+    def test_a_curve(self) -> None:
         """
         `get_elliptic_curve` can be used to retrieve a particular supported
         curve.
@@ -3456,7 +3462,7 @@ class TestEllipticCurve:
         curve = next(iter(curves))
         assert curve.name == get_elliptic_curve(curve.name).name
 
-    def test_not_a_curve(self):
+    def test_not_a_curve(self) -> None:
         """
         `get_elliptic_curve` raises `ValueError` if called with a name which
         does not identify a supported curve.
@@ -3464,7 +3470,7 @@ class TestEllipticCurve:
         with pytest.raises(ValueError):
             get_elliptic_curve("this curve was just invented")
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         """
         The string representation of a curve object includes simply states the
         object is a curve and what its name is.
@@ -3473,7 +3479,7 @@ class TestEllipticCurve:
         curve = next(iter(curves))
         assert f"<Curve {curve.name!r}>" == repr(curve)
 
-    def test_to_EC_KEY(self):
+    def test_to_EC_KEY(self) -> None:
         """
         The curve object can export a version of itself as an EC_KEY* via the
         private `_EllipticCurve._to_EC_KEY`.
@@ -3526,7 +3532,7 @@ class TestEllipticCurveHash:
 
     curve_factory = EllipticCurveFactory()
 
-    def test_contains(self):
+    def test_contains(self) -> None:
         """
         The ``in`` operator reports that a `set` containing a curve does
         contain that curve.
@@ -3535,7 +3541,7 @@ class TestEllipticCurveHash:
         curves = set([curve])
         assert curve in curves
 
-    def test_does_not_contain(self):
+    def test_does_not_contain(self) -> None:
         """
         The ``in`` operator reports that a `set` not containing a curve
         does not contain that curve.

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -426,14 +426,14 @@ class TestVersion:
     `OpenSSL.SSL.OPENSSL_VERSION_NUMBER`.
     """
 
-    def test_OPENSSL_VERSION_NUMBER(self):
+    def test_OPENSSL_VERSION_NUMBER(self) -> None:
         """
         `OPENSSL_VERSION_NUMBER` is an integer with status in the low byte and
         the patch, fix, minor, and major versions in the nibbles above that.
         """
         assert isinstance(OPENSSL_VERSION_NUMBER, int)
 
-    def test_SSLeay_version(self):
+    def test_SSLeay_version(self) -> None:
         """
         `SSLeay_version` takes a version type indicator and returns one of a
         number of version strings based on that indicator.
@@ -506,7 +506,7 @@ class TestContext:
         "cipher_string",
         [b"hello world:AES128-SHA", "hello world:AES128-SHA"],
     )
-    def test_set_cipher_list(self, context, cipher_string):
+    def test_set_cipher_list(self, context, cipher_string) -> None:
         """
         `Context.set_cipher_list` accepts both byte and unicode strings
         for naming the ciphers which connections created with the context
@@ -517,7 +517,7 @@ class TestContext:
 
         assert "AES128-SHA" in conn.get_cipher_list()
 
-    def test_set_cipher_list_wrong_type(self, context):
+    def test_set_cipher_list_wrong_type(self, context) -> None:
         """
         `Context.set_cipher_list` raises `TypeError` when passed a non-string
         argument.
@@ -526,7 +526,7 @@ class TestContext:
             context.set_cipher_list(object())
 
     @pytest.mark.flaky(reruns=2)
-    def test_set_cipher_list_no_cipher_match(self, context):
+    def test_set_cipher_list_no_cipher_match(self, context) -> None:
         """
         `Context.set_cipher_list` raises `OpenSSL.SSL.Error` with a
         `"no cipher match"` reason string regardless of the TLS
@@ -549,13 +549,13 @@ class TestContext:
             ),
         ]
 
-    def test_load_client_ca(self, context, ca_file):
+    def test_load_client_ca(self, context, ca_file) -> None:
         """
         `Context.load_client_ca` works as far as we can tell.
         """
         context.load_client_ca(ca_file)
 
-    def test_load_client_ca_invalid(self, context, tmpdir):
+    def test_load_client_ca_invalid(self, context, tmpdir) -> None:
         """
         `Context.load_client_ca` raises an Error if the ca file is invalid.
         """
@@ -567,19 +567,19 @@ class TestContext:
 
         assert "PEM routines" == e.value.args[0][0][0]
 
-    def test_load_client_ca_unicode(self, context, ca_file):
+    def test_load_client_ca_unicode(self, context, ca_file) -> None:
         """
         Passing the path as unicode raises a warning but works.
         """
         pytest.deprecated_call(context.load_client_ca, ca_file.decode("ascii"))
 
-    def test_set_session_id(self, context):
+    def test_set_session_id(self, context) -> None:
         """
         `Context.set_session_id` works as far as we can tell.
         """
         context.set_session_id(b"abc")
 
-    def test_set_session_id_fail(self, context):
+    def test_set_session_id_fail(self, context) -> None:
         """
         `Context.set_session_id` errors are propagated.
         """
@@ -601,14 +601,14 @@ class TestContext:
             ),
         ]
 
-    def test_set_session_id_unicode(self, context):
+    def test_set_session_id_unicode(self, context) -> None:
         """
         `Context.set_session_id` raises a warning if a unicode string is
         passed.
         """
         pytest.deprecated_call(context.set_session_id, "abc")
 
-    def test_method(self):
+    def test_method(self) -> None:
         """
         `Context` can be instantiated with one of `SSLv2_METHOD`,
         `SSLv3_METHOD`, `SSLv23_METHOD`, `TLSv1_METHOD`, `TLSv1_1_METHOD`,
@@ -623,13 +623,13 @@ class TestContext:
         with pytest.raises(ValueError):
             Context(13)
 
-    def test_type(self):
+    def test_type(self) -> None:
         """
         `Context` can be used to create instances of that type.
         """
         assert is_consistent_type(Context, "Context", TLSv1_METHOD)
 
-    def test_use_privatekey_file_missing(self, tmpfile):
+    def test_use_privatekey_file_missing(self, tmpfile) -> None:
         """
         `Context.use_privatekey_file` raises `OpenSSL.SSL.Error` when passed
         the name of a file which does not exist.
@@ -653,7 +653,7 @@ class TestContext:
         ctx.use_privatekey_file(pemfile, filetype)
 
     @pytest.mark.parametrize("filetype", [object(), "", None, 1.0])
-    def test_wrong_privatekey_file_wrong_args(self, tmpfile, filetype):
+    def test_wrong_privatekey_file_wrong_args(self, tmpfile, filetype) -> None:
         """
         `Context.use_privatekey_file` raises `TypeError` when called with
         a `filetype` which is not a valid file encoding.
@@ -662,7 +662,7 @@ class TestContext:
         with pytest.raises(TypeError):
             ctx.use_privatekey_file(tmpfile, filetype)
 
-    def test_use_privatekey_file_bytes(self, tmpfile):
+    def test_use_privatekey_file_bytes(self, tmpfile) -> None:
         """
         A private key can be specified from a file by passing a ``bytes``
         instance giving the file name to ``Context.use_privatekey_file``.
@@ -672,7 +672,7 @@ class TestContext:
             FILETYPE_PEM,
         )
 
-    def test_use_privatekey_file_unicode(self, tmpfile):
+    def test_use_privatekey_file_unicode(self, tmpfile) -> None:
         """
         A private key can be specified from a file by passing a ``unicode``
         instance giving the file name to ``Context.use_privatekey_file``.
@@ -682,7 +682,7 @@ class TestContext:
             FILETYPE_PEM,
         )
 
-    def test_use_certificate_file_wrong_args(self):
+    def test_use_certificate_file_wrong_args(self) -> None:
         """
         `Context.use_certificate_file` raises `TypeError` if the first
         argument is not a byte string or the second argument is not an integer.
@@ -695,7 +695,7 @@ class TestContext:
         with pytest.raises(TypeError):
             ctx.use_certificate_file(object(), FILETYPE_PEM)
 
-    def test_use_certificate_file_missing(self, tmpfile):
+    def test_use_certificate_file_missing(self, tmpfile) -> None:
         """
         `Context.use_certificate_file` raises `OpenSSL.SSL.Error` if passed
         the name of a file which does not exist.
@@ -719,7 +719,7 @@ class TestContext:
         ctx = Context(SSLv23_METHOD)
         ctx.use_certificate_file(certificate_file)
 
-    def test_use_certificate_file_bytes(self, tmpfile):
+    def test_use_certificate_file_bytes(self, tmpfile) -> None:
         """
         `Context.use_certificate_file` sets the certificate (given as a
         `bytes` filename) which will be used to identify connections created
@@ -728,7 +728,7 @@ class TestContext:
         filename = tmpfile + NON_ASCII.encode(getfilesystemencoding())
         self._use_certificate_file_test(filename)
 
-    def test_use_certificate_file_unicode(self, tmpfile):
+    def test_use_certificate_file_unicode(self, tmpfile) -> None:
         """
         `Context.use_certificate_file` sets the certificate (given as a
         `bytes` filename) which will be used to identify connections created
@@ -737,7 +737,7 @@ class TestContext:
         filename = tmpfile.decode(getfilesystemencoding()) + NON_ASCII
         self._use_certificate_file_test(filename)
 
-    def test_check_privatekey_valid(self):
+    def test_check_privatekey_valid(self) -> None:
         """
         `Context.check_privatekey` returns `None` if the `Context` instance
         has been configured to use a matched key and certificate pair.
@@ -754,7 +754,7 @@ class TestContext:
         context.use_certificate(cert)
         assert None is context.check_privatekey()
 
-    def test_check_privatekey_invalid(self):
+    def test_check_privatekey_invalid(self) -> None:
         """
         `Context.check_privatekey` raises `Error` if the `Context` instance
         has been configured to use a key and certificate pair which don't
@@ -774,7 +774,7 @@ class TestContext:
         with pytest.raises(Error):
             context.check_privatekey()
 
-    def test_app_data(self):
+    def test_app_data(self) -> None:
         """
         `Context.set_app_data` stores an object for later retrieval
         using `Context.get_app_data`.
@@ -784,7 +784,7 @@ class TestContext:
         context.set_app_data(app_data)
         assert context.get_app_data() is app_data
 
-    def test_set_options_wrong_args(self):
+    def test_set_options_wrong_args(self) -> None:
         """
         `Context.set_options` raises `TypeError` if called with
         a non-`int` argument.
@@ -793,7 +793,7 @@ class TestContext:
         with pytest.raises(TypeError):
             context.set_options(None)
 
-    def test_set_options(self):
+    def test_set_options(self) -> None:
         """
         `Context.set_options` returns the new options value.
         """
@@ -801,7 +801,7 @@ class TestContext:
         options = context.set_options(OP_NO_SSLv2)
         assert options & OP_NO_SSLv2 == OP_NO_SSLv2
 
-    def test_set_mode_wrong_args(self):
+    def test_set_mode_wrong_args(self) -> None:
         """
         `Context.set_mode` raises `TypeError` if called with
         a non-`int` argument.
@@ -810,7 +810,7 @@ class TestContext:
         with pytest.raises(TypeError):
             context.set_mode(None)
 
-    def test_set_mode(self):
+    def test_set_mode(self) -> None:
         """
         `Context.set_mode` accepts a mode bitvector and returns the
         newly set mode.
@@ -818,7 +818,7 @@ class TestContext:
         context = Context(SSLv23_METHOD)
         assert MODE_RELEASE_BUFFERS & context.set_mode(MODE_RELEASE_BUFFERS)
 
-    def test_set_timeout_wrong_args(self):
+    def test_set_timeout_wrong_args(self) -> None:
         """
         `Context.set_timeout` raises `TypeError` if called with
         a non-`int` argument.
@@ -827,7 +827,7 @@ class TestContext:
         with pytest.raises(TypeError):
             context.set_timeout(None)
 
-    def test_timeout(self):
+    def test_timeout(self) -> None:
         """
         `Context.set_timeout` sets the session timeout for all connections
         created using the context object. `Context.get_timeout` retrieves
@@ -837,7 +837,7 @@ class TestContext:
         context.set_timeout(1234)
         assert context.get_timeout() == 1234
 
-    def test_set_verify_depth_wrong_args(self):
+    def test_set_verify_depth_wrong_args(self) -> None:
         """
         `Context.set_verify_depth` raises `TypeError` if called with a
         non-`int` argument.
@@ -846,7 +846,7 @@ class TestContext:
         with pytest.raises(TypeError):
             context.set_verify_depth(None)
 
-    def test_verify_depth(self):
+    def test_verify_depth(self) -> None:
         """
         `Context.set_verify_depth` sets the number of certificates in
         a chain to follow before giving up.  The value can be retrieved with
@@ -868,7 +868,7 @@ class TestContext:
             fObj.write(pem.decode("ascii"))
         return tmpfile
 
-    def test_set_passwd_cb_wrong_args(self):
+    def test_set_passwd_cb_wrong_args(self) -> None:
         """
         `Context.set_passwd_cb` raises `TypeError` if called with a
         non-callable first argument.
@@ -877,7 +877,7 @@ class TestContext:
         with pytest.raises(TypeError):
             context.set_passwd_cb(None)
 
-    def test_set_passwd_cb(self, tmpfile):
+    def test_set_passwd_cb(self, tmpfile) -> None:
         """
         `Context.set_passwd_cb` accepts a callable which will be invoked when
         a private key is loaded from an encrypted PEM.
@@ -898,7 +898,7 @@ class TestContext:
         assert isinstance(calledWith[0][1], int)
         assert calledWith[0][2] is None
 
-    def test_passwd_callback_exception(self, tmpfile):
+    def test_passwd_callback_exception(self, tmpfile) -> None:
         """
         `Context.use_privatekey_file` propagates any exception raised
         by the passphrase callback.
@@ -913,7 +913,7 @@ class TestContext:
         with pytest.raises(RuntimeError):
             context.use_privatekey_file(pemFile)
 
-    def test_passwd_callback_false(self, tmpfile):
+    def test_passwd_callback_false(self, tmpfile) -> None:
         """
         `Context.use_privatekey_file` raises `OpenSSL.SSL.Error` if the
         passphrase callback returns a false value.
@@ -928,7 +928,7 @@ class TestContext:
         with pytest.raises(Error):
             context.use_privatekey_file(pemFile)
 
-    def test_passwd_callback_non_string(self, tmpfile):
+    def test_passwd_callback_non_string(self, tmpfile) -> None:
         """
         `Context.use_privatekey_file` raises `OpenSSL.SSL.Error` if the
         passphrase callback returns a true non-string value.
@@ -944,7 +944,7 @@ class TestContext:
         with pytest.raises(ValueError):
             context.use_privatekey_file(pemFile)
 
-    def test_passwd_callback_too_long(self, tmpfile):
+    def test_passwd_callback_too_long(self, tmpfile) -> None:
         """
         If the passphrase returned by the passphrase callback returns a string
         longer than the indicated maximum length, it is truncated.
@@ -963,7 +963,7 @@ class TestContext:
         # passphrase.
         context.use_privatekey_file(pemFile)
 
-    def test_set_info_callback(self):
+    def test_set_info_callback(self) -> None:
         """
         `Context.set_info_callback` accepts a callable which will be
         invoked when certain information about an SSL connection is available.
@@ -1006,7 +1006,7 @@ class TestContext:
         not getattr(_lib, "Cryptography_HAS_KEYLOG", None),
         reason="SSL_CTX_set_keylog_callback unavailable",
     )
-    def test_set_keylog_callback(self):
+    def test_set_keylog_callback(self) -> None:
         """
         `Context.set_keylog_callback` accepts a callable which will be
         invoked when key material is generated or received.
@@ -1033,7 +1033,7 @@ class TestContext:
         assert all(isinstance(conn, Connection) for conn, line in called)
         assert all(b"CLIENT_RANDOM" in line for conn, line in called)
 
-    def test_set_proto_version(self):
+    def test_set_proto_version(self) -> None:
         high_version = TLS1_3_VERSION
         low_version = TLS1_2_VERSION
 
@@ -1115,7 +1115,7 @@ class TestContext:
 
         self._load_verify_locations_test(cafile)
 
-    def test_load_verify_bytes_cafile(self, tmpfile):
+    def test_load_verify_bytes_cafile(self, tmpfile) -> None:
         """
         `Context.load_verify_locations` accepts a file name as a `bytes`
         instance and uses the certificates within for verification purposes.
@@ -1123,7 +1123,7 @@ class TestContext:
         cafile = tmpfile + NON_ASCII.encode(getfilesystemencoding())
         self._load_verify_cafile(cafile)
 
-    def test_load_verify_unicode_cafile(self, tmpfile):
+    def test_load_verify_unicode_cafile(self, tmpfile) -> None:
         """
         `Context.load_verify_locations` accepts a file name as a `unicode`
         instance and uses the certificates within for verification purposes.
@@ -1132,7 +1132,7 @@ class TestContext:
             tmpfile.decode(getfilesystemencoding()) + NON_ASCII
         )
 
-    def test_load_verify_invalid_file(self, tmpfile):
+    def test_load_verify_invalid_file(self, tmpfile) -> None:
         """
         `Context.load_verify_locations` raises `Error` when passed a
         non-existent cafile.
@@ -1173,7 +1173,9 @@ class TestContext:
         ],
     )
     @pytest.mark.parametrize("argtype", ["bytes_arg", "unicode_arg"])
-    def test_load_verify_directory_capath(self, pathtype, argtype, tmpfile):
+    def test_load_verify_directory_capath(
+        self, pathtype, argtype, tmpfile
+    ) -> None:
         """
         `Context.load_verify_locations` accepts a directory name as a `bytes`
         instance and uses the certificates within for verification purposes.
@@ -1184,7 +1186,7 @@ class TestContext:
             tmpfile = tmpfile.decode(getfilesystemencoding())
         self._load_verify_directory_locations_capath(tmpfile)
 
-    def test_load_verify_locations_wrong_args(self):
+    def test_load_verify_locations_wrong_args(self) -> None:
         """
         `Context.load_verify_locations` raises `TypeError` if with non-`str`
         arguments.
@@ -1200,7 +1202,7 @@ class TestContext:
         reason="Loading fallback paths is a linux-specific behavior to "
         "accommodate pyca/cryptography manylinux wheels",
     )
-    def test_fallback_default_verify_paths(self, monkeypatch):
+    def test_fallback_default_verify_paths(self, monkeypatch) -> None:
         """
         Test that we load certificates successfully on linux from the fallback
         path. To do this we set the _CRYPTOGRAPHY_MANYLINUX_CA_FILE and
@@ -1230,7 +1232,7 @@ class TestContext:
         num = _lib.sk_X509_OBJECT_num(sk_obj)
         assert num != 0
 
-    def test_check_env_vars(self, monkeypatch):
+    def test_check_env_vars(self, monkeypatch) -> None:
         """
         Test that we return True/False appropriately if the env vars are set.
         """
@@ -1243,7 +1245,7 @@ class TestContext:
         assert context._check_env_vars_set(dir_var, file_var) is True
         assert context._check_env_vars_set(dir_var, file_var) is True
 
-    def test_verify_no_fallback_if_env_vars_set(self, monkeypatch):
+    def test_verify_no_fallback_if_env_vars_set(self, monkeypatch) -> None:
         """
         Test that we don't use the fallback path if env vars are set.
         """
@@ -1271,7 +1273,7 @@ class TestContext:
         reason="set_default_verify_paths appears not to work on Windows.  "
         "See LP#404343 and LP#404344.",
     )
-    def test_set_default_verify_paths(self):
+    def test_set_default_verify_paths(self) -> None:
         """
         `Context.set_default_verify_paths` causes the platform-specific CA
         certificate locations to be used for verification purposes.
@@ -1302,7 +1304,7 @@ class TestContext:
         clientSSL.send(b"GET / HTTP/1.0\r\n\r\n")
         assert clientSSL.recv(1024)
 
-    def test_fallback_path_is_not_file_or_dir(self):
+    def test_fallback_path_is_not_file_or_dir(self) -> None:
         """
         Test that when passed empty arrays or paths that do not exist no
         errors are raised.
@@ -1311,7 +1313,7 @@ class TestContext:
         context._fallback_default_verify_paths([], [])
         context._fallback_default_verify_paths(["/not/a/file"], ["/not/a/dir"])
 
-    def test_add_extra_chain_cert_invalid_cert(self):
+    def test_add_extra_chain_cert_invalid_cert(self) -> None:
         """
         `Context.add_extra_chain_cert` raises `TypeError` if called with an
         object which is not an instance of `X509`.
@@ -1342,7 +1344,7 @@ class TestContext:
                     except WantReadError:
                         select.select([client, server], [], [])
 
-    def test_set_verify_callback_connection_argument(self):
+    def test_set_verify_callback_connection_argument(self) -> None:
         """
         The first argument passed to the verify callback is the
         `Connection` instance for which verification is taking place.
@@ -1371,7 +1373,7 @@ class TestContext:
 
         assert verify.connection is clientConnection
 
-    def test_x509_in_verify_works(self):
+    def test_x509_in_verify_works(self) -> None:
         """
         We had a bug where the X509 cert instantiated in the callback wrapper
         didn't __init__ so it was missing objects needed when calling
@@ -1398,7 +1400,7 @@ class TestContext:
 
         handshake_in_memory(clientConnection, serverConnection)
 
-    def test_set_verify_callback_exception(self):
+    def test_set_verify_callback_exception(self) -> None:
         """
         If the verify callback passed to `Context.set_verify` raises an
         exception, verification fails and the exception is propagated to the
@@ -1424,7 +1426,7 @@ class TestContext:
 
         assert "silly verify failure" == str(exc.value)
 
-    def test_set_verify_callback_reference(self):
+    def test_set_verify_callback_reference(self) -> None:
         """
         If the verify callback passed to `Context.set_verify` is set multiple
         times, the pointers to the old call functions should not be dangling
@@ -1470,7 +1472,7 @@ class TestContext:
                         pass
 
     @pytest.mark.parametrize("mode", [SSL.VERIFY_PEER, SSL.VERIFY_NONE])
-    def test_set_verify_default_callback(self, mode):
+    def test_set_verify_default_callback(self, mode) -> None:
         """
         If the verify callback is omitted, the preverify value is used.
         """
@@ -1492,7 +1494,7 @@ class TestContext:
         else:
             self._handshake_test(serverContext, clientContext)
 
-    def test_add_extra_chain_cert(self, tmpdir):
+    def test_add_extra_chain_cert(self, tmpdir) -> None:
         """
         `Context.add_extra_chain_cert` accepts an `X509`
         instance to add to the certificate chain.
@@ -1576,7 +1578,7 @@ class TestContext:
 
         self._handshake_test(serverContext, clientContext)
 
-    def test_use_certificate_chain_file_bytes(self, tmpfile):
+    def test_use_certificate_chain_file_bytes(self, tmpfile) -> None:
         """
         ``Context.use_certificate_chain_file`` accepts the name of a file (as
         an instance of ``bytes``) to specify additional certificates to use to
@@ -1586,7 +1588,7 @@ class TestContext:
             tmpfile + NON_ASCII.encode(getfilesystemencoding())
         )
 
-    def test_use_certificate_chain_file_unicode(self, tmpfile):
+    def test_use_certificate_chain_file_unicode(self, tmpfile) -> None:
         """
         ``Context.use_certificate_chain_file`` accepts the name of a file (as
         an instance of ``unicode``) to specify additional certificates to use
@@ -1596,7 +1598,7 @@ class TestContext:
             tmpfile.decode(getfilesystemencoding()) + NON_ASCII
         )
 
-    def test_use_certificate_chain_file_wrong_args(self):
+    def test_use_certificate_chain_file_wrong_args(self) -> None:
         """
         `Context.use_certificate_chain_file` raises `TypeError` if passed a
         non-byte string single argument.
@@ -1605,7 +1607,7 @@ class TestContext:
         with pytest.raises(TypeError):
             context.use_certificate_chain_file(object())
 
-    def test_use_certificate_chain_file_missing_file(self, tmpfile):
+    def test_use_certificate_chain_file_missing_file(self, tmpfile) -> None:
         """
         `Context.use_certificate_chain_file` raises `OpenSSL.SSL.Error` when
         passed a bad chain file name (for example, the name of a file which
@@ -1615,7 +1617,7 @@ class TestContext:
         with pytest.raises(Error):
             context.use_certificate_chain_file(tmpfile)
 
-    def test_set_verify_mode(self):
+    def test_set_verify_mode(self) -> None:
         """
         `Context.get_verify_mode` returns the verify mode flags previously
         passed to `Context.set_verify`.
@@ -1626,7 +1628,7 @@ class TestContext:
         assert context.get_verify_mode() == (VERIFY_PEER | VERIFY_CLIENT_ONCE)
 
     @pytest.mark.parametrize("mode", [None, 1.0, object(), "mode"])
-    def test_set_verify_wrong_mode_arg(self, mode):
+    def test_set_verify_wrong_mode_arg(self, mode) -> None:
         """
         `Context.set_verify` raises `TypeError` if the first argument is
         not an integer.
@@ -1636,7 +1638,7 @@ class TestContext:
             context.set_verify(mode=mode)
 
     @pytest.mark.parametrize("callback", [1.0, "mode", ("foo", "bar")])
-    def test_set_verify_wrong_callable_arg(self, callback):
+    def test_set_verify_wrong_callable_arg(self, callback) -> None:
         """
         `Context.set_verify` raises `TypeError` if the second argument
         is not callable.
@@ -1645,7 +1647,7 @@ class TestContext:
         with pytest.raises(TypeError):
             context.set_verify(mode=VERIFY_PEER, callback=callback)
 
-    def test_load_tmp_dh_wrong_args(self):
+    def test_load_tmp_dh_wrong_args(self) -> None:
         """
         `Context.load_tmp_dh` raises `TypeError` if called with a
         non-`str` argument.
@@ -1654,7 +1656,7 @@ class TestContext:
         with pytest.raises(TypeError):
             context.load_tmp_dh(object())
 
-    def test_load_tmp_dh_missing_file(self):
+    def test_load_tmp_dh_missing_file(self) -> None:
         """
         `Context.load_tmp_dh` raises `OpenSSL.SSL.Error` if the
         specified file does not exist.
@@ -1674,7 +1676,7 @@ class TestContext:
 
         context.load_tmp_dh(dhfilename)
 
-    def test_load_tmp_dh_bytes(self, tmpfile):
+    def test_load_tmp_dh_bytes(self, tmpfile) -> None:
         """
         `Context.load_tmp_dh` loads Diffie-Hellman parameters from the
         specified file (given as ``bytes``).
@@ -1683,7 +1685,7 @@ class TestContext:
             tmpfile + NON_ASCII.encode(getfilesystemencoding()),
         )
 
-    def test_load_tmp_dh_unicode(self, tmpfile):
+    def test_load_tmp_dh_unicode(self, tmpfile) -> None:
         """
         `Context.load_tmp_dh` loads Diffie-Hellman parameters from the
         specified file (given as ``unicode``).
@@ -1692,7 +1694,7 @@ class TestContext:
             tmpfile.decode(getfilesystemencoding()) + NON_ASCII,
         )
 
-    def test_set_tmp_ecdh(self):
+    def test_set_tmp_ecdh(self) -> None:
         """
         `Context.set_tmp_ecdh` sets the elliptic curve for Diffie-Hellman to
         the specified curve.
@@ -1716,7 +1718,7 @@ class TestContext:
             curve = ec.get_curve_for_oid(oid)
             context.set_tmp_ecdh(curve)
 
-    def test_set_session_cache_mode_wrong_args(self):
+    def test_set_session_cache_mode_wrong_args(self) -> None:
         """
         `Context.set_session_cache_mode` raises `TypeError` if called with
         a non-integer argument.
@@ -1726,7 +1728,7 @@ class TestContext:
         with pytest.raises(TypeError):
             context.set_session_cache_mode(object())
 
-    def test_session_cache_mode(self):
+    def test_session_cache_mode(self) -> None:
         """
         `Context.set_session_cache_mode` specifies how sessions are cached.
         The setting can be retrieved via `Context.get_session_cache_mode`.
@@ -1737,7 +1739,7 @@ class TestContext:
         assert SESS_CACHE_OFF == off
         assert SESS_CACHE_BOTH == context.get_session_cache_mode()
 
-    def test_get_cert_store(self):
+    def test_get_cert_store(self) -> None:
         """
         `Context.get_cert_store` returns a `X509Store` instance.
         """
@@ -1745,7 +1747,7 @@ class TestContext:
         store = context.get_cert_store()
         assert isinstance(store, X509Store)
 
-    def test_set_tlsext_use_srtp_not_bytes(self):
+    def test_set_tlsext_use_srtp_not_bytes(self) -> None:
         """
         `Context.set_tlsext_use_srtp' enables negotiating SRTP keying material.
 
@@ -1755,7 +1757,7 @@ class TestContext:
         with pytest.raises(TypeError):
             context.set_tlsext_use_srtp("SRTP_AES128_CM_SHA1_80")
 
-    def test_set_tlsext_use_srtp_invalid_profile(self):
+    def test_set_tlsext_use_srtp_invalid_profile(self) -> None:
         """
         `Context.set_tlsext_use_srtp' enables negotiating SRTP keying material.
 
@@ -1765,7 +1767,7 @@ class TestContext:
         with pytest.raises(Error):
             context.set_tlsext_use_srtp(b"SRTP_BOGUS")
 
-    def test_set_tlsext_use_srtp_valid(self):
+    def test_set_tlsext_use_srtp_valid(self) -> None:
         """
         `Context.set_tlsext_use_srtp' enables negotiating SRTP keying material.
 
@@ -1781,7 +1783,7 @@ class TestServerNameCallback:
     interaction with `Connection`.
     """
 
-    def test_old_callback_forgotten(self):
+    def test_old_callback_forgotten(self) -> None:
         """
         If `Context.set_tlsext_servername_callback` is used to specify
         a new callback, the one it replaces is dereferenced.
@@ -1813,7 +1815,7 @@ class TestServerNameCallback:
             referrers = get_referrers(callback)
             assert len(referrers) == 1
 
-    def test_no_servername(self):
+    def test_no_servername(self) -> None:
         """
         When a client specifies no server name, the callback passed to
         `Context.set_tlsext_servername_callback` is invoked and the
@@ -1849,7 +1851,7 @@ class TestServerNameCallback:
 
         assert args == [(server, None)]
 
-    def test_servername(self):
+    def test_servername(self) -> None:
         """
         When a client specifies a server name in its hello message, the
         callback passed to `Contexts.set_tlsext_servername_callback` is
@@ -1888,7 +1890,7 @@ class TestApplicationLayerProtoNegotiation:
     Tests for ALPN in PyOpenSSL.
     """
 
-    def test_alpn_success(self):
+    def test_alpn_success(self) -> None:
         """
         Clients and servers that agree on the negotiated ALPN protocol can
         correct establish a connection, and the agreed protocol is reported
@@ -1928,7 +1930,7 @@ class TestApplicationLayerProtoNegotiation:
         assert server.get_alpn_proto_negotiated() == b"spdy/2"
         assert client.get_alpn_proto_negotiated() == b"spdy/2"
 
-    def test_alpn_call_failure(self):
+    def test_alpn_call_failure(self) -> None:
         """
         SSL_CTX_set_alpn_protos does not like to be called with an empty
         protocols list. Ensure that we produce a user-visible error.
@@ -1937,7 +1939,7 @@ class TestApplicationLayerProtoNegotiation:
         with pytest.raises(ValueError):
             context.set_alpn_protos([])
 
-    def test_alpn_set_on_connection(self):
+    def test_alpn_set_on_connection(self) -> None:
         """
         The same as test_alpn_success, but setting the ALPN protocols on
         the connection rather than the context.
@@ -1978,7 +1980,7 @@ class TestApplicationLayerProtoNegotiation:
         assert server.get_alpn_proto_negotiated() == b"spdy/2"
         assert client.get_alpn_proto_negotiated() == b"spdy/2"
 
-    def test_alpn_server_fail(self):
+    def test_alpn_server_fail(self) -> None:
         """
         When clients and servers cannot agree on what protocol to use next
         the TLS connection does not get established.
@@ -2016,7 +2018,7 @@ class TestApplicationLayerProtoNegotiation:
 
         assert select_args == [(server, [b"http/1.1", b"spdy/2"])]
 
-    def test_alpn_no_server_overlap(self):
+    def test_alpn_no_server_overlap(self) -> None:
         """
         A server can allow a TLS handshake to complete without
         agreeing to an application protocol by returning
@@ -2056,7 +2058,7 @@ class TestApplicationLayerProtoNegotiation:
 
         assert client.get_alpn_proto_negotiated() == b""
 
-    def test_alpn_select_cb_returns_invalid_value(self):
+    def test_alpn_select_cb_returns_invalid_value(self) -> None:
         """
         If the ALPN selection callback returns anything other than
         a bytestring or ``NO_OVERLAPPING_PROTOCOLS``, a
@@ -2097,7 +2099,7 @@ class TestApplicationLayerProtoNegotiation:
 
         assert client.get_alpn_proto_negotiated() == b""
 
-    def test_alpn_no_server(self):
+    def test_alpn_no_server(self) -> None:
         """
         When clients and servers cannot agree on what protocol to use next
         because the server doesn't offer ALPN, no protocol is negotiated.
@@ -2127,7 +2129,7 @@ class TestApplicationLayerProtoNegotiation:
 
         assert client.get_alpn_proto_negotiated() == b""
 
-    def test_alpn_callback_exception(self):
+    def test_alpn_callback_exception(self) -> None:
         """
         We can handle exceptions in the ALPN select callback.
         """
@@ -2168,7 +2170,7 @@ class TestSession:
     Unit tests for :py:obj:`OpenSSL.SSL.Session`.
     """
 
-    def test_construction(self):
+    def test_construction(self) -> None:
         """
         :py:class:`Session` can be constructed with no arguments, creating
         a new instance of that type.
@@ -2192,7 +2194,7 @@ class TestContextConnection:
     objects.
     """
 
-    def test_use_privatekey(self, ctx_or_conn):
+    def test_use_privatekey(self, ctx_or_conn) -> None:
         """
         `use_privatekey` takes an `OpenSSL.crypto.PKey` instance.
         """
@@ -2205,7 +2207,7 @@ class TestContextConnection:
 
         ctx_or_conn.use_privatekey(key.to_cryptography_key())
 
-    def test_use_privatekey_wrong_key(self, ctx_or_conn):
+    def test_use_privatekey_wrong_key(self, ctx_or_conn) -> None:
         """
         `use_privatekey` raises `OpenSSL.SSL.Error` when passed a
         `OpenSSL.crypto.PKey` instance which has not been initialized.
@@ -2218,7 +2220,7 @@ class TestContextConnection:
         with pytest.raises(Error):
             ctx_or_conn.use_privatekey(key)
 
-    def test_use_certificate(self, ctx_or_conn):
+    def test_use_certificate(self, ctx_or_conn) -> None:
         """
         `use_certificate` sets the certificate which will be
         used to identify connections created using the context.
@@ -2234,7 +2236,7 @@ class TestContextConnection:
             load_certificate(FILETYPE_PEM, root_cert_pem).to_cryptography()
         )
 
-    def test_use_certificate_wrong_args(self, ctx_or_conn):
+    def test_use_certificate_wrong_args(self, ctx_or_conn) -> None:
         """
         `use_certificate_wrong_args` raises `TypeError` when not passed
         exactly one `OpenSSL.crypto.X509` instance as an argument.
@@ -2242,7 +2244,7 @@ class TestContextConnection:
         with pytest.raises(TypeError):
             ctx_or_conn.use_certificate("hello, world")
 
-    def test_use_certificate_uninitialized(self, ctx_or_conn):
+    def test_use_certificate_uninitialized(self, ctx_or_conn) -> None:
         """
         `use_certificate` raises `OpenSSL.SSL.Error` when passed a
         `OpenSSL.crypto.X509` instance which has not been initialized
@@ -2271,7 +2273,7 @@ class TestConnection:
     # XXX send -> TypeError
     # XXX bio_write -> TypeError
 
-    def test_type(self):
+    def test_type(self) -> None:
         """
         `Connection` can be used to create instances of that type.
         """
@@ -2279,7 +2281,7 @@ class TestConnection:
         assert is_consistent_type(Connection, "Connection", ctx, None)
 
     @pytest.mark.parametrize("bad_context", [object(), "context", None, 1])
-    def test_wrong_args(self, bad_context):
+    def test_wrong_args(self, bad_context) -> None:
         """
         `Connection.__init__` raises `TypeError` if called with a non-`Context`
         instance argument.
@@ -2288,7 +2290,7 @@ class TestConnection:
             Connection(bad_context)
 
     @pytest.mark.parametrize("bad_bio", [object(), None, 1, [1, 2, 3]])
-    def test_bio_write_wrong_args(self, bad_bio):
+    def test_bio_write_wrong_args(self, bad_bio) -> None:
         """
         `Connection.bio_write` raises `TypeError` if called with a non-bytes
         (or text) argument.
@@ -2298,7 +2300,7 @@ class TestConnection:
         with pytest.raises(TypeError):
             connection.bio_write(bad_bio)
 
-    def test_bio_write(self):
+    def test_bio_write(self) -> None:
         """
         `Connection.bio_write` does not raise if called with bytes or
         bytearray, warns if called with text.
@@ -2310,7 +2312,7 @@ class TestConnection:
         with pytest.warns(DeprecationWarning):
             connection.bio_write("deprecated")
 
-    def test_get_context(self):
+    def test_get_context(self) -> None:
         """
         `Connection.get_context` returns the `Context` instance used to
         construct the `Connection` instance.
@@ -2319,7 +2321,7 @@ class TestConnection:
         connection = Connection(context, None)
         assert connection.get_context() is context
 
-    def test_set_context_wrong_args(self):
+    def test_set_context_wrong_args(self) -> None:
         """
         `Connection.set_context` raises `TypeError` if called with a
         non-`Context` instance argument.
@@ -2334,7 +2336,7 @@ class TestConnection:
             connection.set_context(1)
         assert ctx is connection.get_context()
 
-    def test_set_context(self):
+    def test_set_context(self) -> None:
         """
         `Connection.set_context` specifies a new `Context` instance to be
         used for the connection.
@@ -2350,7 +2352,7 @@ class TestConnection:
         del original, replacement
         collect()
 
-    def test_set_tlsext_host_name_wrong_args(self):
+    def test_set_tlsext_host_name_wrong_args(self) -> None:
         """
         If `Connection.set_tlsext_host_name` is called with a non-byte string
         argument or a byte string with an embedded NUL, `TypeError` is raised.
@@ -2364,7 +2366,7 @@ class TestConnection:
         with pytest.raises(TypeError):
             conn.set_tlsext_host_name(b"example.com".decode("ascii"))
 
-    def test_pending(self):
+    def test_pending(self) -> None:
         """
         `Connection.pending` returns the number of bytes available for
         immediate read.
@@ -2372,7 +2374,7 @@ class TestConnection:
         connection = Connection(Context(SSLv23_METHOD), None)
         assert connection.pending() == 0
 
-    def test_peek(self):
+    def test_peek(self) -> None:
         """
         `Connection.recv` peeks into the connection if `socket.MSG_PEEK` is
         passed.
@@ -2383,7 +2385,7 @@ class TestConnection:
         assert client.recv(2, MSG_PEEK) == b"xy"
         assert client.recv(2) == b"xy"
 
-    def test_connect_wrong_args(self):
+    def test_connect_wrong_args(self) -> None:
         """
         `Connection.connect` raises `TypeError` if called with a non-address
         argument.
@@ -2392,7 +2394,7 @@ class TestConnection:
         with pytest.raises(TypeError):
             connection.connect(None)
 
-    def test_connect_refused(self):
+    def test_connect_refused(self) -> None:
         """
         `Connection.connect` raises `socket.error` if the underlying socket
         connect method raises it.
@@ -2408,7 +2410,7 @@ class TestConnection:
             exc = e
         assert exc.args[0] == ECONNREFUSED
 
-    def test_connect(self):
+    def test_connect(self) -> None:
         """
         `Connection.connect` establishes a connection to the specified address.
         """
@@ -2420,7 +2422,7 @@ class TestConnection:
         clientSSL.connect((loopback_address(port), port.getsockname()[1]))
         # XXX An assertion?  Or something?
 
-    def test_connect_ex(self):
+    def test_connect_ex(self) -> None:
         """
         If there is a connection error, `Connection.connect_ex` returns the
         errno instead of raising an exception.
@@ -2435,7 +2437,7 @@ class TestConnection:
         expected = (EINPROGRESS, EWOULDBLOCK)
         assert result in expected
 
-    def test_accept(self):
+    def test_accept(self) -> None:
         """
         `Connection.accept` accepts a pending connection attempt and returns a
         tuple of a new `Connection` (the accepted client) and the address the
@@ -2461,7 +2463,7 @@ class TestConnection:
         assert serverSSL.get_context() is ctx
         assert address == clientSSL.getsockname()
 
-    def test_shutdown_wrong_args(self):
+    def test_shutdown_wrong_args(self) -> None:
         """
         `Connection.set_shutdown` raises `TypeError` if called with arguments
         other than integers.
@@ -2470,7 +2472,7 @@ class TestConnection:
         with pytest.raises(TypeError):
             connection.set_shutdown(None)
 
-    def test_shutdown(self):
+    def test_shutdown(self) -> None:
         """
         `Connection.shutdown` performs an SSL-level connection shutdown.
         """
@@ -2486,7 +2488,7 @@ class TestConnection:
             server.recv(1024)
         assert server.get_shutdown() == (SENT_SHUTDOWN | RECEIVED_SHUTDOWN)
 
-    def test_shutdown_closed(self):
+    def test_shutdown_closed(self) -> None:
         """
         If the underlying socket is closed, `Connection.shutdown` propagates
         the write error from the low level write call.
@@ -2500,7 +2502,7 @@ class TestConnection:
         else:
             assert exc.value.args[0] == EPIPE
 
-    def test_shutdown_truncated(self):
+    def test_shutdown_truncated(self) -> None:
         """
         If the underlying connection is truncated, `Connection.shutdown`
         raises an `Error`.
@@ -2523,7 +2525,7 @@ class TestConnection:
         with pytest.raises(Error):
             server.shutdown()
 
-    def test_set_shutdown(self):
+    def test_set_shutdown(self) -> None:
         """
         `Connection.set_shutdown` sets the state of the SSL connection
         shutdown process.
@@ -2532,7 +2534,7 @@ class TestConnection:
         connection.set_shutdown(RECEIVED_SHUTDOWN)
         assert connection.get_shutdown() == RECEIVED_SHUTDOWN
 
-    def test_state_string(self):
+    def test_state_string(self) -> None:
         """
         `Connection.state_string` verbosely describes the current state of
         the `Connection`.
@@ -2550,7 +2552,7 @@ class TestConnection:
             b"before SSL initialization",
         ]
 
-    def test_app_data(self):
+    def test_app_data(self) -> None:
         """
         Any object can be set as app data by passing it to
         `Connection.set_app_data` and later retrieved with
@@ -2562,7 +2564,7 @@ class TestConnection:
         conn.set_app_data(app_data)
         assert conn.get_app_data() is app_data
 
-    def test_makefile(self):
+    def test_makefile(self) -> None:
         """
         `Connection.makefile` is not implemented and calling that
         method raises `NotImplementedError`.
@@ -2571,7 +2573,7 @@ class TestConnection:
         with pytest.raises(NotImplementedError):
             conn.makefile()
 
-    def test_get_certificate(self):
+    def test_get_certificate(self) -> None:
         """
         `Connection.get_certificate` returns the local certificate.
         """
@@ -2591,7 +2593,7 @@ class TestConnection:
             == "CN=Server Certificate"
         )
 
-    def test_get_certificate_none(self):
+    def test_get_certificate_none(self) -> None:
         """
         `Connection.get_certificate` returns the local certificate.
 
@@ -2602,7 +2604,7 @@ class TestConnection:
         cert = client.get_certificate()
         assert cert is None
 
-    def test_get_peer_cert_chain(self):
+    def test_get_peer_cert_chain(self) -> None:
         """
         `Connection.get_peer_cert_chain` returns a list of certificates
         which the connected server returned for the certification verification.
@@ -2646,7 +2648,7 @@ class TestConnection:
             == "CN=Authority Certificate"
         )
 
-    def test_get_peer_cert_chain_none(self):
+    def test_get_peer_cert_chain_none(self) -> None:
         """
         `Connection.get_peer_cert_chain` returns `None` if the peer sends
         no certificate chain.
@@ -2661,7 +2663,7 @@ class TestConnection:
         interact_in_memory(client, server)
         assert None is server.get_peer_cert_chain()
 
-    def test_get_verified_chain(self):
+    def test_get_verified_chain(self) -> None:
         """
         `Connection.get_verified_chain` returns a list of certificates
         which the connected server returned for the certification verification.
@@ -2708,7 +2710,7 @@ class TestConnection:
             == "CN=Authority Certificate"
         )
 
-    def test_get_verified_chain_none(self):
+    def test_get_verified_chain_none(self) -> None:
         """
         `Connection.get_verified_chain` returns `None` if the peer sends
         no certificate chain.
@@ -2723,7 +2725,7 @@ class TestConnection:
         interact_in_memory(client, server)
         assert None is server.get_verified_chain()
 
-    def test_get_verified_chain_unconnected(self):
+    def test_get_verified_chain_unconnected(self) -> None:
         """
         `Connection.get_verified_chain` returns `None` when used with an object
         which has not been connected.
@@ -2732,7 +2734,7 @@ class TestConnection:
         server = Connection(ctx, None)
         assert None is server.get_verified_chain()
 
-    def test_set_verify_overrides_context(self):
+    def test_set_verify_overrides_context(self) -> None:
         context = Context(SSLv23_METHOD)
         context.set_verify(VERIFY_PEER)
         conn = Connection(context, None)
@@ -2747,7 +2749,7 @@ class TestConnection:
         with pytest.raises(TypeError):
             conn.set_verify(VERIFY_PEER, "not a callable")
 
-    def test_set_verify_callback_reference(self):
+    def test_set_verify_callback_reference(self) -> None:
         """
         The callback for certificate verification should only be forgotten if
         the context and all connections created by it do not use it anymore.
@@ -2777,7 +2779,7 @@ class TestConnection:
             referrers = get_referrers(callback)
             assert len(referrers) == 1
 
-    def test_get_session_unconnected(self):
+    def test_get_session_unconnected(self) -> None:
         """
         `Connection.get_session` returns `None` when used with an object
         which has not been connected.
@@ -2787,7 +2789,7 @@ class TestConnection:
         session = server.get_session()
         assert None is session
 
-    def test_server_get_session(self):
+    def test_server_get_session(self) -> None:
         """
         On the server side of a connection, `Connection.get_session` returns a
         `Session` instance representing the SSL session for that connection.
@@ -2796,7 +2798,7 @@ class TestConnection:
         session = server.get_session()
         assert isinstance(session, Session)
 
-    def test_client_get_session(self):
+    def test_client_get_session(self) -> None:
         """
         On the client side of a connection, `Connection.get_session`
         returns a `Session` instance representing the SSL session for
@@ -2806,7 +2808,7 @@ class TestConnection:
         session = client.get_session()
         assert isinstance(session, Session)
 
-    def test_set_session_wrong_args(self):
+    def test_set_session_wrong_args(self) -> None:
         """
         `Connection.set_session` raises `TypeError` if called with an object
         that is not an instance of `Session`.
@@ -2820,7 +2822,7 @@ class TestConnection:
         with pytest.raises(TypeError):
             connection.set_session(object())
 
-    def test_client_set_session(self):
+    def test_client_set_session(self) -> None:
         """
         `Connection.set_session`, when used prior to a connection being
         established, accepts a `Session` instance and causes an attempt to
@@ -2858,7 +2860,7 @@ class TestConnection:
         # connections is the same, the session was re-used!
         assert originalServer.master_key() == resumedServer.master_key()
 
-    def test_set_session_wrong_method(self):
+    def test_set_session_wrong_method(self) -> None:
         """
         If `Connection.set_session` is passed a `Session` instance associated
         with a context using a different SSL method than the `Connection`
@@ -2899,7 +2901,7 @@ class TestConnection:
         with pytest.raises(Error):
             loopback(client_factory=makeClient, server_factory=makeServer)
 
-    def test_wantWriteError(self):
+    def test_wantWriteError(self) -> None:
         """
         `Connection` methods which generate output raise
         `OpenSSL.SSL.WantWriteError` if writing to the connection's BIO
@@ -2935,7 +2937,7 @@ class TestConnection:
 
     # XXX want_read
 
-    def test_get_finished_before_connect(self):
+    def test_get_finished_before_connect(self) -> None:
         """
         `Connection.get_finished` returns `None` before TLS handshake
         is completed.
@@ -2944,7 +2946,7 @@ class TestConnection:
         connection = Connection(ctx, None)
         assert connection.get_finished() is None
 
-    def test_get_peer_finished_before_connect(self):
+    def test_get_peer_finished_before_connect(self) -> None:
         """
         `Connection.get_peer_finished` returns `None` before TLS handshake
         is completed.
@@ -2953,7 +2955,7 @@ class TestConnection:
         connection = Connection(ctx, None)
         assert connection.get_peer_finished() is None
 
-    def test_get_finished(self):
+    def test_get_finished(self) -> None:
         """
         `Connection.get_finished` method returns the TLS Finished message send
         from client, or server. Finished messages are send during
@@ -2964,7 +2966,7 @@ class TestConnection:
         assert server.get_finished() is not None
         assert len(server.get_finished()) > 0
 
-    def test_get_peer_finished(self):
+    def test_get_peer_finished(self) -> None:
         """
         `Connection.get_peer_finished` method returns the TLS Finished
         message received from client, or server. Finished messages are send
@@ -2975,7 +2977,7 @@ class TestConnection:
         assert server.get_peer_finished() is not None
         assert len(server.get_peer_finished()) > 0
 
-    def test_tls_finished_message_symmetry(self):
+    def test_tls_finished_message_symmetry(self) -> None:
         """
         The TLS Finished message send by server must be the TLS Finished
         message received by client.
@@ -2988,7 +2990,7 @@ class TestConnection:
         assert server.get_finished() == client.get_peer_finished()
         assert client.get_finished() == server.get_peer_finished()
 
-    def test_get_cipher_name_before_connect(self):
+    def test_get_cipher_name_before_connect(self) -> None:
         """
         `Connection.get_cipher_name` returns `None` if no connection
         has been established.
@@ -2997,7 +2999,7 @@ class TestConnection:
         conn = Connection(ctx, None)
         assert conn.get_cipher_name() is None
 
-    def test_get_cipher_name(self):
+    def test_get_cipher_name(self) -> None:
         """
         `Connection.get_cipher_name` returns a `unicode` string giving the
         name of the currently used cipher.
@@ -3013,7 +3015,7 @@ class TestConnection:
 
         assert server_cipher_name == client_cipher_name
 
-    def test_get_cipher_version_before_connect(self):
+    def test_get_cipher_version_before_connect(self) -> None:
         """
         `Connection.get_cipher_version` returns `None` if no connection
         has been established.
@@ -3022,7 +3024,7 @@ class TestConnection:
         conn = Connection(ctx, None)
         assert conn.get_cipher_version() is None
 
-    def test_get_cipher_version(self):
+    def test_get_cipher_version(self) -> None:
         """
         `Connection.get_cipher_version` returns a `unicode` string giving
         the protocol name of the currently used cipher.
@@ -3038,7 +3040,7 @@ class TestConnection:
 
         assert server_cipher_version == client_cipher_version
 
-    def test_get_cipher_bits_before_connect(self):
+    def test_get_cipher_bits_before_connect(self) -> None:
         """
         `Connection.get_cipher_bits` returns `None` if no connection has
         been established.
@@ -3047,7 +3049,7 @@ class TestConnection:
         conn = Connection(ctx, None)
         assert conn.get_cipher_bits() is None
 
-    def test_get_cipher_bits(self):
+    def test_get_cipher_bits(self) -> None:
         """
         `Connection.get_cipher_bits` returns the number of secret bits
         of the currently used cipher.
@@ -3063,7 +3065,7 @@ class TestConnection:
 
         assert server_cipher_bits == client_cipher_bits
 
-    def test_get_protocol_version_name(self):
+    def test_get_protocol_version_name(self) -> None:
         """
         `Connection.get_protocol_version_name()` returns a string giving the
         protocol version of the current connection.
@@ -3077,7 +3079,7 @@ class TestConnection:
 
         assert server_protocol_version_name == client_protocol_version_name
 
-    def test_get_protocol_version(self):
+    def test_get_protocol_version(self) -> None:
         """
         `Connection.get_protocol_version()` returns an integer
         giving the protocol version of the current connection.
@@ -3091,7 +3093,7 @@ class TestConnection:
 
         assert server_protocol_version == client_protocol_version
 
-    def test_wantReadError(self):
+    def test_wantReadError(self) -> None:
         """
         `Connection.bio_read` raises `OpenSSL.SSL.WantReadError` if there are
         no bytes available to be read from the BIO.
@@ -3102,7 +3104,7 @@ class TestConnection:
             conn.bio_read(1024)
 
     @pytest.mark.parametrize("bufsize", [1.0, None, object(), "bufsize"])
-    def test_bio_read_wrong_args(self, bufsize):
+    def test_bio_read_wrong_args(self, bufsize) -> None:
         """
         `Connection.bio_read` raises `TypeError` if passed a non-integer
         argument.
@@ -3112,7 +3114,7 @@ class TestConnection:
         with pytest.raises(TypeError):
             conn.bio_read(bufsize)
 
-    def test_buffer_size(self):
+    def test_buffer_size(self) -> None:
         """
         `Connection.bio_read` accepts an integer giving the maximum number
         of bytes to read and return.
@@ -3133,7 +3135,7 @@ class TestConnectionGetCipherList:
     Tests for `Connection.get_cipher_list`.
     """
 
-    def test_result(self):
+    def test_result(self) -> None:
         """
         `Connection.get_cipher_list` returns a list of `bytes` giving the
         names of the ciphers which might be used.
@@ -3159,7 +3161,7 @@ class TestConnectionSend:
     Tests for `Connection.send`.
     """
 
-    def test_wrong_args(self):
+    def test_wrong_args(self) -> None:
         """
         When called with arguments other than string argument for its first
         parameter, `Connection.send` raises `TypeError`.
@@ -3170,7 +3172,7 @@ class TestConnectionSend:
         with pytest.raises(TypeError):
             connection.send([1, 2, 3])
 
-    def test_short_bytes(self):
+    def test_short_bytes(self) -> None:
         """
         When passed a short byte string, `Connection.send` transmits all of it
         and returns the number of bytes sent.
@@ -3180,7 +3182,7 @@ class TestConnectionSend:
         assert count == 2
         assert client.recv(2) == b"xy"
 
-    def test_text(self):
+    def test_text(self) -> None:
         """
         When passed a text, `Connection.send` transmits all of it and
         returns the number of bytes sent. It also raises a DeprecationWarning.
@@ -3195,7 +3197,7 @@ class TestConnectionSend:
         assert count == 2
         assert client.recv(2) == b"xy"
 
-    def test_short_memoryview(self):
+    def test_short_memoryview(self) -> None:
         """
         When passed a memoryview onto a small number of bytes,
         `Connection.send` transmits all of them and returns the number
@@ -3206,7 +3208,7 @@ class TestConnectionSend:
         assert count == 2
         assert client.recv(2) == b"xy"
 
-    def test_short_bytearray(self):
+    def test_short_bytearray(self) -> None:
         """
         When passed a short bytearray, `Connection.send` transmits all of
         it and returns the number of bytes sent.
@@ -3220,7 +3222,7 @@ class TestConnectionSend:
         sys.maxsize < 2**31,
         reason="sys.maxsize < 2**31 - test requires 64 bit",
     )
-    def test_buf_too_large(self):
+    def test_buf_too_large(self) -> None:
         """
         When passed a buffer containing >= 2**31 bytes,
         `Connection.send` bails out as SSL_write only
@@ -3259,7 +3261,7 @@ class TestConnectionRecvInto:
         assert client.recv_into(output_buffer) == 2
         assert output_buffer == bytearray(b"xy\x00\x00\x00")
 
-    def test_bytearray_no_length(self):
+    def test_bytearray_no_length(self) -> None:
         """
         `Connection.recv_into` can be passed a `bytearray` instance and data
         in the receive buffer is written to it.
@@ -3280,7 +3282,7 @@ class TestConnectionRecvInto:
         assert client.recv_into(output_buffer, 5) == 5
         assert output_buffer == bytearray(b"abcde\x00\x00\x00\x00\x00")
 
-    def test_bytearray_respects_length(self):
+    def test_bytearray_respects_length(self) -> None:
         """
         When called with a `bytearray` instance, `Connection.recv_into`
         respects the `nbytes` parameter and doesn't copy in more than that
@@ -3304,7 +3306,7 @@ class TestConnectionRecvInto:
         rest = client.recv(5)
         assert b"fghij" == rest
 
-    def test_bytearray_doesnt_overfill(self):
+    def test_bytearray_doesnt_overfill(self) -> None:
         """
         When called with a `bytearray` instance, `Connection.recv_into`
         respects the size of the array and doesn't write more bytes into it
@@ -3312,7 +3314,7 @@ class TestConnectionRecvInto:
         """
         self._doesnt_overfill_test(bytearray)
 
-    def test_bytearray_really_doesnt_overfill(self):
+    def test_bytearray_really_doesnt_overfill(self) -> None:
         """
         When called with a `bytearray` instance and an `nbytes` value that is
         too large, `Connection.recv_into` respects the size of the array and
@@ -3321,7 +3323,7 @@ class TestConnectionRecvInto:
         """
         self._doesnt_overfill_test(bytearray)
 
-    def test_peek(self):
+    def test_peek(self) -> None:
         server, client = loopback()
         server.send(b"xy")
 
@@ -3330,14 +3332,14 @@ class TestConnectionRecvInto:
             assert client.recv_into(output_buffer, flags=MSG_PEEK) == 2
             assert output_buffer == bytearray(b"xy\x00\x00\x00")
 
-    def test_memoryview_no_length(self):
+    def test_memoryview_no_length(self) -> None:
         """
         `Connection.recv_into` can be passed a `memoryview` instance and data
         in the receive buffer is written to it.
         """
         self._no_length_test(_make_memoryview)
 
-    def test_memoryview_respects_length(self):
+    def test_memoryview_respects_length(self) -> None:
         """
         When called with a `memoryview` instance, `Connection.recv_into`
         respects the ``nbytes`` parameter and doesn't copy more than that
@@ -3345,7 +3347,7 @@ class TestConnectionRecvInto:
         """
         self._respects_length_test(_make_memoryview)
 
-    def test_memoryview_doesnt_overfill(self):
+    def test_memoryview_doesnt_overfill(self) -> None:
         """
         When called with a `memoryview` instance, `Connection.recv_into`
         respects the size of the array and doesn't write more bytes into it
@@ -3353,7 +3355,7 @@ class TestConnectionRecvInto:
         """
         self._doesnt_overfill_test(_make_memoryview)
 
-    def test_memoryview_really_doesnt_overfill(self):
+    def test_memoryview_really_doesnt_overfill(self) -> None:
         """
         When called with a `memoryview` instance and an `nbytes` value that is
         too large, `Connection.recv_into` respects the size of the array and
@@ -3368,7 +3370,7 @@ class TestConnectionSendall:
     Tests for `Connection.sendall`.
     """
 
-    def test_wrong_args(self):
+    def test_wrong_args(self) -> None:
         """
         When called with arguments other than a string argument for its first
         parameter, `Connection.sendall` raises `TypeError`.
@@ -3379,7 +3381,7 @@ class TestConnectionSendall:
         with pytest.raises(TypeError):
             connection.sendall([1, 2, 3])
 
-    def test_short(self):
+    def test_short(self) -> None:
         """
         `Connection.sendall` transmits all of the bytes in the string
         passed to it.
@@ -3388,7 +3390,7 @@ class TestConnectionSendall:
         server.sendall(b"x")
         assert client.recv(1) == b"x"
 
-    def test_text(self):
+    def test_text(self) -> None:
         """
         `Connection.sendall` transmits all the content in the string passed
         to it, raising a DeprecationWarning in case of this being a text.
@@ -3402,7 +3404,7 @@ class TestConnectionSendall:
             ) == str(w[-1].message)
         assert client.recv(1) == b"x"
 
-    def test_short_memoryview(self):
+    def test_short_memoryview(self) -> None:
         """
         When passed a memoryview onto a small number of bytes,
         `Connection.sendall` transmits all of them.
@@ -3411,7 +3413,7 @@ class TestConnectionSendall:
         server.sendall(memoryview(b"x"))
         assert client.recv(1) == b"x"
 
-    def test_long(self):
+    def test_long(self) -> None:
         """
         `Connection.sendall` transmits all the bytes in the string passed to it
         even if this requires multiple calls of an underlying write function.
@@ -3430,7 +3432,7 @@ class TestConnectionSendall:
             received += len(data)
         assert message == b"".join(accum)
 
-    def test_closed(self):
+    def test_closed(self) -> None:
         """
         If the underlying socket is closed, `Connection.sendall` propagates the
         write error from the low level write call.
@@ -3450,7 +3452,7 @@ class TestConnectionRenegotiate:
     Tests for SSL renegotiation APIs.
     """
 
-    def test_total_renegotiations(self):
+    def test_total_renegotiations(self) -> None:
         """
         `Connection.total_renegotiations` returns `0` before any renegotiations
         have happened.
@@ -3458,7 +3460,7 @@ class TestConnectionRenegotiate:
         connection = Connection(Context(SSLv23_METHOD), None)
         assert connection.total_renegotiations() == 0
 
-    def test_renegotiate(self):
+    def test_renegotiate(self) -> None:
         """
         Go through a complete renegotiation cycle.
         """
@@ -3494,7 +3496,7 @@ class TestError:
     Unit tests for `OpenSSL.SSL.Error`.
     """
 
-    def test_type(self):
+    def test_type(self) -> None:
         """
         `Error` is an exception type.
         """
@@ -3515,7 +3517,7 @@ class TestConstants:
         OP_NO_QUERY_MTU is None,
         reason="OP_NO_QUERY_MTU unavailable - OpenSSL version may be too old",
     )
-    def test_op_no_query_mtu(self):
+    def test_op_no_query_mtu(self) -> None:
         """
         The value of `OpenSSL.SSL.OP_NO_QUERY_MTU` is 0x1000, the value
         of `SSL_OP_NO_QUERY_MTU` defined by `openssl/ssl.h`.
@@ -3527,7 +3529,7 @@ class TestConstants:
         reason="OP_COOKIE_EXCHANGE unavailable - "
         "OpenSSL version may be too old",
     )
-    def test_op_cookie_exchange(self):
+    def test_op_cookie_exchange(self) -> None:
         """
         The value of `OpenSSL.SSL.OP_COOKIE_EXCHANGE` is 0x2000, the
         value of `SSL_OP_COOKIE_EXCHANGE` defined by `openssl/ssl.h`.
@@ -3538,7 +3540,7 @@ class TestConstants:
         OP_NO_TICKET is None,
         reason="OP_NO_TICKET unavailable - OpenSSL version may be too old",
     )
-    def test_op_no_ticket(self):
+    def test_op_no_ticket(self) -> None:
         """
         The value of `OpenSSL.SSL.OP_NO_TICKET` is 0x4000, the value of
         `SSL_OP_NO_TICKET` defined by `openssl/ssl.h`.
@@ -3551,42 +3553,42 @@ class TestConstants:
             "OP_NO_COMPRESSION unavailable - OpenSSL version may be too old"
         ),
     )
-    def test_op_no_compression(self):
+    def test_op_no_compression(self) -> None:
         """
         The value of `OpenSSL.SSL.OP_NO_COMPRESSION` is 0x20000, the
         value of `SSL_OP_NO_COMPRESSION` defined by `openssl/ssl.h`.
         """
         assert OP_NO_COMPRESSION == 0x20000
 
-    def test_sess_cache_off(self):
+    def test_sess_cache_off(self) -> None:
         """
         The value of `OpenSSL.SSL.SESS_CACHE_OFF` 0x0, the value of
         `SSL_SESS_CACHE_OFF` defined by `openssl/ssl.h`.
         """
         assert 0x0 == SESS_CACHE_OFF
 
-    def test_sess_cache_client(self):
+    def test_sess_cache_client(self) -> None:
         """
         The value of `OpenSSL.SSL.SESS_CACHE_CLIENT` 0x1, the value of
         `SSL_SESS_CACHE_CLIENT` defined by `openssl/ssl.h`.
         """
         assert 0x1 == SESS_CACHE_CLIENT
 
-    def test_sess_cache_server(self):
+    def test_sess_cache_server(self) -> None:
         """
         The value of `OpenSSL.SSL.SESS_CACHE_SERVER` 0x2, the value of
         `SSL_SESS_CACHE_SERVER` defined by `openssl/ssl.h`.
         """
         assert 0x2 == SESS_CACHE_SERVER
 
-    def test_sess_cache_both(self):
+    def test_sess_cache_both(self) -> None:
         """
         The value of `OpenSSL.SSL.SESS_CACHE_BOTH` 0x3, the value of
         `SSL_SESS_CACHE_BOTH` defined by `openssl/ssl.h`.
         """
         assert 0x3 == SESS_CACHE_BOTH
 
-    def test_sess_cache_no_auto_clear(self):
+    def test_sess_cache_no_auto_clear(self) -> None:
         """
         The value of `OpenSSL.SSL.SESS_CACHE_NO_AUTO_CLEAR` 0x80, the
         value of `SSL_SESS_CACHE_NO_AUTO_CLEAR` defined by
@@ -3594,7 +3596,7 @@ class TestConstants:
         """
         assert 0x80 == SESS_CACHE_NO_AUTO_CLEAR
 
-    def test_sess_cache_no_internal_lookup(self):
+    def test_sess_cache_no_internal_lookup(self) -> None:
         """
         The value of `OpenSSL.SSL.SESS_CACHE_NO_INTERNAL_LOOKUP` 0x100,
         the value of `SSL_SESS_CACHE_NO_INTERNAL_LOOKUP` defined by
@@ -3602,7 +3604,7 @@ class TestConstants:
         """
         assert 0x100 == SESS_CACHE_NO_INTERNAL_LOOKUP
 
-    def test_sess_cache_no_internal_store(self):
+    def test_sess_cache_no_internal_store(self) -> None:
         """
         The value of `OpenSSL.SSL.SESS_CACHE_NO_INTERNAL_STORE` 0x200,
         the value of `SSL_SESS_CACHE_NO_INTERNAL_STORE` defined by
@@ -3610,7 +3612,7 @@ class TestConstants:
         """
         assert 0x200 == SESS_CACHE_NO_INTERNAL_STORE
 
-    def test_sess_cache_no_internal(self):
+    def test_sess_cache_no_internal(self) -> None:
         """
         The value of `OpenSSL.SSL.SESS_CACHE_NO_INTERNAL` 0x300, the
         value of `SSL_SESS_CACHE_NO_INTERNAL` defined by
@@ -3676,7 +3678,7 @@ class TestMemoryBIO:
         client_conn.set_connect_state()
         return client_conn
 
-    def test_memory_connect(self):
+    def test_memory_connect(self) -> None:
         """
         Two `Connection`s which use memory BIOs can be manually connected by
         reading from the output of each and writing those bytes to the input of
@@ -3742,7 +3744,7 @@ class TestMemoryBIO:
             important_message[::-1],
         )
 
-    def test_socket_connect(self):
+    def test_socket_connect(self) -> None:
         """
         Just like `test_memory_connect` but with an actual socket.
 
@@ -3765,7 +3767,7 @@ class TestMemoryBIO:
         msg = client_conn.recv(1024)
         assert msg == important_message
 
-    def test_socket_overrides_memory(self):
+    def test_socket_overrides_memory(self) -> None:
         """
         Test that `OpenSSL.SSL.bio_read` and `OpenSSL.SSL.bio_write` don't
         work on `OpenSSL.SSL.Connection`() that use sockets.
@@ -3780,7 +3782,7 @@ class TestMemoryBIO:
         with pytest.raises(TypeError):
             clientSSL.bio_shutdown()
 
-    def test_outgoing_overflow(self):
+    def test_outgoing_overflow(self) -> None:
         """
         If more bytes than can be written to the memory BIO are passed to
         `Connection.send` at once, the number of bytes which were written is
@@ -3806,7 +3808,7 @@ class TestMemoryBIO:
         # loopback passes 2 ** 16 to recv - more than 2 ** 15.
         assert len(received) == sent
 
-    def test_shutdown(self):
+    def test_shutdown(self) -> None:
         """
         `Connection.bio_shutdown` signals the end of the data stream
         from which the `Connection` reads.
@@ -3819,7 +3821,7 @@ class TestMemoryBIO:
         # handshake failure.
         assert type(err.value) in [Error, SysCallError]
 
-    def test_unexpected_EOF(self):
+    def test_unexpected_EOF(self) -> None:
         """
         If the connection is lost before an orderly SSL shutdown occurs,
         `OpenSSL.SSL.SysCallError` is raised with a message of
@@ -3861,7 +3863,7 @@ class TestMemoryBIO:
         assert client.get_client_ca_list() == expected
         assert server.get_client_ca_list() == expected
 
-    def test_set_client_ca_list_errors(self):
+    def test_set_client_ca_list_errors(self) -> None:
         """
         `Context.set_client_ca_list` raises a `TypeError` if called with a
         non-list or a list that contains objects other than X509Names.
@@ -3872,7 +3874,7 @@ class TestMemoryBIO:
         with pytest.raises(TypeError):
             ctx.set_client_ca_list(["spam"])
 
-    def test_set_empty_ca_list(self):
+    def test_set_empty_ca_list(self) -> None:
         """
         If passed an empty list, `Context.set_client_ca_list` configures the
         context to send no CA names to the client and, on both the server and
@@ -3886,7 +3888,7 @@ class TestMemoryBIO:
 
         self._check_client_ca_list(no_ca)
 
-    def test_set_one_ca_list(self):
+    def test_set_one_ca_list(self) -> None:
         """
         If passed a list containing a single X509Name,
         `Context.set_client_ca_list` configures the context to send
@@ -3903,7 +3905,7 @@ class TestMemoryBIO:
 
         self._check_client_ca_list(single_ca)
 
-    def test_set_multiple_ca_list(self):
+    def test_set_multiple_ca_list(self) -> None:
         """
         If passed a list containing multiple X509Name objects,
         `Context.set_client_ca_list` configures the context to send
@@ -3924,7 +3926,7 @@ class TestMemoryBIO:
 
         self._check_client_ca_list(multiple_ca)
 
-    def test_reset_ca_list(self):
+    def test_reset_ca_list(self) -> None:
         """
         If called multiple times, only the X509Names passed to the final call
         of `Context.set_client_ca_list` are used to configure the CA
@@ -3945,7 +3947,7 @@ class TestMemoryBIO:
 
         self._check_client_ca_list(changed_ca)
 
-    def test_mutated_ca_list(self):
+    def test_mutated_ca_list(self) -> None:
         """
         If the list passed to `Context.set_client_ca_list` is mutated
         afterwards, this does not affect the list of CA names sent to the
@@ -3965,7 +3967,7 @@ class TestMemoryBIO:
 
         self._check_client_ca_list(mutated_ca)
 
-    def test_add_client_ca_wrong_args(self):
+    def test_add_client_ca_wrong_args(self) -> None:
         """
         `Context.add_client_ca` raises `TypeError` if called with
         a non-X509 object.
@@ -3974,7 +3976,7 @@ class TestMemoryBIO:
         with pytest.raises(TypeError):
             ctx.add_client_ca("spam")
 
-    def test_one_add_client_ca(self):
+    def test_one_add_client_ca(self) -> None:
         """
         A certificate's subject can be added as a CA to be sent to the client
         with `Context.add_client_ca`.
@@ -3988,7 +3990,7 @@ class TestMemoryBIO:
 
         self._check_client_ca_list(single_ca)
 
-    def test_multiple_add_client_ca(self):
+    def test_multiple_add_client_ca(self) -> None:
         """
         Multiple CA names can be sent to the client by calling
         `Context.add_client_ca` with multiple X509 objects.
@@ -4006,7 +4008,7 @@ class TestMemoryBIO:
 
         self._check_client_ca_list(multiple_ca)
 
-    def test_set_and_add_client_ca(self):
+    def test_set_and_add_client_ca(self) -> None:
         """
         A call to `Context.set_client_ca_list` followed by a call to
         `Context.add_client_ca` results in using the CA names from the
@@ -4027,7 +4029,7 @@ class TestMemoryBIO:
 
         self._check_client_ca_list(mixed_set_add_ca)
 
-    def test_set_after_add_client_ca(self):
+    def test_set_after_add_client_ca(self) -> None:
         """
         A call to `Context.set_client_ca_list` after a call to
         `Context.add_client_ca` replaces the CA name specified by the
@@ -4054,7 +4056,7 @@ class TestInfoConstants:
     Tests for assorted constants exposed for use in info callbacks.
     """
 
-    def test_integers(self):
+    def test_integers(self) -> None:
         """
         All of the info constants are integers.
 
@@ -4098,7 +4100,7 @@ class TestRequires:
     NotImplementedError when older OpenSSLs are used.
     """
 
-    def test_available(self):
+    def test_available(self) -> None:
         """
         When the OpenSSL functionality is available the decorated functions
         work appropriately.
@@ -4114,7 +4116,7 @@ class TestRequires:
         assert inner() is True
         assert [True] == results
 
-    def test_unavailable(self):
+    def test_unavailable(self) -> None:
         """
         When the OpenSSL functionality is not available the decorated function
         does not execute and NotImplementedError is raised.
@@ -4174,7 +4176,7 @@ class TestOCSP:
         server.set_accept_state()
         return server
 
-    def test_callbacks_arent_called_by_default(self):
+    def test_callbacks_arent_called_by_default(self) -> None:
         """
         If both the client and the server have registered OCSP callbacks, but
         the client does not send the OCSP request, neither callback gets
@@ -4190,7 +4192,7 @@ class TestOCSP:
         server = self._server_connection(callback=ocsp_callback, data=None)
         handshake_in_memory(client, server)
 
-    def test_client_negotiates_without_server(self):
+    def test_client_negotiates_without_server(self) -> None:
         """
         If the client wants to do OCSP but the server does not, the handshake
         succeeds, and the client callback fires with an empty byte string.
@@ -4208,7 +4210,7 @@ class TestOCSP:
         assert len(called) == 1
         assert called[0] == b""
 
-    def test_client_receives_servers_data(self):
+    def test_client_receives_servers_data(self) -> None:
         """
         The data the server sends in its callback is received by the client.
         """
@@ -4228,7 +4230,7 @@ class TestOCSP:
         assert len(calls) == 1
         assert calls[0] == self.sample_ocsp_data
 
-    def test_callbacks_are_invoked_with_connections(self):
+    def test_callbacks_are_invoked_with_connections(self) -> None:
         """
         The first arguments to both callbacks are their respective connections.
         """
@@ -4252,7 +4254,7 @@ class TestOCSP:
         assert client_calls[0] is client
         assert server_calls[0] is server
 
-    def test_opaque_data_is_passed_through(self):
+    def test_opaque_data_is_passed_through(self) -> None:
         """
         Both callbacks receive an opaque, user-provided piece of data in their
         callbacks as the final argument.
@@ -4281,7 +4283,7 @@ class TestOCSP:
         assert calls[0][-1] is sentinel
         assert calls[1][-1] is sentinel
 
-    def test_server_returns_empty_string(self):
+    def test_server_returns_empty_string(self) -> None:
         """
         If the server returns an empty bytestring from its callback, the
         client callback is called with the empty bytestring.
@@ -4302,7 +4304,7 @@ class TestOCSP:
         assert len(client_calls) == 1
         assert client_calls[0] == b""
 
-    def test_client_returns_false_terminates_handshake(self):
+    def test_client_returns_false_terminates_handshake(self) -> None:
         """
         If the client returns False from its callback, the handshake fails.
         """
@@ -4319,7 +4321,7 @@ class TestOCSP:
         with pytest.raises(Error):
             handshake_in_memory(client, server)
 
-    def test_exceptions_in_client_bubble_up(self):
+    def test_exceptions_in_client_bubble_up(self) -> None:
         """
         The callbacks thrown in the client callback bubble up to the caller.
         """
@@ -4339,7 +4341,7 @@ class TestOCSP:
         with pytest.raises(SentinelException):
             handshake_in_memory(client, server)
 
-    def test_exceptions_in_server_bubble_up(self):
+    def test_exceptions_in_server_bubble_up(self) -> None:
         """
         The callbacks thrown in the server callback bubble up to the caller.
         """
@@ -4359,7 +4361,7 @@ class TestOCSP:
         with pytest.raises(SentinelException):
             handshake_in_memory(client, server)
 
-    def test_server_must_return_bytes(self):
+    def test_server_must_return_bytes(self) -> None:
         """
         The server callback must return a bytestring, or a TypeError is thrown.
         """
@@ -4568,13 +4570,13 @@ class TestDTLS:
         c.set_ciphertext_mtu(500)
         assert 0 < c.get_cleartext_mtu() < 500
 
-    def test_it_works_at_all(self):
+    def test_it_works_at_all(self) -> None:
         self._test_handshake_and_data(srtp_profile=None)
 
-    def test_it_works_with_srtp(self):
+    def test_it_works_with_srtp(self) -> None:
         self._test_handshake_and_data(srtp_profile=b"SRTP_AES128_CM_SHA1_80")
 
-    def test_timeout(self, monkeypatch):
+    def test_timeout(self, monkeypatch) -> None:
         c_ctx = Context(DTLS_METHOD)
         c = Connection(c_ctx)
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -10,7 +10,7 @@ U{Twisted<http://twistedmatrix.com/>}.
 NON_ASCII = b"\xe2\x98\x83".decode("utf-8")
 
 
-def is_consistent_type(theType, name, *constructionArgs):
+def is_consistent_type(theType, name, *constructionArgs) -> bool:
     """
     Perform various assertions about *theType* to ensure that it is a
     well-defined type.  This is useful for extension types, where it's


### PR DESCRIPTION
This is part of a gradual effort to make our tests type checkable, which will help catch bugs.