### PR TITLE
Add methods related to client hello callback

### DIFF
--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -2313,6 +2313,60 @@ class TestApplicationLayerProtoNegotiation:
             interact_in_memory(server, client)
         assert select_args == [(server, [b"http/1.1", b"spdy/2"])]
 
+    @pytest.mark.skipif(
+        not getattr(_lib, "Cryptography_HAS_CLIENT_HELLO_CB", None),
+        reason="Client hello callback unavailable in crypto library",
+    )
+    def test_client_hello_callback(self) -> None:
+        """
+        We can handle exceptions in the ALPN select callback.
+        """
+        client_hello_extensions = {}
+
+        def client_hello_callback(conn: Connection) -> None:
+            for ext in conn.get_client_hello_extensions_present():
+                client_hello_extensions[ext] = conn.get_client_hello_extension(
+                    ext
+                )
+
+        client_context = Context(SSLv23_METHOD)
+        client_context.set_alpn_protos([b"http/1.1", b"spdy/2"])
+
+        server_context = Context(SSLv23_METHOD)
+        server_context.set_ssl_ctx_client_hello_callback(client_hello_callback)
+
+        # Necessary to actually accept the connection
+        server_context.use_privatekey(
+            load_privatekey(FILETYPE_PEM, server_key_pem)
+        )
+        server_context.use_certificate(
+            load_certificate(FILETYPE_PEM, server_cert_pem)
+        )
+
+        # Do a little connection to trigger the logic
+        server = Connection(server_context, None)
+        server.set_accept_state()
+
+        client = Connection(client_context, None)
+        client.set_tlsext_host_name(b"unitest.example.com")
+        client.set_connect_state()
+
+        interact_in_memory(server, client)
+
+        # Servername indication has extensions number 0
+        # ALPN has extension number 16
+        assert 0 in client_hello_extensions
+        assert 16 in client_hello_extensions
+
+        # OpenSSL does not expose good APIs to parse hello extensions. Instead
+        # of implementing parsing them just for the unit test we hardcode the
+        # string we expect to see
+        assert (
+            client_hello_extensions[0]
+            == b"\x00\x16\x00\x00\x13unitest.example.com"
+        )
+        assert client_hello_extensions[16] == b"\x00\x10\x08http/1.1\x06spdy/2"
+
 
 class TestSession:
     """


### PR DESCRIPTION
These methods allow a server to switch the context when looking at ALPN and servername together. This is for example require when implementing the ACME tls-alpn/1 protocol.

Unfortunately, OpenSSL does not provide any utility function to actually parse ClientHello extensions when using these APIs and the user has to write their own methods.

Closes: [1430](https://github.com/pyca/pyopenssl/issues/1430)

This PR depends on https://github.com/pyca/cryptography/pull/13634 but I am not sure how to express that properly in the build files.