### PR TITLE
Fix zizmor findings in GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       - "/.github/actions/*/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ on:
   pull_request: {}
   push: {}
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     runs-on: ${{ matrix.PYTHON.OS || 'ubuntu-latest' }}
@@ -52,15 +55,17 @@ jobs:
           - {VERSION: "3.13", NOXSESSION: "mypy"}
           - {VERSION: "3.9", NOXSESSION: "docs"}
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Setup python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
       - name: Cache custom OpenSSL
         if: matrix.PYTHON.OPENSSL
         id: ossl-cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/ossl
           key: ossl-${{ matrix.PYTHON.OPENSSL.TYPE }}-${{ matrix.PYTHON.OPENSSL.VERSION }}
@@ -93,7 +98,9 @@ jobs:
           - {CONTAINER: "ubuntu-rolling", NOXSESSION: "tests-cryptography-main"}
     name: "${{ matrix.TEST.NOXSESSION }} on ${{ matrix.TEST.CONTAINER }}"
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - run: /venv/bin/pip install nox
       - run: /venv/bin/nox
         env:
@@ -114,9 +121,11 @@ jobs:
           - 3.12
     name: "Downstream tests for ${{ matrix.DOWNSTREAM }}"
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Setup python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.PYTHON }}
       - run: ./.github/downstream.d/${{ matrix.DOWNSTREAM }}.sh install
@@ -134,7 +143,7 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v5.0.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         timeout-minutes: 3
         with:
           persist-credentials: false

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -10,7 +10,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v6
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: 90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v5.0.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
Fixes findings from running `zizmor` (v1.25.2) on the GitHub Actions workflows:

- **unpinned-uses**: Pin all actions to commit SHAs with version comments (`actions/checkout`, `actions/setup-python`, `actions/cache`, `dessant/lock-threads`)
- **excessive-permissions**: Add workflow-level `permissions: contents: read` to ci.yml (lock.yml and release.yml already declare permissions)
- **artipacked**: Set `persist-credentials: false` on all checkouts that didn't already have it

Also:
- Corrected stale `# v5.0.1` comments on existing `df4cb1c0` checkout pins — that SHA is actually what the `v6.0.3` tag points to (the SHAs themselves are unchanged)
- Added a 7-day Dependabot `cooldown` for GitHub Actions bumps, so new releases age a bit before being proposed (pairs with SHA-pinning)

The remaining `unpinned-images` finding (the `ghcr.io/pyca/cryptography-runner-*` container) is intentionally left as-is.

https://claude.ai/code/session_01G4WQ9tPWDinfLSX7VnvxPX

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4WQ9tPWDinfLSX7VnvxPX)_