### PR TITLE
correct Homebrew SSL formula version

### DIFF
--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1046,7 +1046,7 @@ class Context:
         binary wheels that cryptography (pyOpenSSL's primary dependency) ships:
 
         *   macOS will only load certificates using this method if the user has
-            the ``openssl@1.1`` `Homebrew <https://brew.sh>`_ formula installed
+            the ``openssl@3`` `Homebrew <https://brew.sh>`_ formula installed
             in the default location.
         *   Windows will not work.
         *   manylinux cryptography wheels will work on most common Linux


### PR DESCRIPTION
I don't have `openssl@1.1` installed, and yet, this works for me.