### PR TITLE
Deprecate X509Name and the remaining APIs that consume or return it

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Deprecations:
 - Deprecated ``OpenSSL.crypto.dump_privatekey``. The serialization APIs on ``cryptography`` private key types should be used instead.
 - Deprecated all the mutable APIs on ``OpenSSL.crypto.X509``: ``set_version``, ``set_pubkey``, ``sign``, ``set_serial_number``, ``gmtime_adj_notAfter``, ``gmtime_adj_notBefore``, ``set_notBefore``, ``set_notAfter``, ``set_issuer``, and ``set_subject``. ``cryptography.x509.CertificateBuilder`` should be used instead.
 - Deprecated ``OpenSSL.SSL.Context.set_passwd_cb``. Users should decrypt and load their private keys themselves, with ``cryptography``'s key loading APIs, and then call ``OpenSSL.SSL.Context.use_privatekey``.
+- Deprecated ``OpenSSL.crypto.X509Name``, as well as the remaining APIs that consume or return it: ``OpenSSL.crypto.X509.get_issuer``, ``OpenSSL.crypto.X509.get_subject``, and ``OpenSSL.SSL.Context.set_client_ca_list``. The APIs in ``cryptography.x509`` should be used instead.
 
 Changes:
 ^^^^^^^^

--- a/src/OpenSSL/SSL.py
+++ b/src/OpenSSL/SSL.py
@@ -1542,6 +1542,10 @@ class Context:
             _lib.SSL_CTX_set_ciphersuites(self._context, ciphersuites) == 1
         )
 
+    @deprecated(
+        "Context.set_client_ca_list is deprecated. X509Name support in "
+        "pyOpenSSL is deprecated."
+    )
     @_require_not_used
     def set_client_ca_list(
         self, certificate_authorities: Sequence[X509Name]
@@ -2700,7 +2704,9 @@ class Connection:
             copy = _lib.X509_NAME_dup(name)
             _openssl_assert(copy != _ffi.NULL)
 
-            pyname = X509Name.__new__(X509Name)
+            # Bypass X509Name.__new__, which warns that X509Name is
+            # deprecated -- this method is not itself deprecated.
+            pyname = object.__new__(X509Name)
             pyname._name = _ffi.gc(copy, _lib.X509_NAME_free)
             result.append(pyname)
         return result

--- a/src/OpenSSL/crypto.py
+++ b/src/OpenSSL/crypto.py
@@ -579,6 +579,10 @@ def get_elliptic_curve(name: str) -> _EllipticCurve:
     raise ValueError("unknown curve name", name)
 
 
+@deprecated(
+    "X509Name support in pyOpenSSL is deprecated. You should use the "
+    "APIs in cryptography."
+)
 @functools.total_ordering
 class X509Name:
     """
@@ -1154,7 +1158,9 @@ class X509:
         return self._set_boundary_time(_lib.X509_getm_notAfter, when)
 
     def _get_name(self, which: Any) -> X509Name:
-        name = X509Name.__new__(X509Name)
+        # Bypass X509Name.__new__, which warns that X509Name is deprecated;
+        # callers that should warn are decorated individually.
+        name = object.__new__(X509Name)
         name._name = which(self._x509)
         _openssl_assert(name._name != _ffi.NULL)
 
@@ -1170,6 +1176,10 @@ class X509:
         set_result = which(self._x509, name._name)
         _openssl_assert(set_result == 1)
 
+    @deprecated(
+        "X509.get_issuer is deprecated. You should use "
+        "cryptography's X.509 APIs instead."
+    )
     def get_issuer(self) -> X509Name:
         """
         Return the issuer of this certificate.
@@ -1202,6 +1212,10 @@ class X509:
         self._set_name(_lib.X509_set_issuer_name, issuer)
         self._issuer_invalidator.clear()
 
+    @deprecated(
+        "X509.get_subject is deprecated. You should use "
+        "cryptography's X.509 APIs instead."
+    )
     def get_subject(self) -> X509Name:
         """
         Return the subject of this certificate.


### PR DESCRIPTION
Deprecates `OpenSSL.crypto.X509Name` and the remaining APIs that consume or return it, in favor of `cryptography.x509`:

- `OpenSSL.crypto.X509Name` (the class itself)
- `OpenSSL.crypto.X509.get_issuer`
- `OpenSSL.crypto.X509.get_subject`
- `OpenSSL.SSL.Context.set_client_ca_list`

`X509.set_issuer` and `X509.set_subject` were already deprecated as part of the X509 mutable-API deprecations (#1510), so they're not repeated here.

Notes:
- `OpenSSL.SSL.Connection.get_client_ca_list` is intentionally **not** deprecated — it grew an `as_cryptography` parameter in #1508, which is the supported path going forward.
- Internal `X509Name` construction sites (`X509._get_name` and `Connection.get_client_ca_list`) use `object.__new__(X509Name)` so they don't emit spurious deprecation warnings; the user-facing deprecated methods are decorated individually and each emits exactly one warning.

https://claude.ai/code/session_01KzTRkDmWNuEfCubRUhVit5

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzTRkDmWNuEfCubRUhVit5)_