### PR TITLE
Remove use of OpenSSL APIs that aren't useful

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1031,13 +1031,7 @@ class Context:
         # First we'll check to see if any env vars have been set. If so,
         # we won't try to do anything else because the user has set the path
         # themselves.
-        dir_env_var = _ffi.string(_lib.X509_get_default_cert_dir_env()).decode(
-            "ascii"
-        )
-        file_env_var = _ffi.string(
-            _lib.X509_get_default_cert_file_env()
-        ).decode("ascii")
-        if not self._check_env_vars_set(dir_env_var, file_env_var):
+        if not self._check_env_vars_set("SSL_CERT_DIR", "SSL_CERT_FILE"):
             default_dir = _ffi.string(_lib.X509_get_default_cert_dir())
             default_file = _ffi.string(_lib.X509_get_default_cert_file())
             # Now we check to see if the default_dir and default_file are set

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1283,14 +1283,8 @@ class TestContext:
         monkeypatch.setattr(
             _lib, "SSL_CTX_set_default_verify_paths", lambda x: 1
         )
-        dir_env_var = _ffi.string(_lib.X509_get_default_cert_dir_env()).decode(
-            "ascii"
-        )
-        file_env_var = _ffi.string(
-            _lib.X509_get_default_cert_file_env()
-        ).decode("ascii")
-        monkeypatch.setenv(dir_env_var, "value")
-        monkeypatch.setenv(file_env_var, "value")
+        monkeypatch.setenv("SSL_CERT_DIR", "value")
+        monkeypatch.setenv("SSL_CERT_FILE", "value")
         context.set_default_verify_paths()
 
         monkeypatch.setattr(


### PR DESCRIPTION
Per https://github.com/pyca/cryptography/issues/12223 these always return constant strings