### PR TITLE
Prepare 26.3.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 Versions are year-based with a strict backward-compatibility policy.
 The third digit is only for regressions.
 
-26.3.0 (UNRELEASED)
+26.3.0 (2026-06-12)
 -------------------
 
 Backward-incompatible changes:

--- a/src/OpenSSL/version.py
+++ b/src/OpenSSL/version.py
@@ -17,7 +17,7 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "26.2.0"
+__version__ = "26.3.0"
 
 __title__ = "pyOpenSSL"
 __uri__ = "https://pyopenssl.org/"


### PR DESCRIPTION
Sets the release date for 26.3.0 in the changelog and bumps `__version__` to 26.3.0.

The `cryptography>=49.0.0,<50` pin in `setup.py` was already updated in #1513, so no dependency changes are needed here.

https://claude.ai/code/session_019DNUJVTLqiBdfvjeJd8nu7

---
_Generated by [Claude Code](https://claude.ai/code/session_019DNUJVTLqiBdfvjeJd8nu7)_