### PR TITLE
Simplify subprocess communication in _runopenssl helper

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2004,13 +2004,7 @@ def _runopenssl(pem: bytes, *args: bytes) -> bytes:
     the given PEM to its stdin.  Not safe for quotes.
     """
     proc = Popen([b"openssl", *list(args)], stdin=PIPE, stdout=PIPE)
-    assert proc.stdin is not None
-    assert proc.stdout is not None
-    proc.stdin.write(pem)
-    proc.stdin.close()
-    output = proc.stdout.read()
-    proc.stdout.close()
-    proc.wait()
+    output, _ = proc.communicate(pem)
     return output
 
 


### PR DESCRIPTION
## Summary
Refactored the `_runopenssl` helper function in the crypto tests to use `subprocess.Popen.communicate()` instead of manually managing stdin/stdout pipes.

## Key Changes
- Replaced manual pipe management (write, close, read, close, wait) with a single `communicate()` call
- Removed unnecessary assertions checking that stdin/stdout are not None
- Simplified the code from 7 lines to 1 line while maintaining identical functionality

## Implementation Details
The `communicate()` method is the recommended way to interact with subprocesses as it:
- Handles all pipe I/O automatically
- Prevents deadlocks that can occur with manual pipe management
- Automatically waits for process completion
- Returns a tuple of (stdout, stderr) data

This change improves code clarity and follows subprocess best practices.

https://claude.ai/code/session_01FHw2uDgLcFsTfoStC4tzGv