### PR TITLE
Prepare 26.4.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,21 @@ Changelog
 Versions are year-based with a strict backward-compatibility policy.
 The third digit is only for regressions.
 
+26.4.0 (2026-08-01)
+-------------------
+
+Backward-incompatible changes:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Deprecations:
+^^^^^^^^^^^^^
+
+Changes:
+^^^^^^^^
+
+- Maximum supported ``cryptography`` version is now 50.x.
+
+
 26.3.0 (2026-06-12)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         packages=find_packages(where="src"),
         package_dir={"": "src"},
         install_requires=[
-            "cryptography>=49.0.0,<50",
+            "cryptography>=49.0.0,<51",
             "typing-extensions>=4.9; python_version < '3.13'",
         ],
         extras_require={

--- a/src/OpenSSL/version.py
+++ b/src/OpenSSL/version.py
@@ -17,7 +17,7 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "26.3.0"
+__version__ = "26.4.0"
 
 __title__ = "pyOpenSSL"
 __uri__ = "https://pyopenssl.org/"


### PR DESCRIPTION
Raises the maximum supported `cryptography` version to 50.x and bumps the version to 26.4.0.

Fixes https://github.com/pyca/pyopenssl/issues/1525
Closes https://github.com/pyca/pyopenssl/pull/1526 (identical `setup.py` change, wrapped in a release)

## Changes

- `setup.py`: `cryptography>=49.0.0,<50` → `cryptography>=49.0.0,<51`
- `CHANGELOG.rst`: new `26.4.0 (2026-08-01)` section noting the new maximum
- `src/OpenSSL/version.py`: `26.3.0` → `26.4.0`

The minimum stays at 49.0.0, so `noxfile.py`'s `MINIMUM_CRYPTOGRAPHY_VERSION` is unchanged.

## Verification

Locally against cryptography 50.0.0 (OpenSSL 4.0.1) and, as a control, against the 49.0.0 minimum:

- Test suite: 431 passed on both. The one failure, `TestContext::test_fallback_default_verify_paths`, reproduces identically on cryptography 49 — it needs system CA certs at OpenSSL's default path, which this sandbox lacks. Not a cryptography 50 regression.
- `mypy src/ tests/` (strict): clean on cryptography 50.
- `ruff check` / `ruff format --check` / `check-manifest`: clean.
- Built the sdist + wheel and installed the wheel into a fresh venv: resolves to cryptography 50.0.0, and `python -m OpenSSL.debug` reports pyOpenSSL 26.4.0 / cryptography 50.0.0. Wheel metadata declares `Requires-Dist: cryptography<51,>=49.0.0`.

One unrelated observation, left alone since it predates this change: `setup.py`'s `long_description` regex terminates on the first literal `----` line, which now lives at CHANGELOG.rst:499, so the PyPI "Release Information" section carries every release back to that point rather than just the newest.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vb6YjYEyUrAMT2UAQtaUHp)_