### PR TITLE
Prepare 26.2.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,8 @@ Changelog
 Versions are year-based with a strict backward-compatibility policy.
 The third digit is only for regressions.
 
-UNRELEASED
-----------
+26.2.0 (2026-05-04)
+-------------------
 
 Backward-incompatible changes:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,6 +19,7 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
+- Maximum supported ``cryptography`` version is now 48.x.
 - Added ``OpenSSL.SSL.Connection.set_options`` to set options on a per-connection basis.
 
 26.1.0 (2026-04-24)

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
         packages=find_packages(where="src"),
         package_dir={"": "src"},
         install_requires=[
-            "cryptography>=46.0.0,<48",
+            "cryptography>=46.0.0,<49",
             (
                 "typing-extensions>=4.9; "
                 "python_version < '3.13' and python_version >= '3.8'"

--- a/src/OpenSSL/version.py
+++ b/src/OpenSSL/version.py
@@ -17,7 +17,7 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "26.1.0"
+__version__ = "26.2.0"
 
 __title__ = "pyOpenSSL"
 __uri__ = "https://pyopenssl.org/"


### PR DESCRIPTION
## Summary
- Raised the maximum supported `cryptography` version to 48.x (`setup.py`).
- Bumped `__version__` to `26.2.0`.
- Converted the `UNRELEASED` changelog section to `26.2.0 (2026-05-04)` and added an entry for the cryptography bump.

## Test plan
- [ ] CI passes against `cryptography` 48.x.
- [ ] Existing tests continue to pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4AHNnr8r2td6noARRySp5)_