### PR TITLE
Require cryptography 49, drop Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         PYTHON:
           # Base builds
-          - {VERSION: "3.8", NOXSESSION: "tests"}
           - {VERSION: "3.9", NOXSESSION: "tests"}
           - {VERSION: "3.10", NOXSESSION: "tests"}
           - {VERSION: "3.11", NOXSESSION: "tests"}
@@ -35,7 +34,6 @@ jobs:
           - {VERSION: "3.14t", NOXSESSION: "tests-cryptography-main"}
           - {VERSION: "pypy-3.11", NOXSESSION: "tests-cryptography-main"}
           # -cryptography-minimum
-          - {VERSION: "3.8", NOXSESSION: "tests-cryptography-minimum"}
           - {VERSION: "3.9", NOXSESSION: "tests-cryptography-minimum"}
           - {VERSION: "3.10", NOXSESSION: "tests-cryptography-minimum"}
           - {VERSION: "3.11", NOXSESSION: "tests-cryptography-minimum"}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ The third digit is only for regressions.
 Backward-incompatible changes:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Dropped support for Python 3.8.
+- The minimum ``cryptography`` version is now 49.0.0.
 - Removed deprecated ``OpenSSL.crypto.X509Req``, ``OpenSSL.crypto.dump_certificate_request``, and ``OpenSSL.crypto.load_certificate_request``. ``cryptography.x509`` should be used instead.
 - ``OpenSSL.SSL.Connection.set_session`` now raises ``ValueError`` if the ``Session`` was obtained from a ``Connection`` that was using a different ``Context`` than this one. OpenSSL requires (but does not verify) that sessions only be re-used with a compatible ``SSL_CTX``, so this contract is now enforced.
 

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -14,7 +14,7 @@ Other OpenSSL wrappers for Python at the time were also limited, though in diffe
 Later it was maintained by `Jean-Paul Calderone`_ who among other things managed to make pyOpenSSL a pure Python project which the current maintainers are *very* grateful for.
 
 Over the time the standard library's ``ssl`` module improved, never reaching the completeness of pyOpenSSL's API coverage.
-pyOpenSSL remains the only choice for full-featured TLS code in Python versions 3.8+ and PyPy_.
+pyOpenSSL remains the only choice for full-featured TLS code in Python versions 3.9+ and PyPy_.
 
 
 Development

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,7 @@ import nox
 nox.options.reuse_existing_virtualenvs = True
 nox.options.default_venv_backend = "uv|virtualenv"
 
-MINIMUM_CRYPTOGRAPHY_VERSION = "46.0.0"
+MINIMUM_CRYPTOGRAPHY_VERSION = "49.0.0"
 
 
 @nox.session

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
             "Operating System :: Microsoft :: Windows",
             "Operating System :: POSIX",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
@@ -89,15 +88,12 @@ if __name__ == "__main__":
             "Topic :: Software Development :: Libraries :: Python Modules",
             "Topic :: System :: Networking",
         ],
-        python_requires=">=3.8",
+        python_requires=">=3.9",
         packages=find_packages(where="src"),
         package_dir={"": "src"},
         install_requires=[
-            "cryptography>=46.0.0,<49",
-            (
-                "typing-extensions>=4.9; "
-                "python_version < '3.13' and python_version >= '3.8'"
-            ),
+            "cryptography>=49.0.0,<50",
+            "typing-extensions>=4.9; python_version < '3.13'",
         ],
         extras_require={
             "test": ["pytest-rerunfailures", "pretend", "pytest>=3.0.1"],

--- a/src/OpenSSL/_util.py
+++ b/src/OpenSSL/_util.py
@@ -7,10 +7,7 @@ from typing import Any, Callable, NoReturn, Union
 
 from cryptography.hazmat.bindings.openssl.binding import Binding
 
-if sys.version_info >= (3, 9):
-    StrOrBytesPath = Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]
-else:
-    StrOrBytesPath = Union[str, bytes, os.PathLike]
+StrOrBytesPath = Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]
 
 binding = Binding()
 ffi = binding.ffi

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -16,11 +16,6 @@ from typing import (
 
 if sys.version_info >= (3, 13):
     from warnings import deprecated
-elif sys.version_info < (3, 8):
-    _T = typing.TypeVar("T")
-
-    def deprecated(msg: str, **kwargs: object) -> Callable[[_T], _T]:
-        return lambda f: f
 else:
     from typing_extensions import deprecated
 


### PR DESCRIPTION
- Bump the `cryptography` pin to `>=49.0.0,<50` now that 49 has been released, and update `MINIMUM_CRYPTOGRAPHY_VERSION` in the noxfile to match.
- Drop Python 3.8: `python_requires`, trove classifiers, the two 3.8 CI matrix rows, and the now-dead version gates (the `< (3, 8)` `deprecated` shim in `crypto.py` and the 3.9 `os.PathLike` gate in `_util.py`). The typing-extensions environment marker simplifies to just `python_version < '3.13'`.
- Changelog and docs updated accordingly.

https://claude.ai/code/session_01NiSGpbM6ady8SuJPmiZ9SP

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiSGpbM6ady8SuJPmiZ9SP)_