### PR TITLE
Prepare 26.1.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,21 @@ Changelog
 Versions are year-based with a strict backward-compatibility policy.
 The third digit is only for regressions.
 
+26.1.0 (2026-04-24)
+-------------------
+
+Backward-incompatible changes:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Deprecations:
+^^^^^^^^^^^^^
+
+Changes:
+^^^^^^^^
+
+- Maximum supported ``cryptography`` version is now 47.x.
+- Fixed ``X509Name`` field setters to correctly pass the value length to OpenSSL. Previously, values containing NUL bytes would be silently truncated, causing a divergence between the stored ASN.1 value and the value visible from Python. Credit to **BudongJW** for reporting the issue. **CVE-2026-40475**
+
 26.0.0 (2026-03-15)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
         packages=find_packages(where="src"),
         package_dir={"": "src"},
         install_requires=[
-            "cryptography>=46.0.0,<47",
+            "cryptography>=46.0.0,<48",
             (
                 "typing-extensions>=4.9; "
                 "python_version < '3.13' and python_version >= '3.8'"

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -651,7 +651,7 @@ class X509Name:
             value = value.encode("utf-8")
 
         add_result = _lib.X509_NAME_add_entry_by_NID(
-            self._name, nid, _lib.MBSTRING_UTF8, value, -1, -1, 0
+            self._name, nid, _lib.MBSTRING_UTF8, value, len(value), -1, 0
         )
         if not add_result:
             _raise_current_error()

--- a/src/OpenSSL/version.py
+++ b/src/OpenSSL/version.py
@@ -17,7 +17,7 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "26.0.0"
+__version__ = "26.1.0"
 
 __title__ = "pyOpenSSL"
 __uri__ = "https://pyopenssl.org/"

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1403,6 +1403,14 @@ class TestX509Name:
         name.emailAddress = "quux@example.com"
         assert copy.emailAddress == "bar@example.com"
 
+    def test_null_bytes_preserved(self) -> None:
+        """
+        Null bytes in X509Name field values are round-tripped correctly.
+        """
+        name = x509_name()
+        name.CN = "a\x00b"
+        assert name.CN == "a\x00b"
+
     def test_repr(self) -> None:
         """
         `repr` passed an `X509Name` instance should return a string containing

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -4686,7 +4686,11 @@ class TestOCSP:
     Tests for PyOpenSSL's OCSP stapling support.
     """
 
-    sample_ocsp_data = b"this is totally ocsp data"
+    # Minimal valid DER-encoded OCSPResponse with status "unauthorized"
+    # (SEQUENCE { ENUMERATED 6 }). Required by OpenSSL 4.0+, which parses
+    # the bytes via d2i_OCSP_RESPONSE before stapling and silently drops
+    # unparseable input.
+    sample_ocsp_data = b"\x30\x03\x0a\x01\x06"
 
     def _client_connection(
         self,


### PR DESCRIPTION
Fixes X509Name NUL-byte truncation (CVE-2026-40475), raises the maximum supported cryptography version to 47.x, and bumps the version to 26.1.0.