### PR TITLE
Deprecate Context.set_passwd_cb

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Deprecations:
 - Deprecated ``OpenSSL.crypto.PKey.generate_key`` and ``OpenSSL.crypto.PKey.check``. The key generation and loading APIs in ``cryptography`` should be used instead.
 - Deprecated ``OpenSSL.crypto.dump_privatekey``. The serialization APIs on ``cryptography`` private key types should be used instead.
 - Deprecated all the mutable APIs on ``OpenSSL.crypto.X509``: ``set_version``, ``set_pubkey``, ``sign``, ``set_serial_number``, ``gmtime_adj_notAfter``, ``gmtime_adj_notBefore``, ``set_notBefore``, ``set_notAfter``, ``set_issuer``, and ``set_subject``. ``cryptography.x509.CertificateBuilder`` should be used instead.
+- Deprecated ``OpenSSL.SSL.Context.set_passwd_cb``. Users should decrypt and load their private keys themselves, with ``cryptography``'s key loading APIs, and then call ``OpenSSL.SSL.Context.use_privatekey``.
 
 Changes:
 ^^^^^^^^

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -13,6 +13,11 @@ from sys import platform
 from typing import Any, Callable, Optional, TypeVar
 from weakref import WeakValueDictionary
 
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
+
 from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric import ec
 
@@ -1016,6 +1021,11 @@ class Context:
             FILETYPE_PEM, wrapper, more_args=True, truncate=True
         )
 
+    @deprecated(
+        "Context.set_passwd_cb is deprecated. You should decrypt and load "
+        "your private key yourself, with cryptography's key loading APIs, "
+        "and then use Context.use_privatekey instead."
+    )
     @_require_not_used
     def set_passwd_cb(
         self,


### PR DESCRIPTION
Users should decrypt and load their private keys themselves, with cryptography's key loading APIs, and then call `Context.use_privatekey`.

Follows the same pattern as the recent `PKey.generate_key` and X509 mutable-API deprecations (`@deprecated` decorator, so the warning fires at runtime and mypy flags usage with `--enable-error-code deprecated`).

https://claude.ai/code/session_011XcX5MQzwFCnMNYP4pKP6V

---
_Generated by [Claude Code](https://claude.ai/code/session_011XcX5MQzwFCnMNYP4pKP6V)_