### PR TITLE
Add note on versioning policy

### DIFF
--- a/doc/backward-compatibility.rst
+++ b/doc/backward-compatibility.rst
@@ -9,3 +9,10 @@ If breaking changes are needed do be done, they are:
 #. …announced in the :doc:`changelog`.
 #. …the old behavior raises a :exc:`DeprecationWarning` for a year.
 #. …are done with another announcement in the :doc:`changelog`.
+
+Versioning Policy
+=================
+
+pyOpenSSL follows `CalVer <https://calver.org>`_ in `YY.MINOR.MICRO` format.
+Unlike SemVer, major versions represent the year, and are not indicative of
+breaking changes.


### PR DESCRIPTION
Specifically, this note calls out SemVer and how major versions do not indicate breaking changes.

See https://github.com/pyca/pyopenssl/issues/1493#issuecomment-4245306095

@reaperhulk Please review.